### PR TITLE
fix: hide minus on trending card

### DIFF
--- a/packages/web/src/containers/trending-card-list-container/TrendingCardListContainer.tsx
+++ b/packages/web/src/containers/trending-card-list-container/TrendingCardListContainer.tsx
@@ -89,7 +89,9 @@ const TrendingCardListContainer: React.FC = () => {
           },
           price: formatPrice(item.tokenPrice),
           upDown: status as UpDownType,
-          content: formatRate(priceChange, { allowZeroDecimals: true }),
+          content: formatRate(Math.abs(Number(priceChange)), {
+            allowZeroDecimals: true,
+          }),
         };
       })
       .slice(0, 3);


### PR DESCRIPTION
Fix
---
- hide `-` on trending card due to DownArrow means minus
<img width="184" alt="image" src="https://github.com/user-attachments/assets/a0b6c934-9838-4551-8401-0c4af1bd4249">
