### PR TITLE
feat: change to an implementation from the launchpad repository

### DIFF
--- a/packages/web/src/providers/gnoswap-service-provider/GnoswapServiceProvider.tsx
+++ b/packages/web/src/providers/gnoswap-service-provider/GnoswapServiceProvider.tsx
@@ -25,8 +25,10 @@ import {
   GovernanceRepository,
   GovernanceRepositoryImpl,
 } from "@repositories/governance";
-import { LaunchpadRepository } from "@repositories/launchpad";
-import { LaunchpadRepositoryMock } from "@repositories/launchpad/launchpad-repository-mock";
+import {
+  LaunchpadRepository,
+  LaunchpadRepositoryImpl,
+} from "@repositories/launchpad";
 import {
   LeaderboardRepository,
   LeaderboardRepositoryMock,
@@ -260,9 +262,7 @@ const GnoswapServiceProvider: React.FC<React.PropsWithChildren> = ({
   }, [gnoswapApiClient]);
 
   const launchpadRepository = useMemo(() => {
-    // TODO: It should be changed to the actual implementation.
-    // return new LaunchpadRepositoryImpl(gnoswapApiClient, walletClient);
-    return new LaunchpadRepositoryMock(walletClient);
+    return new LaunchpadRepositoryImpl(gnoswapApiClient, walletClient);
   }, [gnoswapApiClient, walletClient]);
 
   useEffect(() => {


### PR DESCRIPTION
# Descriptions

- Change the mocked launchpad repository to an implementation.
- Apply after the Gnoswap backend is ready.