### PR TITLE
feat: change page route path

### DIFF
--- a/packages/web/src/components/common/header-side-menu-modal/HeaderSideMenuModal.stories.tsx
+++ b/packages/web/src/components/common/header-side-menu-modal/HeaderSideMenuModal.stories.tsx
@@ -4,7 +4,6 @@ import { css, Theme } from "@emotion/react";
 import { action } from "@storybook/addon-actions";
 
 import HeaderSideMenuModal from "./HeaderSideMenuModal";
-import { RecentdummyToken } from "@containers/header-container/HeaderContainer";
 
 export default {
   title: "common/Header/HeaderSideMenuModal",

--- a/packages/web/src/components/common/header/Header.stories.tsx
+++ b/packages/web/src/components/common/header/Header.stories.tsx
@@ -4,7 +4,6 @@ import { css, Theme } from "@emotion/react";
 import { action } from "@storybook/addon-actions";
 
 import Header from "./Header";
-import { RecentdummyToken } from "@containers/header-container/HeaderContainer";
 import { DEVICE_TYPE } from "@styles/media";
 import { AccountModel } from "@models/account/account-model";
 
@@ -18,7 +17,6 @@ const defaultAccountInfo: AccountModel = {
   sequence: 1,
   chainId: "test3",
 };
-
 
 export default {
   title: "common/Header",
@@ -42,7 +40,7 @@ Default.args = {
   onSideMenuToggle: action("onSideMenuToggle"),
   searchMenuToggle: true,
   onSearchMenuToggle: action("onSearchMenuToggle"),
-  tokens: RecentdummyToken,
+  tokens: [],
   isFetched: true,
   error: null,
   search: action("search"),

--- a/packages/web/src/components/common/header/Header.tsx
+++ b/packages/web/src/components/common/header/Header.tsx
@@ -57,7 +57,8 @@ interface HeaderProps {
   mostLiquidity: Token[];
   popularTokens: Token[];
   recents: Token[];
-  movePage: (path: string) => void;
+  moveTokenPage: (path: string) => void;
+  movePoolPage: (path: string) => void;
   gnotBalance?: number;
   isLoadingGnotBalance?: boolean;
   gnotToken?: ITokenResponse;
@@ -85,7 +86,8 @@ const Header: React.FC<HeaderProps> = ({
   mostLiquidity,
   popularTokens,
   recents,
-  movePage,
+  moveTokenPage,
+  movePoolPage,
   gnotBalance,
   isLoadingGnotBalance,
   gnotToken,
@@ -236,7 +238,8 @@ const Header: React.FC<HeaderProps> = ({
             popularTokens={popularTokens}
             recents={recents}
             placeholder="Search by Name, Symbol, or Path"
-            movePage={movePage}
+            moveTokenPage={moveTokenPage}
+            movePoolPage={movePoolPage}
           />
         )}
       </HeaderWrapper>

--- a/packages/web/src/components/common/range-badge/RangeBadge.tsx
+++ b/packages/web/src/components/common/range-badge/RangeBadge.tsx
@@ -39,7 +39,7 @@ const RangeBadge: React.FC<RangeBadgeProps> = ({
 
     switch (status) {
       case RANGE_STATUS_OPTION.IN:
-        return t("business:rangeStatus.inRange", { context: "short" });
+        return t("business:rangeStatus.inRange");
       case RANGE_STATUS_OPTION.OUT:
         return t("business:rangeStatus.outRange");
       case RANGE_STATUS_OPTION.NONE:

--- a/packages/web/src/components/common/search-menu-modal/SearchMenuModal.spec.tsx
+++ b/packages/web/src/components/common/search-menu-modal/SearchMenuModal.spec.tsx
@@ -2,10 +2,6 @@ import SearchMenuModal from "./SearchMenuModal";
 import { render } from "@testing-library/react";
 import { Provider as JotaiProvider } from "jotai";
 import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
-import {
-  RecentdummyToken,
-  PopulardummyToken,
-} from "@containers/header-container/HeaderContainer";
 import { DEVICE_TYPE } from "@styles/media";
 
 describe("SearchMenuModal Component", () => {
@@ -14,7 +10,8 @@ describe("SearchMenuModal Component", () => {
       onSideMenuToggle: () => null,
       onSearchMenuToggle: () => null,
       search: () => null,
-      movePage: () => null,
+      moveTokenPage: () => null,
+      movePoolPage: () => null,
       keyword: "",
       isFetched: true,
       placeholder: "Search",

--- a/packages/web/src/components/common/search-menu-modal/SearchMenuModal.stories.tsx
+++ b/packages/web/src/components/common/search-menu-modal/SearchMenuModal.stories.tsx
@@ -4,10 +4,6 @@ import { css, Theme } from "@emotion/react";
 import { action } from "@storybook/addon-actions";
 
 import SearchMenuModal from "./SearchMenuModal";
-import {
-  RecentdummyToken,
-  PopulardummyToken,
-} from "@containers/header-container/HeaderContainer";
 
 export default {
   title: "common/Header/SearchMenuModal",
@@ -27,7 +23,7 @@ Default.args = {
   keyword: "",
   isFetched: true,
   placeholder: "Search",
-  tokens: [...RecentdummyToken, ...PopulardummyToken],
+  tokens: [],
 };
 
 const wrapper = (theme: Theme) => css`

--- a/packages/web/src/components/common/search-menu-modal/SearchMenuModal.tsx
+++ b/packages/web/src/components/common/search-menu-modal/SearchMenuModal.tsx
@@ -26,12 +26,12 @@ import { DEVICE_TYPE } from "@styles/media";
 import { useAtom } from "jotai";
 import { TokenState } from "@states/index";
 import MissingLogo from "../missing-logo/MissingLogo";
-import { makeId } from "@utils/common";
 
 interface SearchMenuModalProps {
   onSearchMenuToggle: () => void;
   search: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  movePage: (path: string) => void;
+  moveTokenPage: (path: string) => void;
+  movePoolPage: (path: string) => void;
   keyword: string;
   tokens: Token[];
   isFetched: boolean;
@@ -45,7 +45,8 @@ interface SearchMenuModalProps {
 const SearchMenuModal: React.FC<SearchMenuModalProps> = ({
   onSearchMenuToggle,
   search,
-  movePage,
+  moveTokenPage,
+  movePoolPage,
   keyword,
   isFetched,
   placeholder = "Search",
@@ -116,10 +117,10 @@ const SearchMenuModal: React.FC<SearchMenuModalProps> = ({
       const poolPath = `${item.token.path}:${item?.tokenB?.path}:${
         Number(item.fee.slice(0, item.fee.length - 1)) * 10000
       }`;
-      movePage(`/earn/pool/${makeId(poolPath)}`);
+      movePoolPage(poolPath);
     } else {
-      const routePath = "/tokens/" + makeId(item.token.path);
-      movePage(routePath);
+      const tokenPath = item.token.path;
+      moveTokenPage(tokenPath);
     }
   };
 

--- a/packages/web/src/components/earn/earn-my-positions-content/EarnMyPositionsContent.tsx
+++ b/packages/web/src/components/earn/earn-my-positions-content/EarnMyPositionsContent.tsx
@@ -63,11 +63,11 @@ const EarnMyPositionsContent: React.FC<EarnMyPositionContentProps> = ({
     );
   }
 
-  // if (connected && positions.length === 0 && !loading) {
-  return (
-    <EarnMyPositionNoLiquidity highestApr={highestApr} account={account} />
-  );
-  // }
+  if (connected && positions.length === 0 && !loading) {
+    return (
+      <EarnMyPositionNoLiquidity highestApr={highestApr} account={account} />
+    );
+  }
 
   return (
     <MyPositionCardList

--- a/packages/web/src/components/home/mobile-token-info/MobileTokenInfo.tsx
+++ b/packages/web/src/components/home/mobile-token-info/MobileTokenInfo.tsx
@@ -11,9 +11,8 @@ import {
   TokenInfoWrapper,
 } from "./MobileTokenInfo.styles";
 import { MOBILE_TOKEN_TD_WIDTH } from "@constants/skeleton.constant";
-import { makeId } from "@utils/common";
-import useRouter from "@hooks/common/use-custom-router";
 import TokenInfoCell from "@components/common/token-info-cell/TokenInfoCell";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 interface TokenInfoProps {
   item: Token;
@@ -33,10 +32,10 @@ const renderToNegativeType = (status: MATH_NEGATIVE_TYPE, value: string) => (
 
 const MobileTokenInfo: React.FC<TokenInfoProps> = ({ item }) => {
   const { token, price, priceOf1d } = item;
-  const router = useRouter();
+  const router = useCustomRouter();
 
   const onClickItem = (path: string) => {
-    router.push("/tokens/" + makeId(path));
+    router.movePageWithTokenPath("TOKEN", path);
   };
 
   return (

--- a/packages/web/src/components/home/token-info/TokenInfo.tsx
+++ b/packages/web/src/components/home/token-info/TokenInfo.tsx
@@ -18,8 +18,7 @@ import {
 import { TOKEN_TD_WIDTH } from "@constants/skeleton.constant";
 import SimpleLineGraph from "@components/common/simple-line-graph/SimpleLineGraph";
 import { Global, css } from "@emotion/react";
-import { makeId } from "@utils/common";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import TokenInfoCell from "@components/common/token-info-cell/TokenInfoCell";
 
 interface TokenInfoProps {
@@ -63,10 +62,10 @@ const TokenInfo: React.FC<TokenInfoProps> = ({ item, idx }) => {
     graphStatus,
     isNative,
   } = item;
-  const router = useRouter();
+  const router = useCustomRouter();
 
   const onClickItem = (path: string) => {
-    router.push("/tokens/" + makeId(path));
+    router.movePageWithTokenPath("TOKEN", path);
   };
 
   const onClickPoolItem = (item?: MostLiquidPool) => {
@@ -76,7 +75,7 @@ const TokenInfo: React.FC<TokenInfoProps> = ({ item, idx }) => {
       item.tokenPair.tokenB.path
     }:${Number(item.feeRate.slice(0, item.feeRate.length - 1)) * 10000}`;
     if (!!item.tokenPair.tokenA.path || !!item.tokenPair.tokenB.path) {
-      location.href = `/earn/pool/${makeId(poolPath)}`;
+      router.movePageWithPoolPath("POOL", poolPath);
     }
   };
 

--- a/packages/web/src/components/pool/my-position-card/MyDetailedPositionCard.tsx
+++ b/packages/web/src/components/pool/my-position-card/MyDetailedPositionCard.tsx
@@ -46,6 +46,8 @@ import { formatOtherPrice, formatRate } from "@utils/new-number-utils";
 import { WUGNOT_TOKEN } from "@common/values/token-constant";
 import { isGNOTPath } from "@utils/common";
 import { formatTokenExchangeRate } from "@utils/stake-position-utils";
+import { makeRouteUrl } from "@utils/page.utils";
+import { PAGE_PATH, QUERY_PARAMETER } from "@constants/page.constant";
 
 interface MyDetailedPositionCardProps {
   position: PoolPositionModel;
@@ -730,6 +732,24 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
     );
   }, [totalRewardInfo]);
 
+  const getPoolLink = useCallback(
+    (isDirect: boolean) => {
+      const hash = isDirect ? position.id : undefined;
+      return (
+        window.location.host +
+        makeRouteUrl(
+          PAGE_PATH.POOL,
+          {
+            [QUERY_PARAMETER.POOL_PATH]: position.poolPath,
+            [QUERY_PARAMETER.ADDRESS]: address,
+          },
+          hash,
+        )
+      );
+    },
+    [position, address],
+  );
+
   return (
     <>
       <PositionCardAnchor id={`${position.id}`} />
@@ -759,19 +779,11 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
                       <div
                         onClick={() => {
                           if (isClosed) {
-                            setCopy(
-                              `${
-                                window.location.host + window.location.pathname
-                              }?addr=${address}`,
-                            );
+                            setCopy(getPoolLink(false));
                             return;
                           }
 
-                          setCopy(
-                            `${
-                              window.location.host + window.location.pathname
-                            }?addr=${address}#${position.id}`,
-                          );
+                          setCopy(getPoolLink(true));
                         }}
                       >
                         <IconLinkPage className="icon-link" />
@@ -819,20 +831,11 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
                         <div
                           onClick={() => {
                             if (isClosed) {
-                              setCopy(
-                                `${
-                                  window.location.host +
-                                  window.location.pathname
-                                }?addr=${address}`,
-                              );
+                              setCopy(getPoolLink(false));
                               return;
                             }
 
-                            setCopy(
-                              `${
-                                window.location.host + window.location.pathname
-                              }?addr=${address}#${position.id}`,
-                            );
+                            setCopy(getPoolLink(true));
                           }}
                         >
                           <IconLinkPage className="icon-link" />

--- a/packages/web/src/components/pool/my-position-card/MyDetailedPositionCard.tsx
+++ b/packages/web/src/components/pool/my-position-card/MyDetailedPositionCard.tsx
@@ -677,30 +677,24 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
   const handleSelect = (text: string) => {
     if (text == "Decrease Liquidity") {
       setSelectedPosition(position);
-      router.push(
-        "/earn/pool/" +
-          router.query["pool-path"] +
-          "/" +
-          position?.id +
-          "/decrease-liquidity",
+      router.movePageWithPositionId(
+        "POSITION_DECREASE_LIQUIDITY",
+        position.poolPath,
+        position?.id,
       );
     } else if (text === "Increase Liquidity") {
       setSelectedPosition(position);
-      router.push(
-        "/earn/pool/" +
-          router.query["pool-path"] +
-          "/" +
-          position?.id +
-          "/increase-liquidity",
+      router.movePageWithPositionId(
+        "POSITION_INCREASE_LIQUIDITY",
+        position.poolPath,
+        position?.id,
       );
     } else {
       setSelectedPosition(position);
-      router.push(
-        "/earn/pool/" +
-          router.query["pool-path"] +
-          "/" +
-          position?.id +
-          "/reposition",
+      router.movePageWithPositionId(
+        "POSITION_REPOSITION",
+        position.poolPath,
+        position?.id,
       );
     }
   };

--- a/packages/web/src/components/swap/swap-liquidity/SwapLiquidity.tsx
+++ b/packages/web/src/components/swap/swap-liquidity/SwapLiquidity.tsx
@@ -12,6 +12,7 @@ import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import { formatRate } from "@utils/new-number-utils";
 import IconStar from "@components/common/icons/IconStar";
 import { useTranslation } from "react-i18next";
+import { PAGE_PATH, QUERY_PARAMETER } from "@constants/page.constant";
 
 interface SwapLiquidityProps {
   liquiditys: LiquidityInfo[];
@@ -21,19 +22,9 @@ interface SwapLiquidityProps {
 }
 
 const getPathname = (liquidity: LiquidityInfo) => {
-  if (
-    liquidity.liquidity === "-" ||
-    liquidity.volume === "-" ||
-    liquidity.apr === "-"
-  ) {
-    return {
-      pathname: `/earn/pool/${liquidity.id}`,
-      as: `/earn/pool/${liquidity.id}`,
-    };
-  }
   return {
-    pathname: `/earn/pool/${liquidity.id}`,
-    as: `/earn/pool/${liquidity.id}`,
+    pathname: `${PAGE_PATH.POOL}?${QUERY_PARAMETER.POOL_PATH}=${liquidity.id}`,
+    as: `${PAGE_PATH.POOL}?${QUERY_PARAMETER.POOL_PATH}=${liquidity.id}`,
   };
 };
 

--- a/packages/web/src/components/token/best-pool-card-list/BestPoolCardList.stories.tsx
+++ b/packages/web/src/components/token/best-pool-card-list/BestPoolCardList.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import BestPoolCardList from "./BestPoolCardList";
-import { bestPoolListInit } from "@containers/best-pools-container/BestPoolsContainer";
 
 export default {
   title: "token/BestPoolCardList",
@@ -15,5 +14,5 @@ const Template: ComponentStory<typeof BestPoolCardList> = args => (
 
 export const Default = Template.bind({});
 Default.args = {
-  list: bestPoolListInit,
+  list: [],
 };

--- a/packages/web/src/components/token/best-pool-card-list/BestPoolCardList.tsx
+++ b/packages/web/src/components/token/best-pool-card-list/BestPoolCardList.tsx
@@ -8,6 +8,8 @@ import { SwapFeeTierInfoMap } from "@constants/option.constant";
 import LoadingSpinner from "@components/common/loading-spinner/LoadingSpinner";
 import IconStar from "@components/common/icons/IconStar";
 import { formatRate } from "@utils/new-number-utils";
+import { makeRouteUrl } from "@utils/page.utils";
+import { PAGE_PATH, QUERY_PARAMETER } from "@constants/page.constant";
 
 interface BestPoolCardListProps {
   list: BestPool[];
@@ -42,7 +44,12 @@ const BestPoolCardList: React.FC<BestPoolCardListProps> = ({
       {!loading && (
         <ul>
           {list.map((info, idx) => (
-            <Link href={`/earn/pool/${info.id}`} key={idx}>
+            <Link
+              href={makeRouteUrl(PAGE_PATH.POOL, {
+                [QUERY_PARAMETER.POOL_PATH]: info.id,
+              })}
+              key={idx}
+            >
               <li>
                 <div className="pair">
                   <DoubleLogo

--- a/packages/web/src/components/token/best-pools/BestPools.stories.tsx
+++ b/packages/web/src/components/token/best-pools/BestPools.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import BestPools from "./BestPools";
-import { bestPoolListInit } from "@containers/best-pools-container/BestPoolsContainer";
 
 export default {
   title: "token/BestPools",
@@ -16,5 +15,5 @@ const Template: ComponentStory<typeof BestPools> = args => (
 export const Default = Template.bind({});
 Default.args = {
   titleSymbol: "GNS",
-  cardList: bestPoolListInit,
+  cardList: [],
 };

--- a/packages/web/src/components/token/gainer-card-list/GainerCardList.tsx
+++ b/packages/web/src/components/token/gainer-card-list/GainerCardList.tsx
@@ -9,7 +9,7 @@ import {
 import Link from "next/link";
 import LoadingSpinner from "@components/common/loading-spinner/LoadingSpinner";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
-import { makeId } from "@utils/common";
+import { makeTokenRouteUrl } from "@utils/page.utils";
 
 interface GainerCardListProps {
   gainers: any[];
@@ -35,7 +35,7 @@ const GainerCardList: React.FC<GainerCardListProps> = ({
       )}
       {!loadingGain &&
         gainers.map((gainer, idx) => (
-          <Link href={`/tokens/${makeId(gainer.path)}`} key={idx}>
+          <Link href={makeTokenRouteUrl(gainer.path)} key={idx}>
             <div className="card-wrap">
               <NameSectionWrapper>
                 <MissingLogo

--- a/packages/web/src/components/token/loser-card-list/LoserCardList.tsx
+++ b/packages/web/src/components/token/loser-card-list/LoserCardList.tsx
@@ -9,7 +9,7 @@ import {
 import Link from "next/link";
 import LoadingSpinner from "@components/common/loading-spinner/LoadingSpinner";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
-import { makeId } from "@utils/common";
+import { makeTokenRouteUrl } from "@utils/page.utils";
 
 interface LoserCardListProps {
   losers: any[];
@@ -35,7 +35,7 @@ const LoserCard: React.FC<LoserCardListProps> = ({
       )}
       {!loadingLose &&
         losers.map((loser, idx) => (
-          <Link href={`/tokens/${makeId(loser.path)}`} key={idx}>
+          <Link href={makeTokenRouteUrl(loser.path)} key={idx}>
             <div className="card-wrap">
               <NameSectionWrapper>
                 <MissingLogo

--- a/packages/web/src/components/token/trending-crypto-card/TrendingCryptoCard.tsx
+++ b/packages/web/src/components/token/trending-crypto-card/TrendingCryptoCard.tsx
@@ -4,14 +4,14 @@ import React from "react";
 import { NameSectionWrapper, wrapper } from "./TrendingCryptoCard.styles";
 import Link from "next/link";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
-import { makeId } from "@utils/common";
+import { makeTokenRouteUrl } from "@utils/page.utils";
 interface TrendingCryptoCardProps {
   item: any;
 }
 
 const TrendingCryptoCard: React.FC<TrendingCryptoCardProps> = ({ item }) => {
   return (
-    <Link href={`/tokens/${makeId(item.path)}`}>
+    <Link href={makeTokenRouteUrl(item.path)}>
       <div css={wrapper}>
         <NameSectionWrapper>
           <MissingLogo

--- a/packages/web/src/components/wallet/asset-info/AssetInfo.tsx
+++ b/packages/web/src/components/wallet/asset-info/AssetInfo.tsx
@@ -4,7 +4,6 @@ import IconUpload from "@components/common/icons/IconUpload";
 import { Asset } from "@containers/asset-list-container/AssetListContainer";
 import { AssetInfoWrapper, LoadButton, TableColumn } from "./AssetInfo.styles";
 import { DEVICE_TYPE } from "@styles/media";
-import { makeId } from "@utils/common";
 import { isNativeToken } from "@models/token/token-model";
 import {
   ASSET_INFO,
@@ -17,6 +16,7 @@ interface AssetInfoProps {
   asset: Asset;
   deposit: (asset: Asset) => void;
   withdraw: (asset: Asset) => void;
+  moveTokenPage: (tokenPath: string) => void;
   breakpoint: DEVICE_TYPE;
 }
 
@@ -24,12 +24,13 @@ const AssetInfo: React.FC<AssetInfoProps> = ({
   asset,
   deposit,
   withdraw,
+  moveTokenPage,
   breakpoint,
 }) => {
   const { balance, type, path, price } = asset;
 
   const onClickItem = useCallback((path: string) => {
-    location.href = `/tokens/${makeId(path)}`;
+    moveTokenPage(path);
   }, []);
 
   const onClickDeposit = useCallback(() => {

--- a/packages/web/src/components/wallet/asset-list-table/AssetListTable.tsx
+++ b/packages/web/src/components/wallet/asset-list-table/AssetListTable.tsx
@@ -26,6 +26,7 @@ interface AssetListTableProps {
   sortOption: AssetSortOption | undefined;
   sort: (head: ASSET_HEAD) => void;
   isSortOption: (head: ASSET_HEAD) => boolean;
+  moveTokenPage: (tokenPath: string) => void;
   breakpoint: DEVICE_TYPE;
 }
 
@@ -37,6 +38,7 @@ const AssetListTable: React.FC<AssetListTableProps> = ({
   sortOption,
   sort,
   isSortOption,
+  moveTokenPage,
   breakpoint,
 }) => {
   const isAscendingOption = useCallback(
@@ -64,8 +66,8 @@ const AssetListTable: React.FC<AssetListTableProps> = ({
     return breakpoint === DEVICE_TYPE.WEB
       ? ASSET_INFO
       : breakpoint !== DEVICE_TYPE.MOBILE
-        ? ASSET_INFO_TABLET
-        : ASSET_INFO_MOBILE;
+      ? ASSET_INFO_TABLET
+      : ASSET_INFO_MOBILE;
   }, [breakpoint]);
 
   return (
@@ -107,13 +109,23 @@ const AssetListTable: React.FC<AssetListTableProps> = ({
               asset={asset}
               deposit={deposit}
               withdraw={withdraw}
+              moveTokenPage={moveTokenPage}
               breakpoint={breakpoint}
             />
           ))}
-        {!isFetched && <TableSkeleton
-          className="skeleton"
-          info={breakpoint === DEVICE_TYPE.WEB ? ASSET_INFO : breakpoint !== DEVICE_TYPE.MOBILE ? ASSET_INFO_TABLET : ASSET_INFO_MOBILE}
-          breakpoint={breakpoint} />}
+        {!isFetched && (
+          <TableSkeleton
+            className="skeleton"
+            info={
+              breakpoint === DEVICE_TYPE.WEB
+                ? ASSET_INFO
+                : breakpoint !== DEVICE_TYPE.MOBILE
+                ? ASSET_INFO_TABLET
+                : ASSET_INFO_MOBILE
+            }
+            breakpoint={breakpoint}
+          />
+        )}
       </div>
     </AssetListTableWrapper>
   );

--- a/packages/web/src/components/wallet/asset-list/AssetList.tsx
+++ b/packages/web/src/components/wallet/asset-list/AssetList.tsx
@@ -27,6 +27,7 @@ interface AssetListProps {
   sortOption: AssetSortOption | undefined;
   sort: (item: ASSET_HEAD) => void;
   isSortOption: (item: ASSET_HEAD) => boolean;
+  moveTokenPage: (tokenPath: string) => void;
   breakpoint: DEVICE_TYPE;
   searchIcon: boolean;
   onTogleSearch: () => void;
@@ -48,6 +49,7 @@ const AssetList: React.FC<AssetListProps> = ({
   deposit,
   withdraw,
   sort,
+  moveTokenPage,
   sortOption,
   isSortOption,
   breakpoint,
@@ -76,6 +78,7 @@ const AssetList: React.FC<AssetListProps> = ({
       sort={sort}
       sortOption={sortOption}
       isSortOption={isSortOption}
+      moveTokenPage={moveTokenPage}
       breakpoint={breakpoint}
     />
     {hasLoader && <LoadMoreButton show={!extended} onClick={toggleExtended} />}

--- a/packages/web/src/constants/common.constant.ts
+++ b/packages/web/src/constants/common.constant.ts
@@ -1,19 +1,15 @@
-import { makeId } from "@utils/common";
 import { GNS_TOKEN_PATH, WRAPPED_GNOT_PATH } from "./environment.constant";
 
 export const DEFAULT_NETWORK_ID = "portal-loop";
 
 export const PATH = ["/earn"];
 // 10SECOND/60SECOND is the specific time for data refetching cycles. `useGetPositionsByAddress` will refetch after these specific time
-export const PATH_10SECOND = [
-  "/earn/pool/[pool-path]/remove",
-  "/tokens/[token-path]",
-];
+export const PATH_10SECOND = ["/earn/pool/remove", "/token"];
 export const PATH_60SECOND = [
   "/wallet",
-  "/earn/pool/[pool-path]/stake",
-  "/earn/pool/[pool-path]/unstake",
-  "/earn/pool/[pool-path]",
+  "/earn/pool/stake",
+  "/earn/pool/unstake",
+  "/earn/pool",
 ];
 
 export const HTTP_5XX_ERROR = [
@@ -30,17 +26,17 @@ export type PageKey =
   | "/earn?address"
   | "/earn/add"
   | "/earn/incentivize"
-  | "/earn/pool/[pool-path]"
-  | "/earn/pool/[pool-path]?address"
-  | "/earn/pool/[pool-path]/add"
-  | "/earn/pool/[pool-path]/incentivize"
-  | "/earn/pool/[pool-path]/remove"
-  | "/earn/pool/[pool-path]/stake"
-  | "/earn/pool/[pool-path]/unstake"
-  | "/earn/pool/[pool-path]/[position-id]/reposition"
-  | "/earn/pool/[pool-path]/[position-id]/increase-liquidity"
-  | "/earn/pool/[pool-path]/[position-id]/decrease-liquidity"
-  | "token/[token-path]"
+  | "/earn/pool"
+  | "/earn/pool?address"
+  | "/earn/pool/add"
+  | "/earn/pool/incentivize"
+  | "/earn/pool/remove"
+  | "/earn/pool/stake"
+  | "/earn/pool/unstake"
+  | "/earn/pool/position/reposition"
+  | "/earn/pool/position/increase-liquidity"
+  | "/earn/pool/position/decrease-liquidity"
+  | "/token"
   | "/404"
   | "/500"
   | "/dashboard"
@@ -110,7 +106,7 @@ export const SEOInfo: Record<
     desc: () =>
       "Add incentives to pools for liquidity providers to bootstrap liquidity.",
   },
-  "/earn/pool/[pool-path]": {
+  "/earn/pool": {
     title: (params = []) => {
       if (params.length === 3) {
         const [tokenASymbol, tokenBSymbol, feeTier] = params;
@@ -121,7 +117,7 @@ export const SEOInfo: Record<
     desc: () =>
       "Provide liquidity to earn trading fees and staking rewards. GnoSwap's concentrated liquidity maximizes your earnings by amplifying your capital efficiency.",
   },
-  "/earn/pool/[pool-path]?address": {
+  "/earn/pool?address": {
     title: (params = []) => {
       if (params.length === 4) {
         const [address, tokenASymbol, tokenBSymbol, feeTier] = params;
@@ -132,7 +128,7 @@ export const SEOInfo: Record<
     desc: () =>
       "Create your own positions and provide liquidity to earn trading fees.",
   },
-  "/earn/pool/[pool-path]/add": {
+  "/earn/pool/add": {
     title: (params = []) => {
       if (params.length === 3) {
         const [tokenASymbol, tokenBSymbol, feeTier] = params;
@@ -144,7 +140,7 @@ export const SEOInfo: Record<
     ogTitle: () => "",
     ogDesc: () => "",
   },
-  "/earn/pool/[pool-path]/incentivize": {
+  "/earn/pool/incentivize": {
     title: (params = []) => {
       if (params.length === 3) {
         const [tokenASymbol, tokenBSymbol, feeTier] = params;
@@ -154,7 +150,7 @@ export const SEOInfo: Record<
     },
     desc: () => "Manage your positions to earn trading fees.",
   },
-  "/earn/pool/[pool-path]/remove": {
+  "/earn/pool/remove": {
     title: (params = []) => {
       if (params.length === 3) {
         const [tokenASymbol, tokenBSymbol, feeTier] = params;
@@ -164,7 +160,7 @@ export const SEOInfo: Record<
     },
     desc: () => "Manage your positions to earn trading fees.",
   },
-  "/earn/pool/[pool-path]/stake": {
+  "/earn/pool/stake": {
     title: (params = []) => {
       if (params.length === 3) {
         const [tokenASymbol, tokenBSymbol, feeTier] = params;
@@ -175,7 +171,7 @@ export const SEOInfo: Record<
     desc: () =>
       "Create your own positions and provide liquidity to earn staking rewards.",
   },
-  "/earn/pool/[pool-path]/unstake": {
+  "/earn/pool/unstake": {
     title: (params = []) => {
       if (params.length === 3) {
         const [tokenASymbol, tokenBSymbol, feeTier] = params;
@@ -185,7 +181,7 @@ export const SEOInfo: Record<
     },
     desc: () => "Manage your positions to earn trading fees.",
   },
-  "/earn/pool/[pool-path]/[position-id]/reposition": {
+  "/earn/pool/position/reposition": {
     title: (params = []) => {
       if (params.length === 1) {
         const [positionId] = params;
@@ -197,7 +193,7 @@ export const SEOInfo: Record<
     ogTitle: () => "",
     ogDesc: () => "",
   },
-  "/earn/pool/[pool-path]/[position-id]/increase-liquidity": {
+  "/earn/pool/position/increase-liquidity": {
     title: (params = []) => {
       if (params.length === 1) {
         const [positionId] = params;
@@ -207,7 +203,7 @@ export const SEOInfo: Record<
     },
     desc: () => "Manage your positions to earn trading fees.",
   },
-  "/earn/pool/[pool-path]/[position-id]/decrease-liquidity": {
+  "/earn/pool/position/decrease-liquidity": {
     title: (params = []) => {
       if (params.length === 1) {
         const [positionId] = params;
@@ -217,7 +213,7 @@ export const SEOInfo: Record<
     },
     desc: () => "Manage your positions to earn trading fees.",
   },
-  "token/[token-path]": {
+  "/token": {
     title: (params = []) => {
       const [tokenPrice, tokenName, tokenSymbol] = params;
       const tokenSymbolDisplay = tokenSymbol ? `(${tokenSymbol})` : "";
@@ -301,6 +297,6 @@ export const LANGUAGES = [
 
 export const DEFAULT_TOKEN_PAIR = [WRAPPED_GNOT_PATH, GNS_TOKEN_PATH];
 
-export const DEFAULT_POOL_ID = makeId(
-  [...DEFAULT_TOKEN_PAIR.sort(), "3000"].join(":"),
+export const DEFAULT_POOL_PATH = [...DEFAULT_TOKEN_PAIR.sort(), "3000"].join(
+  ":",
 );

--- a/packages/web/src/constants/footer.constant.tsx
+++ b/packages/web/src/constants/footer.constant.tsx
@@ -3,6 +3,7 @@ import IconGitbook from "@components/common/icons/social/IconGitbook";
 import IconMedium from "@components/common/icons/social/IconMedium";
 import IconTwitter from "@components/common/icons/social/IconTwitter";
 import IconDiscord from "@components/common/icons/social/IconDiscord";
+import { DEFAULT_POOL_PATH } from "./common.constant";
 
 export const FOOTER_LEFT_NAV = {
   content: "HeaderFooter:introduction",
@@ -51,7 +52,7 @@ export const FOOTER_RIGHT_NAV = [
       },
       {
         title: "HeaderFooter:featuresSection.item.stakePosition",
-        path: "/earn/pool/gno.land_r_demo_wugnot:gno.land_r_gnoswap_gns:3000#staking",
+        path: `/earn/pool?poolPath=${DEFAULT_POOL_PATH}#staking`,
         newTab: false,
       },
       {

--- a/packages/web/src/constants/header.constant.ts
+++ b/packages/web/src/constants/header.constant.ts
@@ -3,7 +3,7 @@ export const HEADER_NAV = [
     title: "HeaderFooter:swap",
     path: "/swap",
     iconType: null,
-    subPath: ["/tokens/"],
+    subPath: ["/token"],
   },
   {
     title: "HeaderFooter:earn",

--- a/packages/web/src/constants/page.constant.ts
+++ b/packages/web/src/constants/page.constant.ts
@@ -1,0 +1,33 @@
+export const PAGE_PATH = {
+  HOME: "/",
+  TOKEN: "/token",
+  EARN: "/earn",
+  EARN_ADD: "/earn/add",
+  GOVERNANCE: "/governance",
+  LEADERBOARD: "/leaderboard",
+  SWAP: "/swap",
+  WALLET: "/wallet",
+  POOL: "/earn/pool",
+  POOL_ADD: "/earn/pool/add",
+  POOL_REMOVE: "/earn/pool/remove",
+  POOL_INCENTIVIZE: "/earn/pool/incentivize",
+  POOL_STAKE: "/earn/pool/stake",
+  POOL_UNSTAKE: "/earn/pool/unstake",
+  POSITION_REPOSITION: "/earn/pool/position/reposition",
+  POSITION_INCREASE_LIQUIDITY: "/earn/pool/position/increase-liquidity",
+  POSITION_DECREASE_LIQUIDITY: "/earn/pool/position/decrease-liquidity",
+  DASHBOARD: "/dashboard",
+  "404": "/404",
+  "500": "/500",
+} as const;
+
+export type PAGE_PATH_TYPE = keyof typeof PAGE_PATH;
+
+export const QUERY_PARAMETER = {
+  TOKEN_PATH: "path",
+  POOL_PATH: "poolPath",
+  POSITION_ID: "positionId",
+  ADDRESS: "addr",
+} as const;
+
+export type QUERY_PARAMETER_TYPE = keyof typeof QUERY_PARAMETER;

--- a/packages/web/src/containers/asset-list-container/AssetListContainer.tsx
+++ b/packages/web/src/containers/asset-list-container/AssetListContainer.tsx
@@ -26,6 +26,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ValuesType } from "utility-types";
 import { usePositionData } from "@hooks/common/use-position-data";
 import { formatPoolPairAmount, formatPrice } from "@utils/new-number-utils";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 export interface AssetSortOption {
   key: ASSET_HEAD;
@@ -103,6 +104,7 @@ interface SortedProps extends TokenModel {
 }
 
 const AssetListContainer: React.FC = () => {
+  const router = useCustomRouter();
   const { connected, account, isSwitchNetwork } = useWallet();
 
   const [address] = useState("");
@@ -499,6 +501,10 @@ const AssetListContainer: React.FC = () => {
     onSubmit: handleSubmit,
   } = useWithdrawTokens();
 
+  const moveTokenPage = useCallback((tokenPath: string) => {
+    router.movePageWithTokenPath("TOKEN", tokenPath);
+  }, []);
+
   const onSubmit = (amount: any, address: string) => {
     if (!withdrawInfo || !account?.address) return;
     handleSubmit(
@@ -536,6 +542,7 @@ const AssetListContainer: React.FC = () => {
         withdraw={withdraw}
         sortOption={sortOption}
         sort={sort}
+        moveTokenPage={moveTokenPage}
         isSortOption={isSortOption}
         breakpoint={breakpoint}
         searchIcon={searchIcon}

--- a/packages/web/src/containers/best-pools-container/BestPoolsContainer.tsx
+++ b/packages/web/src/containers/best-pools-container/BestPoolsContainer.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from "react";
 import BestPools from "@components/token/best-pools/BestPools";
 import { SwapFeeTierType } from "@constants/option.constant";
 import { type TokenPairInfo } from "@models/token/token-pair-info";
-import useRouter from "@hooks/common/use-custom-router";
 import {
   useGetChainList,
   useGetTokenByPath,
@@ -15,6 +14,7 @@ import { PoolModel } from "@models/pool/pool-model";
 import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
 import { useLoading } from "@hooks/common/use-loading";
 import { formatOtherPrice } from "@utils/new-number-utils";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 export interface BestPool {
   tokenPair: TokenPairInfo;
@@ -25,41 +25,10 @@ export interface BestPool {
   poolPath: string;
 }
 
-export const bestPoolsInit: BestPool = {
-  tokenPair: {
-    tokenA: {
-      path: Math.floor(Math.random() * 50 + 1).toString(),
-      name: "HEX",
-      symbol: "HEX",
-      logoURI:
-        "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x2b591e99afE9f32eAA6214f7B7629768c40Eeb39/logo.png",
-    },
-    tokenB: {
-      path: Math.floor(Math.random() * 50 + 1).toString(),
-      name: "USDCoin",
-      symbol: "USDC",
-      logoURI:
-        "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
-    },
-  },
-  tvl: "$129.25M",
-  feeRate: "FEE_100",
-  apr: "120.52%",
-  id: "",
-  poolPath: "",
-};
-
-export const bestPoolListInit: BestPool[] = [
-  bestPoolsInit,
-  bestPoolsInit,
-  bestPoolsInit,
-  bestPoolsInit,
-];
-
 const BestPoolsContainer: React.FC = () => {
   const { wugnotPath, getGnotPath } = useGnotToGnot();
-  const router = useRouter();
-  const path = router.query["token-path"] as string;
+  const router = useCustomRouter();
+  const path = router.getTokenPath();
   const { data: { bestPools = [] } = {}, isLoading } = useGetTokenDetailByPath(
     path === "gnot" ? wugnotPath : path,
     { enabled: !!path },

--- a/packages/web/src/containers/breadcrumbs-container/BreadcrumbsContainer.tsx
+++ b/packages/web/src/containers/breadcrumbs-container/BreadcrumbsContainer.tsx
@@ -20,7 +20,7 @@ const getMapping: any = (symbol: any) => {
   return {
     "/earn/add": "Add Liquidity",
     "/earn/stake": "Stake Position",
-    "/tokens/[token-path]": `${symbol || "Loading..."}`,
+    "/token": `${symbol || "Loading..."}`,
   };
 };
 
@@ -37,7 +37,7 @@ const BreadcrumbsContainer: React.FC<Props> = ({
 }) => {
   const router = useRouter();
   const { getGnotPath } = useGnotToGnot();
-  const path = router.query["token-path"] as string;
+  const path = router.getTokenPath();
   const { data: tokenB } = useGetTokenByPath(path, {
     enabled: !!path,
     refetchInterval: 1000 * 10,

--- a/packages/web/src/containers/decrease-liquidity-container/DecreaseLiquidityContainer.tsx
+++ b/packages/web/src/containers/decrease-liquidity-container/DecreaseLiquidityContainer.tsx
@@ -8,11 +8,8 @@ import React, { useState } from "react";
 
 const DecreaseLiquidityContainer: React.FC = () => {
   const router = useRouter();
-  const {slippage} = useSlippage();
-  const positionId =
-    (Array.isArray(router.query["position-id"])
-      ? router.query["position-id"][0]
-      : router.query["position-id"]) || "";
+  const { slippage } = useSlippage();
+  const positionId = router.getPositionId() || "";
   const [isWrap, setIsWrap] = useState(false);
 
   const {

--- a/packages/web/src/containers/earn-add-liquidity-container/EarnAddLiquidityContainer.tsx
+++ b/packages/web/src/containers/earn-add-liquidity-container/EarnAddLiquidityContainer.tsx
@@ -32,11 +32,12 @@ import {
 import useRouter from "@hooks/common/use-custom-router";
 import { PoolModel } from "@models/pool/pool-model";
 import { useLoading } from "@hooks/common/use-loading";
-import { makeQueryString } from "@hooks/common/use-url-param";
 import { isNumber } from "@utils/number-utils";
 import { makeDisplayTokenAmount, makeRawTokenAmount } from "@utils/token-utils";
 import { useRouterBack } from "@hooks/common/use-router-back";
 import { formatRate } from "@utils/new-number-utils";
+import { makeRouteUrl } from "@utils/page.utils";
+import { PAGE_PATH } from "@constants/page.constant";
 
 export interface AddLiquidityPriceRage {
   type: PriceRangeType;
@@ -754,19 +755,15 @@ const EarnAddLiquidityContainer: React.FC = () => {
     })()?.toString();
 
     if (tokenA?.path && tokenB?.path && router.isReady) {
-      const queryString = makeQueryString({
+      const query = {
         tokenA: tokenA?.path,
         tokenB: tokenB?.path,
         fee_tier: computedFeeTier,
         price_range_type: computedPriceRange,
         tickLower: nextTickLower,
         tickUpper: nextTickUpper,
-      });
-      window.history.pushState(
-        "",
-        "",
-        `/earn/add${queryString ? "?" + queryString : ""}`,
-      );
+      };
+      window.history.pushState("", "", makeRouteUrl(PAGE_PATH.EARN_ADD, query));
     }
   }, [
     swapFeeTier,

--- a/packages/web/src/containers/earn-my-position-container/EarnMyPositionContainer.tsx
+++ b/packages/web/src/containers/earn-my-position-container/EarnMyPositionContainer.tsx
@@ -5,7 +5,7 @@ import { usePoolData } from "@hooks/pool/use-pool-data";
 import { useTokenData } from "@hooks/token/use-token-data";
 import { useConnectWalletModal } from "@hooks/wallet/use-connect-wallet-modal";
 import { useWallet } from "@hooks/wallet/use-wallet";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import React, {
   useCallback,
   useEffect,
@@ -16,7 +16,8 @@ import React, {
 import { useAtom, useAtomValue } from "jotai";
 import { EarnState, ThemeState } from "@states/index";
 import { useGetUsernameByAddress } from "@query/address/queries";
-import { DEFAULT_POOL_ID } from "@constants/common.constant";
+import { DEFAULT_POOL_PATH } from "@constants/common.constant";
+import { QUERY_PARAMETER } from "@constants/page.constant";
 
 interface EarnMyPositionContainerProps {
   loadMore?: boolean;
@@ -28,7 +29,7 @@ const EarnMyPositionContainer: React.FC<EarnMyPositionContainerProps> = ({
   address,
   isOtherPosition,
 }) => {
-  const router = useRouter();
+  const router = useCustomRouter();
   const {
     connected,
     connectAdenaClient,
@@ -93,22 +94,25 @@ const EarnMyPositionContainer: React.FC<EarnMyPositionContainerProps> = ({
   ]);
 
   const moveEarnAdd = useCallback(() => {
-    router.push("/earn/add");
+    router.movePage("EARN_ADD");
   }, [router]);
 
   const movePoolDetail = useCallback(
     (poolId: string, positionId: string) => {
-      const query = address && address.length > 0 ? `?addr=${address}` : "";
-      const positionHash = `#${positionId}`;
-
-      router.push(`/earn/pool/${poolId}${query}${positionHash}`);
+      router.movePage(
+        "POOL",
+        {
+          [QUERY_PARAMETER.POOL_PATH]: poolId,
+          [QUERY_PARAMETER.ADDRESS]: address,
+        },
+        positionId,
+      );
     },
     [router, address],
   );
 
   const moveEarnStake = useCallback(() => {
-    const stakingUri = `/earn/pool/${DEFAULT_POOL_ID}#staking`;
-    router.push(stakingUri);
+    router.movePageWithPoolPath("POOL", DEFAULT_POOL_PATH, "staking");
   }, [router]);
 
   const openPosition = useMemo(() => {

--- a/packages/web/src/containers/gainer-and-loser-container/GainerAndLoserContainer.tsx
+++ b/packages/web/src/containers/gainer-and-loser-container/GainerAndLoserContainer.tsx
@@ -10,9 +10,9 @@ import { TokenModel } from "@models/token/token-model";
 import { IGainer } from "@repositories/token";
 import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
 import { useGetPoolList } from "@query/pools";
-import useRouter from "@hooks/common/use-custom-router";
 import { useLoading } from "@hooks/common/use-loading";
 import { formatPrice, formatRate } from "@utils/new-number-utils";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 export const gainersInit = [
   {
@@ -91,13 +91,13 @@ export const losersInit = [
 ];
 
 const GainerAndLoserContainer: React.FC = () => {
+  const router = useCustomRouter();
+  const path = router.getTokenPath();
   const { data: { tokens = [] } = {}, isLoading: isLoadingListToken } =
     useGetTokensList();
   const { data: { gainers = [], losers = [] } = {}, isLoading } =
     useGetChainList();
   const { gnot, wugnotPath } = useGnotToGnot();
-  const router = useRouter();
-  const path = router.query["token-path"] as string;
   const { isLoading: isLoadingGetPoolList } = useGetPoolList();
   const { isLoading: isLoadingTokenDetail } = useGetTokenDetailByPath(
     path === "gnot" ? wugnotPath : path,

--- a/packages/web/src/containers/header-container/HeaderContainer.tsx
+++ b/packages/web/src/containers/header-container/HeaderContainer.tsx
@@ -43,109 +43,8 @@ export interface Token {
   isNative: boolean;
 }
 
-export const RecentdummyToken: Token[] = [
-  {
-    path: Math.floor(Math.random() * 50 + 1).toString(),
-    searchType: "recent",
-    token: {
-      path: "gno.land/r/gnoswap/gns",
-      name: "GNS",
-      symbol: "APR",
-      logoURI: "/gnos.svg",
-    },
-    price: "$12,090.09",
-    priceOf1d: {
-      status: MATH_NEGATIVE_TYPE.POSITIVE,
-      value: "52.4",
-    },
-    tokenB: {
-      path: "gno.land/r/gnoswap/gns",
-      name: "GNOT",
-      symbol: "GNOT",
-      logoURI:
-        "https://raw.githubusercontent.com/onbloc/gno-token-resource/main/gno-native/images/gnot.svg",
-    },
-    fee: "0.03%",
-    isLiquid: true,
-    liquidity: 0,
-    isNative: false,
-  },
-  {
-    path: Math.floor(Math.random() * 50 + 1).toString(),
-    searchType: "recent",
-    token: {
-      path: "gno.land/r/gnoswap/gns",
-      name: "GNS",
-      symbol: "APR",
-      logoURI: "/gnos.svg",
-    },
-    price: "$12,090.09",
-    priceOf1d: {
-      status: MATH_NEGATIVE_TYPE.POSITIVE,
-      value: "107.4",
-    },
-    tokenB: {
-      path: "gno.land/r/gnoswap/gns",
-      name: "GNOT",
-      symbol: "GNOT",
-      logoURI:
-        "https://raw.githubusercontent.com/onbloc/gno-token-resource/main/gno-native/images/gnot.svg",
-    },
-    liquidity: 0,
-    fee: "0.03%",
-    isNative: false,
-  },
-  {
-    path: Math.floor(Math.random() * 50 + 1).toString(),
-    searchType: "recent",
-    token: {
-      path: "gno.land/r/gnoswap/gns",
-      name: "GNS",
-      symbol: "APR",
-      logoURI: "/gnos.svg",
-    },
-    price: "$12,090.09",
-    priceOf1d: {
-      status: MATH_NEGATIVE_TYPE.POSITIVE,
-      value: "31.4",
-    },
-    tokenB: {
-      path: "gno.land/r/gnoswap/gns",
-      name: "GNOT",
-      symbol: "GNOT",
-      logoURI:
-        "https://raw.githubusercontent.com/onbloc/gno-token-resource/main/gno-native/images/gnot.svg",
-    },
-    fee: "0.03%",
-    liquidity: 0,
-    isNative: false,
-  },
-];
-
-export const PopulardummyToken: Token[] = [
-  {
-    path: Math.floor(Math.random() * 50 + 1).toString(),
-    searchType: "popular",
-    token: {
-      path: "gno.land/r/gnoswap/gns",
-      name: "Gnoland",
-      symbol: "GNOT",
-      logoURI:
-        "https://raw.githubusercontent.com/onbloc/gno-token-resource/main/gno-native/images/gnot.svg",
-    },
-    price: "$12,090.09",
-    priceOf1d: {
-      status: MATH_NEGATIVE_TYPE.POSITIVE,
-      value: "12.08%",
-    },
-    fee: "0.03%",
-    liquidity: 0,
-    isNative: false,
-  },
-];
-
 const HeaderContainer: React.FC = () => {
-  const { pathname, push } = useRouter();
+  const { pathname, movePageWithTokenPath, movePageWithPoolPath } = useRouter();
   const [sideMenuToggle, setSideMenuToggle] = useState(false);
   const [searchMenuToggle, setSearchMenuToggle] = useState(false);
   const [keyword, setKeyword] = useState("");
@@ -354,8 +253,12 @@ const HeaderContainer: React.FC = () => {
     openModal();
   }, [openModal]);
 
-  const movePage = useCallback((path: string) => {
-    push(path);
+  const moveTokenPage = useCallback((path: string) => {
+    movePageWithTokenPath("TOKEN", path);
+  }, []);
+
+  const movePoolPage = useCallback((path: string) => {
+    movePageWithPoolPath("POOL", path);
   }, []);
 
   return (
@@ -382,7 +285,8 @@ const HeaderContainer: React.FC = () => {
       mostLiquidity={mostLiquidity}
       popularTokens={popularTokens}
       recents={recents}
-      movePage={movePage}
+      moveTokenPage={moveTokenPage}
+      movePoolPage={movePoolPage}
       gnotBalance={gnotBalance}
       isLoadingGnotBalance={isLoadingGnotBalance}
       gnotToken={gnot}

--- a/packages/web/src/containers/highest-aprs-card-list-container/HighestAprsCardListContainer.tsx
+++ b/packages/web/src/containers/highest-aprs-card-list-container/HighestAprsCardListContainer.tsx
@@ -1,18 +1,19 @@
+import React, { useCallback } from "react";
+
 import HighestAprsCardList from "@components/home/highest-aprs-card-list/HighestAprsCardList";
 import { useLoading } from "@hooks/common/use-loading";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { usePoolData } from "@hooks/pool/use-pool-data";
-import useRouter from "@hooks/common/use-custom-router";
-import React, { useCallback } from "react";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 const HighestAprsCardListContainer: React.FC = () => {
-  const router = useRouter();
+  const router = useCustomRouter();
   const { breakpoint } = useWindowSize();
   const { higestAPRs } = usePoolData();
   const { isLoadingHighestAPRPools } = useLoading();
 
   const onClickItem = useCallback((path: string) => {
-    router.push("/earn/pool/" + path);
+    router.movePageWithPoolPath("POOL", path);
   }, []);
 
   return (

--- a/packages/web/src/containers/incentivized-pool-card-list-container/IncentivizedPoolCardListContainer.tsx
+++ b/packages/web/src/containers/incentivized-pool-card-list-container/IncentivizedPoolCardListContainer.tsx
@@ -6,12 +6,12 @@ import React, {
   useRef,
 } from "react";
 import IncentivizedPoolCardList from "@components/earn/incentivized-pool-card-list/IncentivizedPoolCardList";
-import useRouter from "@hooks/common/use-custom-router";
 import { useAtomValue } from "jotai";
 import { ThemeState } from "@states/index";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { usePositionData } from "@hooks/common/use-position-data";
 import { useIncentivizePool } from "@hooks/pool/use-incentivize-pool";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 export interface PoolListProps {
   logo: string[];
@@ -27,7 +27,7 @@ export interface PoolListProps {
 const IncentivizedPoolCardListContainer: React.FC = () => {
   const [currentIndex, setCurrentIndex] = useState(1);
   const [page, setPage] = useState(1);
-  const router = useRouter();
+  const router = useCustomRouter();
   const [mobile, setMobile] = useState(false);
   const {
     data: incentivizePools = [],
@@ -57,7 +57,7 @@ const IncentivizedPoolCardListContainer: React.FC = () => {
   }, [incentivizePools.length, page]);
 
   const routeItem = (id: string) => {
-    router.push(`/earn/pool/${id}`);
+    router.movePageWithPoolPath("POOL", id);
   };
 
   const handleClickLoadMore = useCallback(() => {

--- a/packages/web/src/containers/my-position-card-list-container/MyPositionCardListContainer.tsx
+++ b/packages/web/src/containers/my-position-card-list-container/MyPositionCardListContainer.tsx
@@ -1,9 +1,9 @@
 import MyPositionCardList from "@components/common/my-position-card-list/MyPositionCardList";
 import { useWindowSize } from "@hooks/common/use-window-size";
-import useRouter from "@hooks/common/use-custom-router";
 import React, { useEffect, useState } from "react";
 import { ValuesType } from "utility-types";
 import { useTokenData } from "@hooks/token/use-token-data";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 export const POSITION_CONTENT_LABEL = {
   DAILY: "Daily Earnings",
@@ -26,7 +26,7 @@ interface MyPositionCardListContainerProps {
 const MyPositionCardListContainer: React.FC<
   MyPositionCardListContainerProps
 > = () => {
-  const router = useRouter();
+  const router = useCustomRouter();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [currentIndex, setCurrentIndex] = useState(0);
   const { width } = useWindowSize();
@@ -47,7 +47,7 @@ const MyPositionCardListContainer: React.FC<
   }, []);
 
   const movePoolDetail = (id: string) => {
-    router.push(`/earn/pool/${id}`);
+    router.movePageWithPoolPath("POOL", id);
   };
 
   const onClickLoadMore = () => {

--- a/packages/web/src/containers/pool-add-incentivize-container/PoolAddIncentivizeContainer.tsx
+++ b/packages/web/src/containers/pool-add-incentivize-container/PoolAddIncentivizeContainer.tsx
@@ -11,7 +11,7 @@ import { useAtom } from "jotai";
 import { EarnState } from "@states/index";
 import { useWallet } from "@hooks/wallet/use-wallet";
 import { useGetPoolDetailByPath, useGetPoolList } from "@query/pools";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
 
 export const dummyDisclaimer =
@@ -24,8 +24,8 @@ const PoolAddIncentivizeContainer: React.FC = () => {
   const [period, setPeriod] = useAtom(EarnState.period);
   const [startDate, setStartDate] = useAtom(EarnState.date);
   const [, setDataModal] = useAtom(EarnState.dataModal);
-  const router = useRouter();
-  const poolPath = router.query["pool-path"] as string;
+  const router = useCustomRouter();
+  const poolPath = router.getPoolPath();
   const { getGnotPath } = useGnotToGnot();
 
   const { connected, connectAdenaClient, isSwitchNetwork } = useWallet();

--- a/packages/web/src/containers/pool-list-container/PoolListContainer.tsx
+++ b/packages/web/src/containers/pool-list-container/PoolListContainer.tsx
@@ -12,8 +12,8 @@ import { PoolListInfo } from "@models/pool/info/pool-list-info";
 import { useLoading } from "@hooks/common/use-loading";
 import { INCENTIVE_TYPE } from "@constants/option.constant";
 import { EARN_POOL_LIST_SIZE } from "@constants/table.constant";
-import useRouter from "@hooks/common/use-custom-router";
 import { formatOtherPrice } from "@utils/new-number-utils";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 export interface Pool {
   poolId: string;
@@ -74,7 +74,7 @@ const PoolListContainer: React.FC = () => {
   });
   const [searchIcon, setSearchIcon] = useState(false);
   const [breakpoint] = useAtom(CommonState.breakpoint);
-  const router = useRouter();
+  const router = useCustomRouter();
   const { poolListInfos, updatePools } = usePoolData();
   const [componentRef, isClickOutside, setIsInside] = useClickOutside();
   const { isLoadingPools } = useLoading();
@@ -221,7 +221,7 @@ const PoolListContainer: React.FC = () => {
   }, [sortedPoolListInfos.length]);
 
   const routeItem = (id: string) => {
-    router.push(`/earn/pool/${id}`);
+    router.movePageWithPoolPath("POOL", id);
   };
   const onTogleSearch = () => {
     setSearchIcon(prev => !prev);

--- a/packages/web/src/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
+++ b/packages/web/src/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import PoolPairInformation from "@components/pool/pool-pair-information/PoolPairInformation";
 import { makeSwapFeeTier } from "@utils/swap-utils";
 import { SwapFeeTierInfoMap } from "@constants/option.constant";
@@ -7,7 +7,6 @@ import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
 import { useGetBinsByPath, useGetPoolDetailByPath } from "@query/pools";
 import { PoolDetailModel } from "@models/pool/pool-detail-model";
 import { usePositionData } from "@hooks/common/use-position-data";
-import { encryptId } from "@utils/common";
 
 export interface pathProps {
   title: string;
@@ -80,14 +79,14 @@ interface PoolPairInformationContainerProps {
 const PoolPairInformationContainer: React.FC<
   PoolPairInformationContainerProps
 > = ({ address }) => {
-  const router = useRouter();
+  const router = useCustomRouter();
   const { getGnotPath } = useGnotToGnot();
-  const poolPath = (router.query["pool-path"] || "") as string;
+  const poolPath = router.getPoolPath();
   const { data = initialPool as PoolDetailModel, isLoading: loading } =
     useGetPoolDetailByPath(poolPath as string, { enabled: !!poolPath });
   const { loading: loadingPosition } = usePositionData({
     address,
-    poolPath: encryptId(poolPath),
+    poolPath,
     queryOption: {
       enabled: !!poolPath,
     },

--- a/packages/web/src/containers/recently-added-card-list-container/RecentlyAddedCardListContainer.tsx
+++ b/packages/web/src/containers/recently-added-card-list-container/RecentlyAddedCardListContainer.tsx
@@ -4,14 +4,13 @@ import { useWindowSize } from "@hooks/common/use-window-size";
 import { CardListKeyStats } from "@models/common/card-list-item-info";
 import { useGetDashboardTVL, useGetDashboardVolume } from "@query/dashboard";
 import { useGetChainList } from "@query/token";
-import { makeId } from "@utils/common";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import React, { useCallback } from "react";
 import { useTranslation } from "next-i18next";
 import { formatOtherPrice } from "@utils/new-number-utils";
 
 const RecentlyAddedCardListContainer: React.FC = () => {
-  const router = useRouter();
+  const router = useCustomRouter();
   const { breakpoint } = useWindowSize();
   const { isLoadingDashboardStats } = useLoading();
   const { data: tvlData } = useGetDashboardTVL();
@@ -38,7 +37,7 @@ const RecentlyAddedCardListContainer: React.FC = () => {
 
   const moveTokenDetails = useCallback(
     (path: string) => {
-      router.push("/tokens/" + makeId(path));
+      router.movePageWithTokenPath("TOKEN", path);
     },
     [router],
   );

--- a/packages/web/src/containers/remove-liquidity-container/RemoveLiquidityContainer.tsx
+++ b/packages/web/src/containers/remove-liquidity-container/RemoveLiquidityContainer.tsx
@@ -2,19 +2,18 @@ import RemoveLiquidity from "@components/remove/remove-liquidity/RemoveLiquidity
 import React, { useCallback, useMemo, useState } from "react";
 import { useRemovePositionModal } from "@hooks/earn/use-remove-position-modal";
 import { usePositionData } from "@hooks/common/use-position-data";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import { useWallet } from "@hooks/wallet/use-wallet";
-import { encryptId } from "@utils/common";
 
 const RemoveLiquidityContainer: React.FC = () => {
-  const router = useRouter();
+  const router = useCustomRouter();
   const { connected } = useWallet();
   const [checkedList, setCheckedList] = useState<string[]>([]);
   const [isWrap, setIsWrap] = useState(false);
-  const poolPath = router.query["pool-path"] as string;
+  const poolPath = router.getPoolPath();
   const { positions, loading: isLoadingPositions } = usePositionData({
     isClosed: false,
-    poolPath: encryptId(poolPath),
+    poolPath,
     queryOption: {
       enabled: !!poolPath,
       refetchInterval: () => {

--- a/packages/web/src/containers/stake-position-container/StakePositionContainer.tsx
+++ b/packages/web/src/containers/stake-position-container/StakePositionContainer.tsx
@@ -2,14 +2,13 @@ import StakePosition from "@components/stake/stake-position/StakePosition";
 import { usePositionData } from "@hooks/common/use-position-data";
 import { useStakePositionModal } from "@hooks/earn/use-stake-position-modal";
 import { useWallet } from "@hooks/wallet/use-wallet";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import React, { useCallback, useState, useMemo } from "react";
-import { encryptId } from "@utils/common";
 import { useGetPoolDetailByPath } from "@query/pools";
 
 const StakePositionContainer: React.FC = () => {
-  const router = useRouter();
-  const poolPath = (router.query["pool-path"] ?? "") as string;
+  const router = useCustomRouter();
+  const poolPath = router.getPoolPath();
   const { connected, connectAccount } = useWallet();
   const {
     positions: allPositionData,
@@ -17,17 +16,20 @@ const StakePositionContainer: React.FC = () => {
     loading: isLoadingAllPositions,
   } = usePositionData({
     isClosed: false,
-    poolPath: encryptId(poolPath),
+    poolPath,
     queryOption: {
-      enabled: !!poolPath
-    }
+      enabled: !!poolPath,
+    },
   });
   const { data: poolDetail } = useGetPoolDetailByPath(poolPath, {
-    enabled: !!poolPath
+    enabled: !!poolPath,
   });
   const [checkedList, setCheckedList] = useState<string[]>([]);
   // For this domain only show `closed = false` && `staked = false` position
-  const unstakedPositions = useMemo(() => allPositionData.filter(item => !item.staked), [allPositionData]);
+  const unstakedPositions = useMemo(
+    () => allPositionData.filter(item => !item.staked),
+    [allPositionData],
+  );
 
   const { openModal } = useStakePositionModal({
     positions: unstakedPositions,
@@ -58,7 +60,9 @@ const StakePositionContainer: React.FC = () => {
       setCheckedList([]);
       return;
     }
-    const checkedList = unstakedPositions.map(unstakedPosition => unstakedPosition.id);
+    const checkedList = unstakedPositions.map(
+      unstakedPosition => unstakedPosition.id,
+    );
     setCheckedList(checkedList);
   }, [checkedAll, unstakedPositions]);
 

--- a/packages/web/src/containers/stake-position-modal-container/StakePositionModalContainer.tsx
+++ b/packages/web/src/containers/stake-position-modal-container/StakePositionModalContainer.tsx
@@ -4,7 +4,7 @@ import { useClearModal } from "@hooks/common/use-clear-modal";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { useWallet } from "@hooks/wallet/use-wallet";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import {
   makeBroadcastStakingMessage,
   useBroadcastHandler,
@@ -30,10 +30,10 @@ const StakePositionModalContainer = ({
     broadcastPending,
   } = useBroadcastHandler();
   const { positionRepository } = useGnoswapContext();
-  const router = useRouter();
+  const router = useCustomRouter();
   const clearModal = useClearModal();
   const { tokenPrices } = useTokenData();
-  const poolPath = router.query["pool-path"] as string;
+  const poolPath = router.getPoolPath();
   const { data: pool } = useGetPoolDetailByPath(poolPath, {
     enabled: !!poolPath,
   });
@@ -131,9 +131,7 @@ const StakePositionModalContainer = ({
           );
         }, 1000);
         openTransactionConfirmModal();
-      } else if (
-        result.code === ERROR_VALUE.TRANSACTION_REJECTED.status
-      ) {
+      } else if (result.code === ERROR_VALUE.TRANSACTION_REJECTED.status) {
         broadcastRejected(
           makeBroadcastStakingMessage("error", {
             tokenASymbol: tokenA?.token?.symbol,

--- a/packages/web/src/containers/staking-container/StakingContainer.tsx
+++ b/packages/web/src/containers/staking-container/StakingContainer.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useMemo, useCallback } from "react";
 import Staking from "@components/pool/staking/Staking";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { useWallet } from "@hooks/wallet/use-wallet";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import { usePositionData } from "@hooks/common/use-position-data";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { usePoolData } from "@hooks/pool/use-pool-data";
@@ -11,7 +11,6 @@ import { useGetPoolDetailByPath } from "@query/pools";
 import { StakingPeriodType } from "@constants/option.constant";
 import useUrlParam from "@hooks/common/use-url-param";
 import { addressValidationCheck } from "@utils/validation-utils";
-import { encryptId } from "@utils/common";
 import { formatRate } from "@utils/new-number-utils";
 
 const DAY_TIME = 24 * 60 * 60 * 1000;
@@ -26,8 +25,8 @@ const StakingContainer: React.FC = () => {
   const { initializedData } = useUrlParam<{ addr: string | undefined }>({
     addr: account?.address,
   });
-  const router = useRouter();
-  const poolPath = (router.query["pool-path"] || "") as string;
+  const router = useCustomRouter();
+  const poolPath = router.getPoolPath();
 
   const address = useMemo(() => {
     const address = initializedData?.addr;
@@ -40,7 +39,7 @@ const StakingContainer: React.FC = () => {
   const { positions: allPositions, loading: isLoadingPosition } =
     usePositionData({
       address,
-      poolPath: encryptId(poolPath),
+      poolPath,
       queryOption: {
         enabled: !!poolPath,
       },
@@ -98,11 +97,11 @@ const StakingContainer: React.FC = () => {
   }, [pool?.stakingApr]);
 
   const handleClickStakeRedirect = useCallback(() => {
-    router.push(`/earn/pool/${router.query["pool-path"]}/stake`);
+    router.movePageWithPoolPath("POOL_STAKE", router.getPoolPath() || "");
   }, [router]);
 
   const handleClickUnStakeRedirect = useCallback(() => {
-    router.push(`/earn/pool/${router.query["pool-path"]}/unstake`);
+    router.movePageWithPoolPath("POOL_UNSTAKE", router.getPoolPath() || "");
   }, [router]);
 
   useEffect(() => {

--- a/packages/web/src/containers/swap-liquidity-container/SwapLiquidityContainer.tsx
+++ b/packages/web/src/containers/swap-liquidity-container/SwapLiquidityContainer.tsx
@@ -73,17 +73,12 @@ const SwapLiquidityContainer: React.FC = () => {
   const { wugnotPath, gnot, getGnotPath } = useGnotToGnot();
   const { tokenA, tokenB } = swapValue;
   const router = useRouter();
+
   const createPool = () => {
-    router.push(
-      {
-        pathname: "/earn/add",
-        query: {
-          tokenA: tokenA?.path as string,
-          tokenB: tokenB?.path as string,
-        },
-      },
-      "/earn/add",
-    );
+    router.movePage("EARN_ADD", {
+      tokenA: tokenA?.path as string,
+      tokenB: tokenB?.path as string,
+    });
   };
 
   const poolDetail: PoolModel[] = useMemo(() => {

--- a/packages/web/src/containers/token-chart-container/TokenChartContainer.tsx
+++ b/packages/web/src/containers/token-chart-container/TokenChartContainer.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState, useEffect, useMemo } from "react";
 import TokenChart from "@components/token/token-chart/TokenChart";
-import useRouter from "@hooks/common/use-custom-router";
 import { IPriceResponse, IPrices1d } from "@repositories/token";
 import { useAtom } from "jotai";
 import { TokenState } from "@states/index";
@@ -27,6 +26,7 @@ import {
 } from "@utils/chart";
 import BigNumber from "bignumber.js";
 import { formatPrice } from "@utils/new-number-utils";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 export const TokenChartGraphPeriods = ["1D", "7D", "1M", "1Y", "ALL"] as const;
 export type TokenChartGraphPeriodType = (typeof TokenChartGraphPeriods)[number];
@@ -153,7 +153,7 @@ const priceChangeDetailInit = {
 const TokenChartContainer: React.FC = () => {
   const [tokenInfo, setTokenInfo] = useState<TokenInfo>(dummyTokenInfo);
   const [currentTab, setCurrentTab] = useState<TokenChartGraphPeriodType>("1D");
-  const router = useRouter();
+  const router = useCustomRouter();
   const [fromSelectToken, setFromSelectToken] = useAtom(
     TokenState.fromSelectToken,
   );
@@ -171,7 +171,7 @@ const TokenChartContainer: React.FC = () => {
       router.push("/");
     },
   });
-  const path = router.query["token-path"] as string;
+  const path = router.getTokenPath();
   const { data: tokenB } = useGetTokenByPath(path, {
     enabled: !!path,
     refetchInterval: 1000 * 10,

--- a/packages/web/src/containers/token-description-container/TokenDescriptionContainer.tsx
+++ b/packages/web/src/containers/token-description-container/TokenDescriptionContainer.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from "react";
 import TokenDescription from "@components/token/token-description/TokenDescription";
-import useRouter from "@hooks/common/use-custom-router";
 import { useGetTokenByPath } from "@query/token";
 import { useLoading } from "@hooks/common/use-loading";
 import { useGnoscanUrl } from "@hooks/common/use-gnoscan-url";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 export interface DescriptionInfo {
   token: {
@@ -42,8 +42,8 @@ const TokenDescriptionContainer: React.FC = () => {
   const [descriptionInfo, setDescriptionInfo] =
     useState<DescriptionInfo>(descriptionInit);
   const [copied, setCopied] = useState(false);
-  const router = useRouter();
-  const path = router.query["token-path"] as string;
+  const router = useCustomRouter();
+  const path = router.getTokenPath();
   const { data: tokenB, isLoading } = useGetTokenByPath(path, {
     enabled: !!path,
   });

--- a/packages/web/src/containers/token-info-content-container/TokenInfoContentContainer.tsx
+++ b/packages/web/src/containers/token-info-content-container/TokenInfoContentContainer.tsx
@@ -2,11 +2,11 @@ import React, { useMemo } from "react";
 import TokenInfoContent from "@components/token/token-info-content/TokenInfoContent";
 import { MATH_NEGATIVE_TYPE } from "@constants/option.constant";
 import { useGetTokenDetailByPath, useGetTokenPricesByPath } from "@query/token";
-import useRouter from "@hooks/common/use-custom-router";
 import { checkPositivePrice } from "@utils/common";
 import { useLoading } from "@hooks/common/use-loading";
 import { WRAPPED_GNOT_PATH } from "@constants/environment.constant";
 import { formatOtherPrice } from "@utils/new-number-utils";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 export const performanceInit = [
   {
@@ -99,8 +99,8 @@ const priceChangeDetailInit = {
 };
 
 const TokenInfoContentContainer: React.FC = () => {
-  const router = useRouter();
-  const path = router.query["token-path"];
+  const router = useCustomRouter();
+  const path = router.getTokenPath();
   const { data: { market = marketInformationInit } = {}, isLoading } =
     useGetTokenDetailByPath(
       path === "gnot" ? WRAPPED_GNOT_PATH : (path as string),

--- a/packages/web/src/containers/token-swap-container/TokenSwapContainer.tsx
+++ b/packages/web/src/containers/token-swap-container/TokenSwapContainer.tsx
@@ -4,20 +4,19 @@ import React, { useState, useEffect } from "react";
 import { useAtomValue } from "jotai";
 import { ThemeState } from "@states/index";
 import SettingMenuModal from "@components/swap/setting-menu-modal/SettingMenuModal";
-import useRouter from "@hooks/common/use-custom-router";
 import { useSwapHandler } from "@hooks/swap/use-swap-handler";
 import { useGetTokenByPath } from "@query/token";
 import { TokenModel } from "@models/token/token-model";
 import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
-import { encryptId, makeId } from "@utils/common";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 const TokenSwapContainer: React.FC = () => {
   const themeKey = useAtomValue(ThemeState.themeKey);
-  const router = useRouter();
+  const router = useCustomRouter();
   const [openedSlippage, setOpenedSlippage] = useState(false);
   const { getGnotPath } = useGnotToGnot();
-  const path = router.query["token-path"] as string;
-  const tokenAPath = router.query["tokenA"] as string;
+  const path = router.getTokenPath();
+  const tokenAPath = router.getParameter("tokenA");
   const { data: tokenB } = useGetTokenByPath(path, {
     enabled: !!path,
   });
@@ -114,22 +113,20 @@ const TokenSwapContainer: React.FC = () => {
 
   const handleChangeTokenB = (token: TokenModel) => {
     if (
-      swapValue?.tokenB?.path ===
-        encryptId(router?.query?.["token-path"] as string) &&
+      swapValue?.tokenB?.path === router.getTokenPath() &&
       swapValue?.tokenA?.symbol !== token?.symbol
     ) {
-      router.push(`/tokens/${makeId(token.path)}`);
+      router.movePageWithTokenPath("TOKEN", token.path);
     }
     changeTokenB(token);
   };
 
   const handleChangeTokenA = (token: TokenModel) => {
     if (
-      swapValue?.tokenA?.path ===
-        encryptId(router?.query?.["token-path"] as string) &&
+      swapValue?.tokenA?.path === router.getTokenPath() &&
       swapValue?.tokenB?.symbol !== token?.symbol
     ) {
-      router.push(`/tokens/${makeId(token.path)}`);
+      router.movePageWithTokenPath("TOKEN", token.path);
     }
     changeTokenA(token);
   };

--- a/packages/web/src/containers/trending-card-list-container/TrendingCardListContainer.tsx
+++ b/packages/web/src/containers/trending-card-list-container/TrendingCardListContainer.tsx
@@ -7,8 +7,7 @@ import { UpDownType } from "@models/common/card-list-item-info";
 import { TokenModel } from "@models/token/token-model";
 import { useGetChainList, useGetTokensList } from "@query/token";
 import { ITrending } from "@repositories/token";
-import { makeId } from "@utils/common";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import React, { useCallback, useMemo } from "react";
 import { formatPrice, formatRate } from "@utils/new-number-utils";
 
@@ -32,7 +31,7 @@ const defaultToken = {
 };
 
 const TrendingCardListContainer: React.FC = () => {
-  const router = useRouter();
+  const router = useCustomRouter();
   const { breakpoint } = useWindowSize();
   const { data: { tokens = [] } = {} } = useGetTokensList();
   const { data: { trending = [] } = {} } = useGetChainList();
@@ -42,7 +41,7 @@ const TrendingCardListContainer: React.FC = () => {
 
   const moveTokenDetails = useCallback(
     (path: string) => {
-      router.push("/tokens/" + makeId(path));
+      router.movePageWithTokenPath("TOKEN", path);
     },
     [router],
   );

--- a/packages/web/src/containers/trending-crypto-card-list-container/TrendingCryptoCardListContainer.tsx
+++ b/packages/web/src/containers/trending-crypto-card-list-container/TrendingCryptoCardListContainer.tsx
@@ -9,10 +9,10 @@ import {
 import { ITrending } from "@repositories/token";
 import { TokenModel } from "@models/token/token-model";
 import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
-import useRouter from "@hooks/common/use-custom-router";
 import { useGetPoolList } from "@query/pools";
 import { useLoading } from "@hooks/common/use-loading";
 import { formatPrice } from "@utils/new-number-utils";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 const trendingCryptoInit = [
   {
@@ -48,12 +48,12 @@ export const trendingCryptoListInit = [
 ];
 
 const TrendingCryptoCardListContainer: React.FC = () => {
+  const router = useCustomRouter();
+  const path = router.getTokenPath();
   const { data: { tokens = [] } = {}, isLoading: isLoadingListToken } =
     useGetTokensList();
   const { data: { trending = [] } = {}, isLoading } = useGetChainList();
   const { gnot, wugnotPath } = useGnotToGnot();
-  const router = useRouter();
-  const path = router.query["token-path"] as string;
   const { isLoading: isLoadingTokenDetail } = useGetTokenDetailByPath(
     path === "gnot" ? wugnotPath : path,
     { enabled: !!path },

--- a/packages/web/src/containers/unstake-position-container/UnstakePositionContainer.tsx
+++ b/packages/web/src/containers/unstake-position-container/UnstakePositionContainer.tsx
@@ -1,22 +1,25 @@
 import React, { useCallback, useMemo, useState } from "react";
 import UnstakeLiquidity from "@components/unstake/unstake-liquidity/UnstakeLiquidity";
 import { useUnstakePositionModal } from "@hooks/earn/use-unstake-position-modal";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import { usePositionData } from "@hooks/common/use-position-data";
-import { encryptId } from "@utils/common";
 
 const UnstakeLiquidityContainer: React.FC = () => {
-  const router = useRouter();
-  const poolPath = (router.query["pool-path"] ?? "") as string;
-  const { positions: allPosition, loading: isPositionsLoading } = usePositionData({
-    poolPath: encryptId(poolPath),
-    queryOption: {
-      enabled: !!poolPath
-    }
-  });
+  const router = useCustomRouter();
+  const poolPath = router.getPoolPath();
+  const { positions: allPosition, loading: isPositionsLoading } =
+    usePositionData({
+      poolPath,
+      queryOption: {
+        enabled: !!poolPath,
+      },
+    });
   const [checkedList, setCheckedList] = useState<string[]>([]);
 
-  const stakedPositions = useMemo(() => allPosition.filter(item => item.staked), [allPosition]);
+  const stakedPositions = useMemo(
+    () => allPosition.filter(item => item.staked),
+    [allPosition],
+  );
 
   const { openModal } = useUnstakePositionModal({
     positions: stakedPositions,
@@ -47,7 +50,9 @@ const UnstakeLiquidityContainer: React.FC = () => {
       setCheckedList([]);
       return;
     }
-    const checkedList = stakedPositions.map(stakedPosition => stakedPosition.id);
+    const checkedList = stakedPositions.map(
+      stakedPosition => stakedPosition.id,
+    );
     setCheckedList(checkedList);
   }, [checkedAll, stakedPositions]);
 

--- a/packages/web/src/containers/wallet-position-card-list-container/WalletPositionCardListContainer.tsx
+++ b/packages/web/src/containers/wallet-position-card-list-container/WalletPositionCardListContainer.tsx
@@ -32,8 +32,10 @@ const WalletPositionCardListContainer: React.FC = () => {
   } = usePositionData({
     isClosed: false,
   });
-  const isLoadingPosition = useMemo(() => connected && loadingPositions, [connected, loadingPositions]);
-
+  const isLoadingPosition = useMemo(
+    () => connected && loadingPositions,
+    [connected, loadingPositions],
+  );
 
   const { pools, loading } = usePoolData();
   const themeKey = useAtomValue(ThemeState.themeKey);
@@ -56,7 +58,7 @@ const WalletPositionCardListContainer: React.FC = () => {
 
   const movePoolDetail = useCallback(
     (id: string) => {
-      router.push(`/earn/pool/${id}`);
+      router.movePageWithPoolPath("POOL", router.getPoolPath() || id);
     },
     [router],
   );
@@ -106,7 +108,6 @@ const WalletPositionCardListContainer: React.FC = () => {
     (x, y) => Number(y.positionUsdValue) - Number(x.positionUsdValue),
   );
   if (!isFetchedPosition || isSwitchNetwork) return null;
-
 
   return (
     <MyPositionCardList

--- a/packages/web/src/hooks/common/use-background.tsx
+++ b/packages/web/src/hooks/common/use-background.tsx
@@ -55,11 +55,7 @@ export const useBackground = () => {
   }, [router.pathname]);
 
   const onPopPage = (): void => {
-    if (
-      ["/earn/add", "/earn/pool/[pool-path]", "/tokens/[token-path]"].includes(
-        router.pathname,
-      )
-    ) {
+    if (["/earn/add", "/earn/pool", "/token"].includes(router.pathname)) {
       setMemorizedPath(router.pathname);
     } else {
       setMemorizedPath(null);

--- a/packages/web/src/hooks/common/use-custom-router.ts
+++ b/packages/web/src/hooks/common/use-custom-router.ts
@@ -1,9 +1,20 @@
-import { Url } from "next/dist/shared/lib/router/router";
 import { useRouter } from "next/router";
+import { useSearchParams } from "next/navigation";
+import {
+  PAGE_PATH,
+  PAGE_PATH_TYPE,
+  QUERY_PARAMETER,
+} from "@constants/page.constant";
 import useScrollData from "./use-scroll-data";
+import { makeRouteUrl } from "@utils/page.utils";
+
+export type QueryParameter = {
+  [key in string]: string | number | null | undefined;
+};
 
 const useCustomRouter = () => {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { saveCurrentScrollHeight } = useScrollData();
 
   function toMain() {
@@ -15,7 +26,7 @@ const useCustomRouter = () => {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function push(pathname: Url, as?: any, options?: any) {
+  function push(pathname: string, as?: any, options?: any) {
     saveCurrentScrollHeight(window?.location?.pathname);
     router.push(pathname, as, options);
   }
@@ -24,11 +35,84 @@ const useCustomRouter = () => {
     router.replace(pathname);
   }
 
+  function getParameter(key: string): string | null {
+    return searchParams.get(key);
+  }
+
+  function getAddress(): string | null {
+    return getParameter(QUERY_PARAMETER["ADDRESS"]);
+  }
+
+  function getTokenPath(): string | null {
+    return getParameter(QUERY_PARAMETER["TOKEN_PATH"]);
+  }
+
+  function getPoolPath(): string | null {
+    return getParameter(QUERY_PARAMETER["POOL_PATH"]);
+  }
+
+  function getPositionId(): string | null {
+    return getParameter(QUERY_PARAMETER["POSITION_ID"]);
+  }
+
+  function pushByParams(
+    url: string,
+    params?: QueryParameter,
+    hash?: string | number,
+  ) {
+    return push(makeRouteUrl(url, params, hash));
+  }
+
+  function movePage(
+    pathType: PAGE_PATH_TYPE,
+    params?: QueryParameter,
+    hash?: string | number,
+  ) {
+    const path = PAGE_PATH[pathType];
+    return pushByParams(path, params, hash);
+  }
+
+  function movePageWithTokenPath(
+    path: PAGE_PATH_TYPE,
+    tokenPath: string,
+    hash?: string | number,
+  ) {
+    return movePage(path, { [QUERY_PARAMETER.TOKEN_PATH]: tokenPath }, hash);
+  }
+
+  function movePageWithPoolPath(
+    path: PAGE_PATH_TYPE,
+    poolPath: string,
+    hash?: string | number,
+  ) {
+    return movePage(path, { [QUERY_PARAMETER.POOL_PATH]: poolPath }, hash);
+  }
+
+  function movePageWithPositionId(
+    path: PAGE_PATH_TYPE,
+    poolPath: string,
+    positionId: string | number,
+  ) {
+    return movePage(path, {
+      [QUERY_PARAMETER.POOL_PATH]: poolPath,
+      [QUERY_PARAMETER.POSITION_ID]: positionId,
+    });
+  }
+
   return {
     toMain,
     back,
     push,
     replace,
+    getAddress,
+    getParameter,
+    getTokenPath,
+    getPoolPath,
+    getPositionId,
+    movePage,
+    movePageWithTokenPath,
+    movePageWithPoolPath,
+    movePageWithPositionId,
     query: router.query,
     asPath: router.asPath,
     pathname: router.pathname,

--- a/packages/web/src/hooks/common/use-position-data.ts
+++ b/packages/web/src/hooks/common/use-position-data.ts
@@ -18,8 +18,13 @@ function secToMilliSec(sec: number) {
 export interface UsePositionDataOption {
   address?: string;
   isClosed?: boolean;
-  poolPath?: string;
-  queryOption?: UseQueryOptions<PositionModel[], Error, PositionModel[], QueryKey>;
+  poolPath?: string | null;
+  queryOption?: UseQueryOptions<
+    PositionModel[],
+    Error,
+    PositionModel[],
+    QueryKey
+  >;
 }
 
 export const usePositionData = (options?: UsePositionDataOption) => {
@@ -36,7 +41,7 @@ export const usePositionData = (options?: UsePositionDataOption) => {
     data,
     isError,
     isFetched: isFetchedPosition,
-    isLoading: isLoadingPosition
+    isLoading: isLoadingPosition,
   } = useGetPositionsByAddress({
     address: fetchedAddress as string,
     isClosed: options?.isClosed,
@@ -57,8 +62,11 @@ export const usePositionData = (options?: UsePositionDataOption) => {
 
   const { isLoading: isCommonLoading } = useLoading();
 
-  const { data: positions = [], isFetched: isFetchedPoolPositions, isLoading: isLoadingPoolPositions } =
-    useMakePoolPositions(data, pools, isFetchedPosition);
+  const {
+    data: positions = [],
+    isFetched: isFetchedPoolPositions,
+    isLoading: isLoadingPoolPositions,
+  } = useMakePoolPositions(data, pools, isFetchedPosition);
 
   const availableStake = useMemo(() => {
     if (!isFetchedPoolPositions) {
@@ -91,21 +99,22 @@ export const usePositionData = (options?: UsePositionDataOption) => {
     return positions;
   }, [isFetchedPoolPositions, positions]);
 
-
   const loading = useMemo(() => {
-    return (isLoadingPool
-      || isLoadingPosition
-      || isCommonLoading
-      || isLoadingPoolPositions)
-      && walletConnected
-      && !!account;
+    return (
+      (isLoadingPool ||
+        isLoadingPosition ||
+        isCommonLoading ||
+        isLoadingPoolPositions) &&
+      walletConnected &&
+      !!account
+    );
   }, [
     isCommonLoading,
     isLoadingPool,
     isLoadingPoolPositions,
     isLoadingPosition,
     walletConnected,
-    account
+    account,
   ]);
 
   return {

--- a/packages/web/src/hooks/common/use-router-back.ts
+++ b/packages/web/src/hooks/common/use-router-back.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import useRouter from "./use-custom-router";
 
 export const useRouterBack = () => {
-  const initLocation = window.location.href;
+  const initLocation = window.location.pathname;
   const targetLocation = initLocation.substring(
     0,
     initLocation.lastIndexOf("/"),
@@ -11,12 +11,12 @@ export const useRouterBack = () => {
   const router = useRouter();
 
   const back = (): void => {
-    if (history.length < 1) {
+    if (history.length < 3) {
       window.history.pushState("", "", null);
       return;
     }
 
-    if (targetLocation !== window.location.href) {
+    if (targetLocation !== window.location.pathname) {
       router.back();
     }
   };

--- a/packages/web/src/hooks/decrease/use-decrease-handle.tsx
+++ b/packages/web/src/hooks/decrease/use-decrease-handle.tsx
@@ -11,9 +11,8 @@ import { IncreaseState } from "@states/index";
 import { isEndTickBy, tickToPriceStr } from "@utils/swap-utils";
 import BigNumber from "bignumber.js";
 import { useAtom } from "jotai";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import { useCallback, useMemo, useState, useEffect } from "react";
-import { encryptId } from "@utils/common";
 import { formatOtherPrice } from "@utils/new-number-utils";
 
 export interface IPriceRange {
@@ -40,12 +39,12 @@ export interface IPooledTokenInfo {
 export type DeCREASE_BUTTON_TYPE = "ENTER_AMOUNT" | "INCREASE_LIQUIDITY";
 
 export const useDecreaseHandle = () => {
-  const router = useRouter();
+  const router = useCustomRouter();
   const [selectedPosition, setSelectedPosition] = useAtom(
     IncreaseState.selectedPosition,
   );
-  const poolPath = router.query["pool-path"] as string;
-  const positionId = router.query["position-id"] as string;
+  const poolPath = router.getPoolPath();
+  const positionId = router.getPositionId();
   const { getGnotPath } = useGnotToGnot();
   const [priceRange, setPriceRange] = useState<AddLiquidityPriceRage | null>({
     type: "Custom",
@@ -54,7 +53,7 @@ export const useDecreaseHandle = () => {
   const { tokenPrices } = useTokenData();
 
   const { positions } = usePositionData({
-    poolPath: encryptId(poolPath),
+    poolPath,
   });
 
   const loading = useMemo(() => {
@@ -68,7 +67,7 @@ export const useDecreaseHandle = () => {
       );
 
       if (!position) {
-        router.push(`/earn/pool/${poolPath}`);
+        router.movePageWithPoolPath("POOL", router.getPoolPath() || "");
         return;
       }
 

--- a/packages/web/src/hooks/pool/use-select-pool.tsx
+++ b/packages/web/src/hooks/pool/use-select-pool.tsx
@@ -350,9 +350,7 @@ export const useSelectPool = ({
     },
     staleTime: 5_000,
     refetchInterval: () => {
-      if (
-        ["/earn/pool/[pool-path]/add", "/earn/add"].includes(router.pathname)
-      ) {
+      if (["/earn/pool/add", "/earn/add"].includes(router.pathname)) {
         return 10_000;
       }
 

--- a/packages/web/src/hooks/reposition/use-reposition-handle.tsx
+++ b/packages/web/src/hooks/reposition/use-reposition-handle.tsx
@@ -31,7 +31,7 @@ import BigNumber from "bignumber.js";
 import { useAtom } from "jotai";
 import useRouter from "@hooks/common/use-custom-router";
 import { useTransactionConfirmModal } from "@hooks/common/use-transaction-confirm-modal";
-import { checkGnotPath, encryptId } from "@utils/common";
+import { checkGnotPath } from "@utils/common";
 import { useEstimateSwap } from "@query/router";
 import { makeShiftAmount } from "@utils/token-utils";
 import {
@@ -59,8 +59,8 @@ const compareDepositAmount = 100_000_000n;
 
 export const useRepositionHandle = () => {
   const router = useRouter();
-  const poolPath = router.query["pool-path"] as string;
-  const positionId = router.query["position-id"] as string;
+  const poolPath = router.getPoolPath();
+  const positionId = router.getPositionId();
 
   const [defaultPosition] = useAtom(IncreaseState.selectedPosition);
 
@@ -71,7 +71,7 @@ export const useRepositionHandle = () => {
   const { connected, account } = useWallet();
   const [initialized, setInitialized] = useState(false);
   const { positions, loading: isLoadingPosition } = usePositionData({
-    poolPath: encryptId(poolPath),
+    poolPath,
   });
 
   const selectedPosition = useMemo(

--- a/packages/web/src/hooks/swap/use-swap-handler.tsx
+++ b/packages/web/src/hooks/swap/use-swap-handler.tsx
@@ -33,6 +33,7 @@ import { QUERY_KEY, useGetSwapFee } from "@query/router";
 import { SwapRouteSuccessResponse } from "@repositories/swap/response/swap-route-response";
 import { formatPrice } from "@utils/new-number-utils";
 import { useTranslation } from "react-i18next";
+import { PAGE_PATH } from "@constants/page.constant";
 
 type SwapButtonStateType =
   | "WALLET_LOGIN"
@@ -798,9 +799,12 @@ export const useSwapHandler = () => {
 
   const copyURL = async () => {
     try {
-      if (router.pathname === "/tokens/[token-path]") {
+      if (router.pathname === PAGE_PATH.TOKEN) {
         let url =
-          window?.location?.host + "/tokens/" + router.query?.["token-path"];
+          window?.location?.host +
+          PAGE_PATH.TOKEN +
+          "?" +
+          router.getTokenPath();
         const query = {
           to: tokenB?.path,
           from: tokenA?.path,

--- a/packages/web/src/layouts/pool-layout/PoolLayout.tsx
+++ b/packages/web/src/layouts/pool-layout/PoolLayout.tsx
@@ -21,8 +21,13 @@ const PoolLayout: React.FC<PoolLayoutProps> = ({
   isStaking,
 }) => {
   const router = useRouter();
+  const poolPath = router.getPoolPath();
+
   const onClickIncentivize = () => {
-    router.push(`/earn/pool/${router.query["pool-path"]}/incentivize`);
+    if (!poolPath) {
+      return;
+    }
+    router.movePageWithPoolPath("POOL_INCENTIVIZE", poolPath);
   };
   return (
     <PoolLayoutWrapper>

--- a/packages/web/src/models/pool/mapper/pool-mapper.ts
+++ b/packages/web/src/models/pool/mapper/pool-mapper.ts
@@ -4,7 +4,6 @@ import { INCENTIVE_TYPE, SwapFeeTierInfoMap } from "@constants/option.constant";
 import { IncentivizePoolCardInfo } from "../info/pool-card-info";
 import { PoolSelectItemInfo } from "../info/pool-select-item-info";
 import { PoolResponse } from "@repositories/pool";
-import { makeId } from "@utils/common";
 import { PoolDetailModel } from "../pool-detail-model";
 import { formatOtherPrice } from "@utils/new-number-utils";
 
@@ -105,7 +104,7 @@ export class PoolMapper {
   }
 
   public static fromResponse(pool: PoolResponse): PoolModel {
-    const id = pool.id ?? makeId(pool.poolPath);
+    const id = pool.id ?? pool.poolPath;
     return {
       ...pool,
       id,
@@ -119,7 +118,7 @@ export class PoolMapper {
   }
 
   public static toIncentivePool(pool: PoolResponse): IncentivizePoolModel {
-    const id = pool.id ?? makeId(pool.poolPath);
+    const id = pool.id ?? pool.poolPath;
     return {
       ...pool,
       id,
@@ -134,7 +133,7 @@ export class PoolMapper {
   }
 
   public static detailFromResponse(pool: PoolResponse): PoolDetailModel {
-    const id = pool.id ?? makeId(pool.poolPath);
+    const id = pool.id ?? pool.poolPath;
     return {
       ...pool,
       id,

--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -61,4 +61,7 @@ function App({ Component, pageProps }: AppProps) {
 
 /// Cast to fix type error from next-i18next.
 /// Reference: https://github.com/i18next/next-i18next/issues/2049
-export default appWithTranslation(App, nextI18NextConfig as UserConfig);
+export default appWithTranslation(App, {
+  ...nextI18NextConfig,
+  debug: false,
+} as UserConfig);

--- a/packages/web/src/pages/earn/index.tsx
+++ b/packages/web/src/pages/earn/index.tsx
@@ -7,7 +7,7 @@ import EarnLayout from "@layouts/earn-layout/EarnLayout";
 import EarnIncentivizedPools from "@components/earn/earn-incentivized-pools/EarnIncentivizedPools";
 import EarnMyPositionContainer from "@containers/earn-my-position-container/EarnMyPositionContainer";
 import { useWallet } from "@hooks/wallet/use-wallet";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import SEOHeader from "@components/common/seo-header/seo-header";
 import { formatAddress } from "@utils/string-utils";
 import { SEOInfo } from "@constants/common.constant";
@@ -28,8 +28,8 @@ export async function getServerSideProps({ locale }: { locale: string }) {
 
 export default function Earn() {
   const { account } = useWallet();
-  const router = useRouter();
-  const addr = router?.query?.addr as string;
+  const router = useCustomRouter();
+  const addr = router.getAddress();
   const isOtherPosition = !!(addr && addr !== account?.address);
 
   const seoInfo = useMemo(

--- a/packages/web/src/pages/earn/pool/incentivize.tsx
+++ b/packages/web/src/pages/earn/pool/incentivize.tsx
@@ -1,20 +1,22 @@
 import Footer from "@components/common/footer/Footer";
 import BreadcrumbsContainer from "@containers/breadcrumbs-container/BreadcrumbsContainer";
 import HeaderContainer from "@containers/header-container/HeaderContainer";
-import StakePositionContainer from "@containers/stake-position-container/StakePositionContainer";
+import PoolAddIncentivizeContainer from "@containers/pool-add-incentivize-container/PoolAddIncentivizeContainer";
 import { useWindowSize } from "@hooks/common/use-window-size";
-import StakePositionLayout from "@layouts/stake-position-layout/StakePositionLayout";
+import PoolIncentivizeLayout from "@layouts/pool-incentivize-layout/PoolIncentivizeLayout";
+import { DEVICE_TYPE } from "@styles/media";
 import React, { useMemo } from "react";
 import useRouter from "@hooks/common/use-custom-router";
 import { useGetPoolDetailByPath } from "src/react-query/pools";
-import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
 import { useLoading } from "@hooks/common/use-loading";
-import { DeviceSize } from "@styles/media";
+import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
 import SEOHeader from "@components/common/seo-header/seo-header";
-import { SwapFeeTierInfoMap } from "@constants/option.constant";
 import { makeSwapFeeTier } from "@utils/swap-utils";
+import { SwapFeeTierInfoMap } from "@constants/option.constant";
 import { SEOInfo } from "@constants/common.constant";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { makeRouteUrl } from "@utils/page.utils";
+import { PAGE_PATH, QUERY_PARAMETER } from "@constants/page.constant";
 
 export async function getServerSideProps({ locale }: { locale: string }) {
   return {
@@ -24,14 +26,15 @@ export async function getServerSideProps({ locale }: { locale: string }) {
   };
 }
 
-export default function Earn() {
-  const { width } = useWindowSize();
+export default function PoolIncentivize() {
+  const { breakpoint } = useWindowSize();
   const router = useRouter();
-  const poolPath = router.query["pool-path"];
+  const poolPath = router.getPoolPath();
+  const { getGnotPath } = useGnotToGnot();
+
   const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
     enabled: !!poolPath,
   });
-  const { getGnotPath } = useGnotToGnot();
   const { isLoading: isLoadingCommon } = useLoading();
 
   const listBreadcrumb = useMemo(() => {
@@ -39,16 +42,19 @@ export default function Earn() {
       { title: "Earn", path: "/earn" },
       {
         title:
-          width >= DeviceSize.mediumWeb
+          breakpoint === DEVICE_TYPE.WEB ||
+          breakpoint === DEVICE_TYPE.MEDIUM_WEB
             ? `${getGnotPath(data?.tokenA).symbol}/${
                 getGnotPath(data?.tokenB).symbol
               } (${Number(data?.fee) / 10000}%)`
             : "...",
-        path: `/earn/pool/${poolPath}`,
+        path: makeRouteUrl(PAGE_PATH.POOL, {
+          [QUERY_PARAMETER.POOL_PATH]: poolPath,
+        }),
       },
-      { title: "Stake Position", path: "" },
+      { title: "Incentivize Pool", path: "" },
     ];
-  }, [data, width]);
+  }, [data, breakpoint]);
 
   const feeStr = useMemo(() => {
     const feeTier = data?.fee;
@@ -59,7 +65,7 @@ export default function Earn() {
     return SwapFeeTierInfoMap[makeSwapFeeTier(feeTier)]?.rateStr;
   }, [data?.fee]);
 
-  const seoInfo = useMemo(() => SEOInfo["/earn/pool/[pool-path]/stake"], []);
+  const seoInfo = useMemo(() => SEOInfo["/earn/pool/incentivize"], []);
 
   const title = useMemo(() => {
     const tokenA = getGnotPath(data?.tokenA);
@@ -78,7 +84,7 @@ export default function Earn() {
         ogTitle={seoInfo?.ogTitle?.()}
         ogDescription={seoInfo?.ogDesc?.()}
       />
-      <StakePositionLayout
+      <PoolIncentivizeLayout
         header={<HeaderContainer />}
         breadcrumbs={
           <BreadcrumbsContainer
@@ -86,7 +92,7 @@ export default function Earn() {
             isLoading={isLoadingCommon || isLoading}
           />
         }
-        stakeLiquidity={<StakePositionContainer />}
+        poolIncentivize={<PoolAddIncentivizeContainer />}
         footer={<Footer />}
       />
     </>

--- a/packages/web/src/pages/earn/pool/incentivize.tsx
+++ b/packages/web/src/pages/earn/pool/incentivize.tsx
@@ -32,9 +32,7 @@ export default function PoolIncentivize() {
   const poolPath = router.getPoolPath();
   const { getGnotPath } = useGnotToGnot();
 
-  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
-    enabled: !!poolPath,
-  });
+  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string);
   const { isLoading: isLoadingCommon } = useLoading();
 
   const listBreadcrumb = useMemo(() => {

--- a/packages/web/src/pages/earn/pool/index.tsx
+++ b/packages/web/src/pages/earn/pool/index.tsx
@@ -5,13 +5,12 @@ import PoolLayout from "@layouts/pool-layout/PoolLayout";
 import StakingContainer from "@containers/staking-container/StakingContainer";
 import PoolPairInformationContainer from "@containers/pool-pair-information-container/PoolPairInformationContainer";
 import MyLiquidityContainer from "@containers/my-liquidity-container/MyLiquidityContainer";
-import useRouter from "@hooks/common/use-custom-router";
+import useCustomRouter from "@hooks/common/use-custom-router";
 import { useGetPoolDetailByPath } from "@query/pools";
 import useUrlParam from "@hooks/common/use-url-param";
 import { useWallet } from "@hooks/wallet/use-wallet";
 import { addressValidationCheck } from "@utils/validation-utils";
 import { usePositionData } from "@hooks/common/use-position-data";
-import { encryptId } from "@utils/common";
 import SEOHeader from "@components/common/seo-header/seo-header";
 import { SwapFeeTierInfoMap } from "@constants/option.constant";
 import { makeSwapFeeTier } from "@utils/swap-utils";
@@ -29,16 +28,16 @@ export async function getServerSideProps({ locale }: { locale: string }) {
 }
 
 export default function Pool() {
-  const router = useRouter();
+  const router = useCustomRouter();
   const { account } = useWallet();
-  const poolPath = (router.query["pool-path"] || "") as string;
+  const poolPath = router.getPoolPath();
   const { getGnotPath } = useGnotToGnot();
   const jumpFlagRef = useRef(false);
   const { data } = useGetPoolDetailByPath(poolPath, {
     enabled: !!poolPath,
     onError: (err: any) => {
       if (err?.["response"]?.["status"] === 404) {
-        router.push("/404");
+        router.movePage("404");
       }
     },
   });
@@ -57,7 +56,7 @@ export default function Pool() {
 
   const { isFetchedPosition, loading, positions } = usePositionData({
     address,
-    poolPath: encryptId(poolPath),
+    poolPath,
     queryOption: {
       enabled: !!poolPath,
     },
@@ -196,10 +195,7 @@ export default function Pool() {
   }, [data?.fee]);
 
   const seoInfo = useMemo(
-    () =>
-      SEOInfo[
-        address ? "/earn/pool/[pool-path]?address" : "/earn/pool/[pool-path]"
-      ],
+    () => SEOInfo[address ? "/earn/pool?address" : "/earn/pool"],
     [address],
   );
 

--- a/packages/web/src/pages/earn/pool/index.tsx
+++ b/packages/web/src/pages/earn/pool/index.tsx
@@ -33,14 +33,7 @@ export default function Pool() {
   const poolPath = router.getPoolPath();
   const { getGnotPath } = useGnotToGnot();
   const jumpFlagRef = useRef(false);
-  const { data } = useGetPoolDetailByPath(poolPath, {
-    enabled: !!poolPath,
-    onError: (err: any) => {
-      if (err?.["response"]?.["status"] === 404) {
-        router.movePage("404");
-      }
-    },
-  });
+  const { data } = useGetPoolDetailByPath(poolPath);
 
   const { initializedData, hash } = useUrlParam<{ addr: string | undefined }>({
     addr: account?.address,

--- a/packages/web/src/pages/earn/pool/position/decrease-liquidity.tsx
+++ b/packages/web/src/pages/earn/pool/position/decrease-liquidity.tsx
@@ -29,9 +29,7 @@ export default function DecreaseLiquidity() {
   const router = useRouter();
   const poolPath = router.getPoolPath();
   const positionId = router.getPositionId();
-  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
-    enabled: !!poolPath,
-  });
+  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string);
   const { getGnotPath } = useGnotToGnot();
   const { isLoading: isLoadingCommon } = useLoading();
 

--- a/packages/web/src/pages/earn/pool/position/decrease-liquidity.tsx
+++ b/packages/web/src/pages/earn/pool/position/decrease-liquidity.tsx
@@ -1,7 +1,7 @@
 import Footer from "@components/common/footer/Footer";
 import BreadcrumbsContainer from "@containers/breadcrumbs-container/BreadcrumbsContainer";
+import DecreaseLiquidityContainer from "@containers/decrease-liquidity-container/DecreaseLiquidityContainer";
 import HeaderContainer from "@containers/header-container/HeaderContainer";
-import IncreaseLiquidityContainer from "@containers/increase-liquidity-container/IncreaseLiquidityContainer";
 import { useLoading } from "@hooks/common/use-loading";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
@@ -13,28 +13,22 @@ import { useGetPoolDetailByPath } from "src/react-query/pools";
 import SEOHeader from "@components/common/seo-header/seo-header";
 import { SEOInfo } from "@constants/common.constant";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { GetStaticPaths } from "next";
-
-export const getStaticPaths: GetStaticPaths<{ slug: string }> = async () => {
-  return {
-    paths: [], //indicates that no page needs be created at build time
-    fallback: "blocking", //indicates the type of fallback
-  };
-};
+import { makeRouteUrl } from "@utils/page.utils";
+import { PAGE_PATH, QUERY_PARAMETER } from "@constants/page.constant";
 
 export async function getStaticProps({ locale }: { locale: string }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["HeaderFooter", "common"])),
+      ...(await serverSideTranslations(locale, ["HeaderFooter"])),
     },
   };
 }
 
-export default function IncreaseLiquidity() {
+export default function DecreaseLiquidity() {
   const { width } = useWindowSize();
   const router = useRouter();
-  const poolPath = router.query["pool-path"] || "";
-  const positionId = router.query["position-id"] || "";
+  const poolPath = router.getPoolPath();
+  const positionId = router.getPositionId();
   const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
     enabled: !!poolPath,
   });
@@ -51,14 +45,17 @@ export default function IncreaseLiquidity() {
                 getGnotPath(data?.tokenB).symbol
               } (${Number(data?.fee) / 10000}%)`
             : "...",
-        path: `/earn/pool/${router.query["pool-path"]}`,
+        poolPath: router.getPoolPath(),
+        path: makeRouteUrl(PAGE_PATH.POOL, {
+          [QUERY_PARAMETER.POOL_PATH]: poolPath,
+        }),
       },
-      { title: "Increase Liquidity", path: "" },
+      { title: "Decrease Liquidity", path: "" },
     ];
   }, [data, width]);
 
   const seoInfo = useMemo(
-    () => SEOInfo["/earn/pool/[pool-path]/[position-id]/increase-liquidity"],
+    () => SEOInfo["/earn/pool/position/decrease-liquidity"],
     [],
   );
 
@@ -78,7 +75,7 @@ export default function IncreaseLiquidity() {
             isLoading={isLoadingCommon || isLoading}
           />
         }
-        increaseLiquidity={<IncreaseLiquidityContainer />}
+        increaseLiquidity={<DecreaseLiquidityContainer />}
         footer={<Footer />}
       />
     </>

--- a/packages/web/src/pages/earn/pool/position/increase-liquidity.tsx
+++ b/packages/web/src/pages/earn/pool/position/increase-liquidity.tsx
@@ -29,9 +29,7 @@ export default function IncreaseLiquidity() {
   const router = useRouter();
   const poolPath = router.getPoolPath();
   const positionId = router.getPositionId();
-  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
-    enabled: !!poolPath,
-  });
+  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string);
   const { getGnotPath } = useGnotToGnot();
   const { isLoading: isLoadingCommon } = useLoading();
 

--- a/packages/web/src/pages/earn/pool/position/increase-liquidity.tsx
+++ b/packages/web/src/pages/earn/pool/position/increase-liquidity.tsx
@@ -1,11 +1,11 @@
 import Footer from "@components/common/footer/Footer";
 import BreadcrumbsContainer from "@containers/breadcrumbs-container/BreadcrumbsContainer";
 import HeaderContainer from "@containers/header-container/HeaderContainer";
-import RepositionContainer from "@containers/reposition-container/RepositionContainer";
+import IncreaseLiquidityContainer from "@containers/increase-liquidity-container/IncreaseLiquidityContainer";
 import { useLoading } from "@hooks/common/use-loading";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
-import RepositionLayout from "@layouts/reposition/RepositionLayout";
+import IncreaseLiquidityLayout from "@layouts/increase-liquidity-layout/IncreaseLiquidityLayout";
 import { DeviceSize } from "@styles/media";
 import useRouter from "@hooks/common/use-custom-router";
 import { useMemo } from "react";
@@ -13,14 +13,8 @@ import { useGetPoolDetailByPath } from "src/react-query/pools";
 import SEOHeader from "@components/common/seo-header/seo-header";
 import { SEOInfo } from "@constants/common.constant";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { GetStaticPaths } from "next";
-
-export const getStaticPaths: GetStaticPaths<{ slug: string }> = async () => {
-  return {
-    paths: [], //indicates that no page needs be created at build time
-    fallback: "blocking", //indicates the type of fallback
-  };
-};
+import { makeRouteUrl } from "@utils/page.utils";
+import { PAGE_PATH, QUERY_PARAMETER } from "@constants/page.constant";
 
 export async function getStaticProps({ locale }: { locale: string }) {
   return {
@@ -30,11 +24,11 @@ export async function getStaticProps({ locale }: { locale: string }) {
   };
 }
 
-export default function EarnAdd() {
+export default function IncreaseLiquidity() {
   const { width } = useWindowSize();
   const router = useRouter();
-  const poolPath = router.query["pool-path"] || "";
-  const positionId = router.query["position-id"] || "";
+  const poolPath = router.getPoolPath();
+  const positionId = router.getPositionId();
   const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
     enabled: !!poolPath,
   });
@@ -51,14 +45,16 @@ export default function EarnAdd() {
                 getGnotPath(data?.tokenB).symbol
               } (${Number(data?.fee) / 10000}%)`
             : "...",
-        path: `/earn/pool/${router.query["pool-path"]}`,
+        path: makeRouteUrl(PAGE_PATH.POOL, {
+          [QUERY_PARAMETER.POOL_PATH]: poolPath,
+        }),
       },
-      { title: "Reposition", path: "" },
+      { title: "Increase Liquidity", path: "" },
     ];
   }, [data, width]);
 
   const seoInfo = useMemo(
-    () => SEOInfo["/earn/pool/[pool-path]/[position-id]/reposition"],
+    () => SEOInfo["/earn/pool/position/increase-liquidity"],
     [],
   );
 
@@ -70,7 +66,7 @@ export default function EarnAdd() {
         ogTitle={seoInfo?.ogTitle?.()}
         ogDescription={seoInfo?.ogDesc?.()}
       />
-      <RepositionLayout
+      <IncreaseLiquidityLayout
         header={<HeaderContainer />}
         breadcrumbs={
           <BreadcrumbsContainer
@@ -78,7 +74,7 @@ export default function EarnAdd() {
             isLoading={isLoadingCommon || isLoading}
           />
         }
-        reposition={<RepositionContainer />}
+        increaseLiquidity={<IncreaseLiquidityContainer />}
         footer={<Footer />}
       />
     </>

--- a/packages/web/src/pages/earn/pool/position/reposition.tsx
+++ b/packages/web/src/pages/earn/pool/position/reposition.tsx
@@ -1,11 +1,11 @@
 import Footer from "@components/common/footer/Footer";
 import BreadcrumbsContainer from "@containers/breadcrumbs-container/BreadcrumbsContainer";
-import DecreaseLiquidityContainer from "@containers/decrease-liquidity-container/DecreaseLiquidityContainer";
 import HeaderContainer from "@containers/header-container/HeaderContainer";
+import RepositionContainer from "@containers/reposition-container/RepositionContainer";
 import { useLoading } from "@hooks/common/use-loading";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
-import IncreaseLiquidityLayout from "@layouts/increase-liquidity-layout/IncreaseLiquidityLayout";
+import RepositionLayout from "@layouts/reposition/RepositionLayout";
 import { DeviceSize } from "@styles/media";
 import useRouter from "@hooks/common/use-custom-router";
 import { useMemo } from "react";
@@ -13,28 +13,22 @@ import { useGetPoolDetailByPath } from "src/react-query/pools";
 import SEOHeader from "@components/common/seo-header/seo-header";
 import { SEOInfo } from "@constants/common.constant";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { GetStaticPaths } from "next";
-
-export const getStaticPaths: GetStaticPaths<{ slug: string }> = async () => {
-  return {
-    paths: [], //indicates that no page needs be created at build time
-    fallback: "blocking", //indicates the type of fallback
-  };
-};
+import { makeRouteUrl } from "@utils/page.utils";
+import { PAGE_PATH, QUERY_PARAMETER } from "@constants/page.constant";
 
 export async function getStaticProps({ locale }: { locale: string }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["HeaderFooter"])),
+      ...(await serverSideTranslations(locale, ["HeaderFooter", "common"])),
     },
   };
 }
 
-export default function DecreaseLiquidity() {
+export default function Reposition() {
   const { width } = useWindowSize();
   const router = useRouter();
-  const poolPath = router.query["pool-path"] || "";
-  const positionId = router.query["position-id"] || "";
+  const poolPath = router.getPoolPath();
+  const positionId = router.getPositionId();
   const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
     enabled: !!poolPath,
   });
@@ -51,16 +45,15 @@ export default function DecreaseLiquidity() {
                 getGnotPath(data?.tokenB).symbol
               } (${Number(data?.fee) / 10000}%)`
             : "...",
-        path: `/earn/pool/${router.query["pool-path"]}`,
+        path: makeRouteUrl(PAGE_PATH.POOL, {
+          [QUERY_PARAMETER.POOL_PATH]: poolPath,
+        }),
       },
-      { title: "Decrease Liquidity", path: "" },
+      { title: "Reposition", path: "" },
     ];
   }, [data, width]);
 
-  const seoInfo = useMemo(
-    () => SEOInfo["/earn/pool/[pool-path]/[position-id]/decrease-liquidity"],
-    [],
-  );
+  const seoInfo = useMemo(() => SEOInfo["/earn/pool/position/reposition"], []);
 
   return (
     <>
@@ -70,7 +63,7 @@ export default function DecreaseLiquidity() {
         ogTitle={seoInfo?.ogTitle?.()}
         ogDescription={seoInfo?.ogDesc?.()}
       />
-      <IncreaseLiquidityLayout
+      <RepositionLayout
         header={<HeaderContainer />}
         breadcrumbs={
           <BreadcrumbsContainer
@@ -78,7 +71,7 @@ export default function DecreaseLiquidity() {
             isLoading={isLoadingCommon || isLoading}
           />
         }
-        increaseLiquidity={<DecreaseLiquidityContainer />}
+        reposition={<RepositionContainer />}
         footer={<Footer />}
       />
     </>

--- a/packages/web/src/pages/earn/pool/position/reposition.tsx
+++ b/packages/web/src/pages/earn/pool/position/reposition.tsx
@@ -29,9 +29,7 @@ export default function Reposition() {
   const router = useRouter();
   const poolPath = router.getPoolPath();
   const positionId = router.getPositionId();
-  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
-    enabled: !!poolPath,
-  });
+  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string);
   const { getGnotPath } = useGnotToGnot();
   const { isLoading: isLoadingCommon } = useLoading();
 

--- a/packages/web/src/pages/earn/pool/remove.tsx
+++ b/packages/web/src/pages/earn/pool/remove.tsx
@@ -28,9 +28,7 @@ export default function Earn() {
   const { width } = useWindowSize();
   const router = useRouter();
   const poolPath = router.getPoolPath();
-  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
-    enabled: !!poolPath,
-  });
+  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string);
 
   const { getGnotPath } = useGnotToGnot();
   const { isLoading: isLoadingCommon } = useLoading();

--- a/packages/web/src/pages/earn/pool/remove.tsx
+++ b/packages/web/src/pages/earn/pool/remove.tsx
@@ -1,9 +1,9 @@
 import Footer from "@components/common/footer/Footer";
 import BreadcrumbsContainer from "@containers/breadcrumbs-container/BreadcrumbsContainer";
 import HeaderContainer from "@containers/header-container/HeaderContainer";
-import UnstakeLiquidityContainer from "@containers/unstake-position-container/UnstakePositionContainer";
+import RemoveLiquidityContainer from "@containers/remove-liquidity-container/RemoveLiquidityContainer";
 import { useWindowSize } from "@hooks/common/use-window-size";
-import UnstakeLiquidityLayout from "@layouts/unstake-liquidity-layout/UnstakeLiquidityLayout";
+import PoolRemoveLayout from "@layouts/pool-remove-layout/PoolRemoveLayout";
 import React, { useMemo } from "react";
 import useRouter from "@hooks/common/use-custom-router";
 import { useGetPoolDetailByPath } from "src/react-query/pools";
@@ -27,10 +27,11 @@ export async function getServerSideProps({ locale }: { locale: string }) {
 export default function Earn() {
   const { width } = useWindowSize();
   const router = useRouter();
-  const poolPath = router.query["pool-path"];
+  const poolPath = router.getPoolPath();
   const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
     enabled: !!poolPath,
   });
+
   const { getGnotPath } = useGnotToGnot();
   const { isLoading: isLoadingCommon } = useLoading();
 
@@ -46,7 +47,7 @@ export default function Earn() {
             : "...",
         path: `/earn/pool/${poolPath}`,
       },
-      { title: "Unstake Position", path: "" },
+      { title: "Remove Position", path: "" },
     ];
   }, [data, width]);
 
@@ -59,7 +60,7 @@ export default function Earn() {
     return SwapFeeTierInfoMap[makeSwapFeeTier(feeTier)]?.rateStr;
   }, [data?.fee]);
 
-  const seoInfo = useMemo(() => SEOInfo["/earn/pool/[pool-path]/unstake"], []);
+  const seoInfo = useMemo(() => SEOInfo["/earn/pool/remove"], []);
 
   const title = useMemo(() => {
     const tokenA = getGnotPath(data?.tokenA);
@@ -78,7 +79,7 @@ export default function Earn() {
         ogTitle={seoInfo?.ogTitle?.()}
         ogDescription={seoInfo?.ogDesc?.()}
       />
-      <UnstakeLiquidityLayout
+      <PoolRemoveLayout
         header={<HeaderContainer />}
         breadcrumbs={
           <BreadcrumbsContainer
@@ -86,7 +87,7 @@ export default function Earn() {
             isLoading={isLoadingCommon || isLoading}
           />
         }
-        unstakeLiquidity={<UnstakeLiquidityContainer />}
+        removeLiquidity={<RemoveLiquidityContainer />}
         footer={<Footer />}
       />
     </>

--- a/packages/web/src/pages/earn/pool/stake.tsx
+++ b/packages/web/src/pages/earn/pool/stake.tsx
@@ -28,9 +28,7 @@ export default function Earn() {
   const { width } = useWindowSize();
   const router = useRouter();
   const poolPath = router.getPoolPath();
-  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
-    enabled: !!poolPath,
-  });
+  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string);
   const { getGnotPath } = useGnotToGnot();
   const { isLoading: isLoadingCommon } = useLoading();
 

--- a/packages/web/src/pages/earn/pool/stake.tsx
+++ b/packages/web/src/pages/earn/pool/stake.tsx
@@ -1,22 +1,18 @@
-import HeaderContainer from "@containers/header-container/HeaderContainer";
 import Footer from "@components/common/footer/Footer";
 import BreadcrumbsContainer from "@containers/breadcrumbs-container/BreadcrumbsContainer";
-import PoolAddLayout from "@layouts/pool-add-layout/PoolAddLayout";
-import PoolAddLiquidityContainer from "@containers/pool-add-liquidity-container/PoolAddLiquidityContainer";
+import HeaderContainer from "@containers/header-container/HeaderContainer";
+import StakePositionContainer from "@containers/stake-position-container/StakePositionContainer";
 import { useWindowSize } from "@hooks/common/use-window-size";
-import OneClickStakingContainer from "@containers/one-click-staking-container/OneClickStakingContainer";
+import StakePositionLayout from "@layouts/stake-position-layout/StakePositionLayout";
 import React, { useMemo } from "react";
 import useRouter from "@hooks/common/use-custom-router";
 import { useGetPoolDetailByPath } from "src/react-query/pools";
 import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
 import { useLoading } from "@hooks/common/use-loading";
 import { DeviceSize } from "@styles/media";
-import ExchangeRateGraphContainer from "@containers/exchange-rate-graph-container/ExchangeRateGraphContainer";
 import SEOHeader from "@components/common/seo-header/seo-header";
 import { SwapFeeTierInfoMap } from "@constants/option.constant";
 import { makeSwapFeeTier } from "@utils/swap-utils";
-import { checkGnotPath } from "@utils/common";
-import { useTokenData } from "@hooks/token/use-token-data";
 import { SEOInfo } from "@constants/common.constant";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
@@ -28,31 +24,29 @@ export async function getServerSideProps({ locale }: { locale: string }) {
   };
 }
 
-export default function EarnAdd() {
+export default function Earn() {
   const { width } = useWindowSize();
   const router = useRouter();
-  const poolPath = (router.query["pool-path"] || "") as string;
-  const { data, isLoading } = useGetPoolDetailByPath(poolPath, {
+  const poolPath = router.getPoolPath();
+  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
     enabled: !!poolPath,
-    refetchInterval: 10_000,
   });
   const { getGnotPath } = useGnotToGnot();
   const { isLoading: isLoadingCommon } = useLoading();
-  const { tokens } = useTokenData();
 
   const listBreadcrumb = useMemo(() => {
     return [
       { title: "Earn", path: "/earn" },
       {
         title:
-          width > DeviceSize.mediumWeb
+          width >= DeviceSize.mediumWeb
             ? `${getGnotPath(data?.tokenA).symbol}/${
                 getGnotPath(data?.tokenB).symbol
               } (${Number(data?.fee) / 10000}%)`
             : "...",
-        path: `/earn/pool/${router.query["pool-path"]}`,
+        path: `/earn/pool/${poolPath}`,
       },
-      { title: "Add Position", path: "" },
+      { title: "Stake Position", path: "" },
     ];
   }, [data, width]);
 
@@ -65,34 +59,16 @@ export default function EarnAdd() {
     return SwapFeeTierInfoMap[makeSwapFeeTier(feeTier)]?.rateStr;
   }, [data?.fee]);
 
-  const seoInfo = useMemo(() => SEOInfo["/earn/pool/[pool-path]/add"], []);
+  const seoInfo = useMemo(() => SEOInfo["/earn/pool/stake"], []);
 
   const title = useMemo(() => {
-    const tokenAPath = data?.tokenA.path;
-    const tokenBPath = data?.tokenB.path;
-
-    const tokenA = getGnotPath(
-      tokenAPath
-        ? tokens.find(item => item.path === checkGnotPath(tokenAPath))
-        : undefined,
-    );
-    const tokenB = getGnotPath(
-      tokenBPath
-        ? tokens.find(item => item.path === checkGnotPath(tokenBPath))
-        : undefined,
-    );
+    const tokenA = getGnotPath(data?.tokenA);
+    const tokenB = getGnotPath(data?.tokenB);
 
     return seoInfo.title(
       [tokenA?.symbol, tokenB?.symbol, feeStr].filter(item => item) as string[],
     );
-  }, [
-    data?.tokenA.path,
-    data?.tokenB.path,
-    feeStr,
-    getGnotPath,
-    seoInfo,
-    tokens,
-  ]);
+  }, [data?.tokenA, data?.tokenB, feeStr, getGnotPath, seoInfo]);
 
   return (
     <>
@@ -102,7 +78,7 @@ export default function EarnAdd() {
         ogTitle={seoInfo?.ogTitle?.()}
         ogDescription={seoInfo?.ogDesc?.()}
       />
-      <PoolAddLayout
+      <StakePositionLayout
         header={<HeaderContainer />}
         breadcrumbs={
           <BreadcrumbsContainer
@@ -110,9 +86,7 @@ export default function EarnAdd() {
             isLoading={isLoadingCommon || isLoading}
           />
         }
-        addLiquidity={<PoolAddLiquidityContainer />}
-        oneStaking={<OneClickStakingContainer />}
-        exchangeRateGraph={<ExchangeRateGraphContainer />}
+        stakeLiquidity={<StakePositionContainer />}
         footer={<Footer />}
       />
     </>

--- a/packages/web/src/pages/earn/pool/unstake.tsx
+++ b/packages/web/src/pages/earn/pool/unstake.tsx
@@ -1,18 +1,18 @@
 import Footer from "@components/common/footer/Footer";
 import BreadcrumbsContainer from "@containers/breadcrumbs-container/BreadcrumbsContainer";
 import HeaderContainer from "@containers/header-container/HeaderContainer";
-import PoolAddIncentivizeContainer from "@containers/pool-add-incentivize-container/PoolAddIncentivizeContainer";
+import UnstakeLiquidityContainer from "@containers/unstake-position-container/UnstakePositionContainer";
 import { useWindowSize } from "@hooks/common/use-window-size";
-import PoolIncentivizeLayout from "@layouts/pool-incentivize-layout/PoolIncentivizeLayout";
-import { DEVICE_TYPE } from "@styles/media";
+import UnstakeLiquidityLayout from "@layouts/unstake-liquidity-layout/UnstakeLiquidityLayout";
 import React, { useMemo } from "react";
 import useRouter from "@hooks/common/use-custom-router";
 import { useGetPoolDetailByPath } from "src/react-query/pools";
-import { useLoading } from "@hooks/common/use-loading";
 import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
-import SEOHeader from "@components/common/seo-header/seo-header";
-import { makeSwapFeeTier } from "@utils/swap-utils";
+import { useLoading } from "@hooks/common/use-loading";
+import { DeviceSize } from "@styles/media";
 import { SwapFeeTierInfoMap } from "@constants/option.constant";
+import { makeSwapFeeTier } from "@utils/swap-utils";
+import SEOHeader from "@components/common/seo-header/seo-header";
 import { SEOInfo } from "@constants/common.constant";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
@@ -24,15 +24,14 @@ export async function getServerSideProps({ locale }: { locale: string }) {
   };
 }
 
-export default function PoolIncentivize() {
-  const { breakpoint } = useWindowSize();
+export default function Earn() {
+  const { width } = useWindowSize();
   const router = useRouter();
-  const { getGnotPath } = useGnotToGnot();
-  const poolPath = router.query["pool-path"];
-
+  const poolPath = router.getPoolPath();
   const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
     enabled: !!poolPath,
   });
+  const { getGnotPath } = useGnotToGnot();
   const { isLoading: isLoadingCommon } = useLoading();
 
   const listBreadcrumb = useMemo(() => {
@@ -40,17 +39,16 @@ export default function PoolIncentivize() {
       { title: "Earn", path: "/earn" },
       {
         title:
-          breakpoint === DEVICE_TYPE.WEB ||
-          breakpoint === DEVICE_TYPE.MEDIUM_WEB
+          width > DeviceSize.mediumWeb
             ? `${getGnotPath(data?.tokenA).symbol}/${
                 getGnotPath(data?.tokenB).symbol
               } (${Number(data?.fee) / 10000}%)`
             : "...",
-        path: `/earn/pool/${router.query["pool-path"]}`,
+        path: `/earn/pool/${poolPath}`,
       },
-      { title: "Incentivize Pool", path: "" },
+      { title: "Unstake Position", path: "" },
     ];
-  }, [data, breakpoint]);
+  }, [data, width]);
 
   const feeStr = useMemo(() => {
     const feeTier = data?.fee;
@@ -61,10 +59,7 @@ export default function PoolIncentivize() {
     return SwapFeeTierInfoMap[makeSwapFeeTier(feeTier)]?.rateStr;
   }, [data?.fee]);
 
-  const seoInfo = useMemo(
-    () => SEOInfo["/earn/pool/[pool-path]/incentivize"],
-    [],
-  );
+  const seoInfo = useMemo(() => SEOInfo["/earn/pool/unstake"], []);
 
   const title = useMemo(() => {
     const tokenA = getGnotPath(data?.tokenA);
@@ -83,7 +78,7 @@ export default function PoolIncentivize() {
         ogTitle={seoInfo?.ogTitle?.()}
         ogDescription={seoInfo?.ogDesc?.()}
       />
-      <PoolIncentivizeLayout
+      <UnstakeLiquidityLayout
         header={<HeaderContainer />}
         breadcrumbs={
           <BreadcrumbsContainer
@@ -91,7 +86,7 @@ export default function PoolIncentivize() {
             isLoading={isLoadingCommon || isLoading}
           />
         }
-        poolIncentivize={<PoolAddIncentivizeContainer />}
+        unstakeLiquidity={<UnstakeLiquidityContainer />}
         footer={<Footer />}
       />
     </>

--- a/packages/web/src/pages/earn/pool/unstake.tsx
+++ b/packages/web/src/pages/earn/pool/unstake.tsx
@@ -28,9 +28,7 @@ export default function Earn() {
   const { width } = useWindowSize();
   const router = useRouter();
   const poolPath = router.getPoolPath();
-  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string, {
-    enabled: !!poolPath,
-  });
+  const { data, isLoading } = useGetPoolDetailByPath(poolPath as string);
   const { getGnotPath } = useGnotToGnot();
   const { isLoading: isLoadingCommon } = useLoading();
 

--- a/packages/web/src/pages/token/index.tsx
+++ b/packages/web/src/pages/token/index.tsx
@@ -15,7 +15,6 @@ import GainerAndLoserContainer from "@containers/gainer-and-loser-container/Gain
 import { useLoading } from "@hooks/common/use-loading";
 import { useGetTokenByPath, useGetTokenPricesByPath } from "@query/token";
 import { useEffect, useMemo } from "react";
-import { useRouter } from "next/router";
 import SEOHeader from "@components/common/seo-header/seo-header";
 import { WRAPPED_GNOT_PATH } from "@constants/environment.constant";
 import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
@@ -23,6 +22,7 @@ import { SEOInfo } from "@constants/common.constant";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { formatPrice } from "@utils/new-number-utils";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 export async function getServerSideProps({ locale }: { locale: string }) {
   return {
@@ -33,9 +33,9 @@ export async function getServerSideProps({ locale }: { locale: string }) {
 }
 
 export default function Token() {
+  const router = useCustomRouter();
+  const path = router.getTokenPath();
   const { isLoading } = useLoading();
-  const router = useRouter();
-  const path = router.query["token-path"] as string;
 
   const { i18n } = useTranslation(["HeaderFooter", "common"], {
     bindI18n: "languageChanged loaded",
@@ -87,7 +87,7 @@ export default function Token() {
 
   const wrappedToken = useMemo(() => getGnotPath(token), [getGnotPath, token]);
 
-  const seoInfo = useMemo(() => SEOInfo["token/[token-path]"], []);
+  const seoInfo = useMemo(() => SEOInfo["/token"], []);
 
   const title = useMemo(() => {
     return seoInfo.title([

--- a/packages/web/src/pages/token/index.tsx
+++ b/packages/web/src/pages/token/index.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { formatPrice } from "@utils/new-number-utils";
 import useCustomRouter from "@hooks/common/use-custom-router";
+import { TokenError } from "@common/errors/token";
 
 export async function getServerSideProps({ locale }: { locale: string }) {
   return {
@@ -46,10 +47,12 @@ export default function Token() {
   }, []);
 
   const { data: token } = useGetTokenByPath(path, {
-    enabled: !!path,
     refetchInterval: 1000 * 10,
     onError: (err: any) => {
       if (err?.["response"]?.["status"] === 404) {
+        router.push("/");
+      }
+      if (err instanceof TokenError) {
         router.push("/");
       }
     },

--- a/packages/web/src/react-query/pools/queries.ts
+++ b/packages/web/src/react-query/pools/queries.ts
@@ -7,9 +7,9 @@ import { PoolBinModel } from "@models/pool/pool-bin-model";
 import { priceToTick } from "@utils/swap-utils";
 import { SwapFeeTierType } from "@constants/option.constant";
 import { PoolDetailRPCModel } from "@models/pool/pool-detail-rpc-model";
-import { useRouter } from "next/navigation";
 import { PoolStakingModel } from "@models/pool/pool-staking";
 import { PoolError } from "@common/errors/pool";
+import useCustomRouter from "@hooks/common/use-custom-router";
 
 export const useGetPoolCreationFee = (
   options?: UseQueryOptions<number, Error>,
@@ -125,7 +125,7 @@ export const useGetPoolDetailByPath = (
   options?: UseQueryOptions<PoolDetailModel, Error>,
 ) => {
   const { poolRepository } = useGnoswapContext();
-  const router = useRouter();
+  const router = useCustomRouter();
 
   return useQuery<PoolDetailModel, Error>({
     queryKey: [QUERY_KEY.poolDetail, path],
@@ -137,8 +137,13 @@ export const useGetPoolDetailByPath = (
       return data;
     },
     onError: (err: any) => {
+      if (err instanceof PoolError) {
+        router.movePage("EARN");
+        return;
+      }
       if (err?.["response"]?.["status"] === 404) {
-        router.push("/earn");
+        router.movePage("EARN");
+        return;
       }
     },
     ...options,

--- a/packages/web/src/react-query/positions/queries.ts
+++ b/packages/web/src/react-query/positions/queries.ts
@@ -14,7 +14,7 @@ import { useWallet } from "@hooks/wallet/use-wallet";
 interface UseGetPositionsByAddressOptions {
   address?: string;
   isClosed?: boolean;
-  poolPath?: string;
+  poolPath?: string | null;
   queryOptions?: UseQueryOptions<PositionModel[], Error>;
 }
 
@@ -109,10 +109,6 @@ export const useGetLazyPositionBins = (
   });
 };
 
-function makeId(data: PoolModel[] | PositionModel[]) {
-  return data.map(item => item.id).join("_");
-}
-
 export const useMakePoolPositions = (
   positions: PositionModel[] | undefined,
   pools: PoolModel[],
@@ -120,7 +116,7 @@ export const useMakePoolPositions = (
   options?: UseQueryOptions<PoolPositionModel[], Error>,
 ) => {
   return useQuery<PoolPositionModel[], Error>({
-    queryKey: [QUERY_KEY.poolPositions, makeId(positions || [])],
+    queryKey: [QUERY_KEY.poolPositions, positions?.map(p => p.id).join(",")],
     queryFn: async () => {
       return new Promise(resolve => {
         const poolPositions: PoolPositionModel[] = [];

--- a/packages/web/src/react-query/token/queries.ts
+++ b/packages/web/src/react-query/token/queries.ts
@@ -9,7 +9,7 @@ import { QUERY_KEY } from "./types";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 import { TokenPriceModel } from "@models/token/token-price-model";
 import { IBalancesByAddressResponse } from "@repositories/token/response/balance-by-address-response";
-import { encryptId } from "@utils/common";
+import { TokenError } from "@common/errors/token";
 
 export const useGetTokensList = (
   options?: UseQueryOptions<TokenListResponse, Error>,
@@ -47,29 +47,37 @@ export const useGetTokenPrices = (
 };
 
 export const useGetTokenPricesByPath = (
-  path: string,
+  path: string | null,
   options?: UseQueryOptions<TokenPriceModel, Error>,
 ) => {
   const { tokenRepository } = useGnoswapContext();
-  const currentPath = encryptId(path);
 
   return useQuery<TokenPriceModel, Error>({
-    queryKey: [QUERY_KEY.tokenPrices, currentPath],
-    queryFn: () => tokenRepository.getTokenPricesByPath(currentPath),
+    queryKey: [QUERY_KEY.tokenPrices, path],
+    queryFn: () => {
+      if (!path) {
+        throw new TokenError("NO_MATCH_TOKENID");
+      }
+      return tokenRepository.getTokenPricesByPath(path);
+    },
     ...options,
   });
 };
 
 export const useGetTokenDetailByPath = (
-  path: string,
+  path: string | null,
   option?: UseQueryOptions<ITokenDetailResponse, Error>,
 ) => {
   const { tokenRepository } = useGnoswapContext();
-  const currentPath = encryptId(path);
 
   return useQuery<ITokenDetailResponse, Error>({
-    queryKey: [QUERY_KEY.tokenDetails, currentPath],
-    queryFn: () => tokenRepository.getTokenDetailByPath(currentPath),
+    queryKey: [QUERY_KEY.tokenDetails, path],
+    queryFn: () => {
+      if (!path) {
+        throw new TokenError("NO_MATCH_TOKENID");
+      }
+      return tokenRepository.getTokenDetailByPath(path);
+    },
     ...option,
   });
 };
@@ -87,14 +95,18 @@ export const useGetChainList = (
 };
 
 export const useGetTokenByPath = (
-  path: string,
+  path: string | null,
   option?: UseQueryOptions<ITokenResponse, Error>,
 ) => {
   const { tokenRepository } = useGnoswapContext();
-  const currentPath = encryptId(path);
   return useQuery<ITokenResponse, Error>({
-    queryKey: [QUERY_KEY.tokenByPath, currentPath],
-    queryFn: () => tokenRepository.getTokenByPath(currentPath),
+    queryKey: [QUERY_KEY.tokenByPath, path],
+    queryFn: () => {
+      if (!path) {
+        throw new TokenError("NO_MATCH_TOKENID");
+      }
+      return tokenRepository.getTokenByPath(path);
+    },
     ...option,
   });
 };

--- a/packages/web/src/utils/page.utils.ts
+++ b/packages/web/src/utils/page.utils.ts
@@ -1,0 +1,46 @@
+import { PAGE_PATH, QUERY_PARAMETER } from "@constants/page.constant";
+
+export function makeQueryStringByParams(params: {
+  [key in string]: string | number | null | undefined;
+}): string {
+  const queryParams = Object.entries(params).reduce<string[]>((acc, entry) => {
+    if (entry?.[1] === undefined || entry?.[1] === null) {
+      return acc;
+    }
+    acc.push(`${entry[0]}=${entry[1]}`);
+    return acc;
+  }, []);
+  return queryParams.join("&");
+}
+
+export function makeRouteUrl(
+  url: string,
+  params?: {
+    [key in string]: string | number | null | undefined;
+  },
+  hash?: string | number,
+): string {
+  const hashString = hash !== undefined ? `#${hash}` : "";
+  const queryParams = params ? makeQueryStringByParams(params) : null;
+  if (!queryParams) {
+    return `${url}${hashString}`;
+  }
+
+  return `${url}?${queryParams}${hashString}`;
+}
+
+export function makeTokenRouteUrl(tokenPath: string): string {
+  return makeRouteUrl(PAGE_PATH.TOKEN, {
+    [QUERY_PARAMETER.TOKEN_PATH]: tokenPath,
+  });
+}
+
+export function makePoolRouteUrl(poolPath: string, hash?: string): string {
+  return makeRouteUrl(
+    PAGE_PATH.POOL,
+    {
+      [QUERY_PARAMETER.POOL_PATH]: poolPath,
+    },
+    hash,
+  );
+}

--- a/packages/web/src/utils/page.utils.ts
+++ b/packages/web/src/utils/page.utils.ts
@@ -4,7 +4,7 @@ export function makeQueryStringByParams(params: {
   [key in string]: string | number | null | undefined;
 }): string {
   const queryParams = Object.entries(params).reduce<string[]>((acc, entry) => {
-    if (entry?.[1] === undefined || entry?.[1] === null) {
+    if (entry?.[1] === undefined || entry?.[1] === null || entry?.[1] === "") {
       return acc;
     }
     acc.push(`${entry[0]}=${entry[1]}`);


### PR DESCRIPTION
# Descriptions

Resolve an issue where changing `/` to `_` when generating pool and token IDs was corrupting data.

- Find pools and tokens by query parameter.

- Use the original path for better usability.