### PR TITLE
feat: reorder the collect functions in Launchpad

### DIFF
--- a/packages/web/src/repositories/launchpad/launchpad-repository-impl.ts
+++ b/packages/web/src/repositories/launchpad/launchpad-repository-impl.ts
@@ -194,14 +194,14 @@ export class LaunchpadRepositoryImpl implements LaunchpadRepository {
       makeTransactionMessage({
         packagePath: PACKAGE_LAUNCHPAD_PATH,
         send: "",
-        func: "CollectDepositGnsByProjectId",
+        func: "CollectRewardByProjectId",
         args: [projectId],
         caller,
       }),
       makeTransactionMessage({
         packagePath: PACKAGE_LAUNCHPAD_PATH,
         send: "",
-        func: "CollectRewardByProjectId",
+        func: "CollectDepositGnsByProjectId",
         args: [projectId],
         caller,
       }),
@@ -227,14 +227,14 @@ export class LaunchpadRepositoryImpl implements LaunchpadRepository {
       makeTransactionMessage({
         packagePath: PACKAGE_LAUNCHPAD_PATH,
         send: "",
-        func: "CollectDepositGnsByDepositId",
+        func: "CollectRewardByDepositId",
         args: [depositId],
         caller,
       }),
       makeTransactionMessage({
         packagePath: PACKAGE_LAUNCHPAD_PATH,
         send: "",
-        func: "CollectRewardByDepositId",
+        func: "CollectDepositGnsByDepositId",
         args: [depositId],
         caller,
       }),


### PR DESCRIPTION
# Descriptions

When you receive your Launchpad Rewards and Deposit, we guarantee the order in which you receive them.
The Reward must be called first before the Depsoit amount can be calculated with the Reward.