### PR TITLE
fix: improve graph tooltip performance

### DIFF
--- a/packages/web/src/components/common/pool-graph/PoolGraph.tsx
+++ b/packages/web/src/components/common/pool-graph/PoolGraph.tsx
@@ -371,7 +371,9 @@ const PoolGraph: React.FC<PoolGraphProps> = ({
     if (!currentBin) {
       setPositionX(null);
       setPositionY(null);
-      !nextSpacing && setTooltipInfo(null);
+      if (!nextSpacing) {
+        setTooltipInfo(null);
+      }
       return;
     }
 
@@ -529,13 +531,15 @@ const PoolGraph: React.FC<PoolGraphProps> = ({
       .on("mousemove", onMouseoverChartBin)
       .on("mouseout", onMouseoutChartBin);
 
-    svgElement
-      .append("defs")
-      .append("clipPath")
-      .attr("id", "clip")
-      .append("rect")
-      .attr("width", width)
-      .attr("height", height);
+    if (svgElement.select("defs").empty()) {
+      svgElement
+        .append("defs")
+        .append("clipPath")
+        .attr("id", "clip")
+        .append("rect")
+        .attr("width", width)
+        .attr("height", height);
+    }
 
     if (!!width && !!height && !!scaleX && !!scaleY) {
       updateChart();
@@ -634,7 +638,7 @@ export const PoolGraphBinTooptip: React.FC<PoolGraphBinTooptipProps> = ({
       return "-";
     }
     return `${tokenAPrice} ${tokenB.symbol}`;
-  }, [tooltipInfo]);
+  }, [tooltipInfo?.tokenB, tooltipInfo?.tokenAPrice]);
 
   const tokenBPriceString = useMemo(() => {
     if (tooltipInfo === null) {
@@ -645,7 +649,7 @@ export const PoolGraphBinTooptip: React.FC<PoolGraphBinTooptipProps> = ({
       return "-";
     }
     return `${tokenBPrice} ${tokenA.symbol}`;
-  }, [tooltipInfo]);
+  }, [tooltipInfo?.tokenA, tooltipInfo?.tokenBPrice]);
 
   const tokenAPriceRangeStr = useMemo(() => {
     if (tooltipInfo === null) {
@@ -656,7 +660,7 @@ export const PoolGraphBinTooptip: React.FC<PoolGraphBinTooptipProps> = ({
       return "-";
     }
     return `${tokenARange.min} - ${tokenARange.max} ${tokenB.symbol}`;
-  }, [tooltipInfo]);
+  }, [tooltipInfo?.tokenB, tooltipInfo?.tokenARange]);
 
   const tokenBPriceRangeStr = useMemo(() => {
     if (tooltipInfo === null) {
@@ -667,7 +671,7 @@ export const PoolGraphBinTooptip: React.FC<PoolGraphBinTooptipProps> = ({
       return "-";
     }
     return `${tokenBRange.max} - ${tokenBRange.min} ${tokenA.symbol}`;
-  }, [tooltipInfo]);
+  }, [tooltipInfo?.tokenA, tooltipInfo?.tokenBRange]);
 
   return tooltipInfo ? (
     <div className="tooltip-wrapper">

--- a/packages/web/src/components/common/pool-graph/PoolGraph.tsx
+++ b/packages/web/src/components/common/pool-graph/PoolGraph.tsx
@@ -301,7 +301,7 @@ const PoolGraph: React.FC<PoolGraphProps> = ({
             .attr("class", "bin-inner")
             .style("stroke-width", "0")
             .attr("x", scaleX(bin.minTick) + 1)
-            .attr("width", scaleX(bin.maxTick - bin.minTick) - 1)
+            .attr("width", scaleX(bin.maxTick - bin.minTick) - 0.5)
             .attr("y", () => {
               const scaleYComputation = scaleY(bin.reserveTokenMap) ?? 0;
               return (
@@ -345,6 +345,7 @@ const PoolGraph: React.FC<PoolGraphProps> = ({
       const isHoveringPreviousBin = document
         .getElementById(getBinId(bin.index - 1))
         ?.matches(":hover");
+
       const isHoveringNextBin = document
         .getElementById(getBinId(bin.index + 1))
         ?.matches(":hover");

--- a/packages/web/src/hooks/common/use-floating-tooltip.tsx
+++ b/packages/web/src/hooks/common/use-floating-tooltip.tsx
@@ -4,7 +4,7 @@ import {
   shift,
   useFloating,
 } from "@floating-ui/react";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 
 type FloatingPlacement = "end" | "start";
 type FloatingSide = "top" | "right" | "bottom" | "left";
@@ -17,6 +17,7 @@ interface UseFloatingTooltip {
   tooltipWidth?: number;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function useFloatingTooltip<T extends HTMLElement = any>({
   offset,
   position,
@@ -25,20 +26,23 @@ export function useFloatingTooltip<T extends HTMLElement = any>({
   const [opened, setOpened] = useState(false);
   const boundaryRef = useRef<T>();
   const arrowRef = useRef(null);
-  const { x, y, elements, context, refs, strategy, update, placement } =
-    useFloating({
-      placement: position,
-      middleware: [
-        shift({
-          crossAxis: true,
-          padding: 5,
-          rootBoundary: "document",
-        }),
-        arrow({
-          element: arrowRef,
-        }),
-      ],
-    });
+  const { x, y, context, refs, strategy, update, placement } = useFloating({
+    placement: position,
+    middleware: [
+      shift({
+        crossAxis: true,
+        padding: 5,
+        rootBoundary: "document",
+      }),
+      arrow({
+        element: arrowRef,
+      }),
+    ],
+  });
+
+  const isDisplay = useMemo(() => {
+    return !!refs.reference && refs.floating?.current && boundaryRef?.current;
+  }, [refs.reference, refs.floating?.current, boundaryRef.current]);
 
   const horizontalOffset = placement.includes("right")
     ? offset
@@ -47,42 +51,51 @@ export function useFloatingTooltip<T extends HTMLElement = any>({
     : position.includes("top-start")
     ? offset
     : position.includes("top-end")
-    ? - offset
+    ? -offset
     : 0;
 
-  const verticalOffset = placement.includes("bottom") || placement.includes("right") || placement.includes("left")
-    ? offset + 32
-    : position.includes("top")
-    ? offset * -1
-    : 0;
-  
-  const handleMouseMove = useCallback(
-    ( event: MouseEvent | React.MouseEvent<T, MouseEvent> | React.TouchEvent<T>) => {
-      const isTouch = event.type.startsWith("touch");
-      const touch = isTouch ? (event as React.TouchEvent<T>).touches[0] : null;
-      const clientX = (isTouch ? touch?.clientX : (event as React.MouseEvent<T, MouseEvent>).clientX) || 0;
-      const clientY = (isTouch ? touch?.clientY : (event as React.MouseEvent<T, MouseEvent>).clientY) || 0;
-      
-      refs.setPositionReference({
-        getBoundingClientRect() {
-          return {
-            width: 0,
-            height: 0,
-            x: clientX,
-            y: clientY,
-            left: clientX + horizontalOffset,
-            top: clientY + verticalOffset,
-            right: clientX,
-            bottom: clientY,
-          };
-        },
-      });
-    },
-    [elements.reference],
-  );
+  const verticalOffset =
+    placement.includes("bottom") ||
+    placement.includes("right") ||
+    placement.includes("left")
+      ? offset + 32
+      : position.includes("top")
+      ? offset * -1
+      : 0;
+
+  const handleMouseMove = (
+    event: MouseEvent | React.MouseEvent<T, MouseEvent> | React.TouchEvent<T>,
+  ) => {
+    const isTouch = event.type.startsWith("touch");
+    const touch = isTouch ? (event as React.TouchEvent<T>).touches[0] : null;
+    const clientX =
+      (isTouch
+        ? touch?.clientX
+        : (event as React.MouseEvent<T, MouseEvent>).clientX) || 0;
+    const clientY =
+      (isTouch
+        ? touch?.clientY
+        : (event as React.MouseEvent<T, MouseEvent>).clientY) || 0;
+
+    refs.setPositionReference({
+      getBoundingClientRect() {
+        return {
+          width: 0,
+          height: 0,
+          x: clientX,
+          y: clientY,
+          left: clientX + horizontalOffset,
+          top: clientY + verticalOffset,
+          right: clientX,
+          bottom: clientY,
+        };
+      },
+    });
+  };
 
   useEffect(() => {
-    if (refs.floating.current) {
+    console.log(boundaryRef.current);
+    if (isDisplay && refs.floating.current && boundaryRef.current) {
       const boundary = boundaryRef.current!;
       boundary.addEventListener("mousemove", handleMouseMove);
 
@@ -100,16 +113,11 @@ export function useFloatingTooltip<T extends HTMLElement = any>({
     }
 
     return undefined;
-  }, [
-    elements.reference,
-    refs.floating.current,
-    update,
-    handleMouseMove,
-    opened,
-  ]);
+  }, [isDisplay, boundaryRef.current]);
+
   return {
     handleMouseMove,
-    x: Math.min((tooltipWidth || 0), (x || 0)),
+    x: Math.min(tooltipWidth || 0, x || 0),
     y,
     arrowRef,
     context,


### PR DESCRIPTION
# Descriptions

Improve the performance of tooltips generated when hovering over full graphs.
- Remove unnecessary code that stacks together when generating tooltips.