### PR TITLE
chore: Increase gas wanted 20,000,000 to 100,000,000

### DIFF
--- a/packages/web/src/common/values/data-constant.ts
+++ b/packages/web/src/common/values/data-constant.ts
@@ -23,6 +23,6 @@ export type MathSymbolType = "NEGATIVE" | "POSITIVE" | "NAN";
 export const DEFAULT_TRANSACTION_DEADLINE = "7282571140" as const;
 export const DEFAULT_CONTRACT_USE_FEE = 1000000 as const;
 export const DEFAULT_GAS_FEE = 1 as const;
-export const DEFAULT_GAS_WANTED = 20_000_000 as const;
+export const DEFAULT_GAS_WANTED = 100_000_000 as const;
 
 export const SCANNER_URL = "https://gnoscan.io";


### PR DESCRIPTION
# Descriptions

When calling the contract, increase the default `gas-wanted` limit. 