### PR TITLE
feat: launchpad responsive detail page

### DIFF
--- a/packages/web/src/components/common/icons/IconChevronRight.tsx
+++ b/packages/web/src/components/common/icons/IconChevronRight.tsx
@@ -1,0 +1,18 @@
+const IconChevronRight = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+    >
+      <path
+        d="M5.72668 11.06L8.78002 8L5.72668 4.94L6.66668 4L10.6667 8L6.66668 12L5.72668 11.06Z"
+        fill="#596782"
+      />
+    </svg>
+  );
+};
+
+export default IconChevronRight;

--- a/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/LaunchpadClaimAllModal.styles.ts
+++ b/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/LaunchpadClaimAllModal.styles.ts
@@ -19,6 +19,10 @@ export const LaunchpadClaimAllModalWrapper = styled.div`
     width: 100%;
     gap: 16px;
     padding: 24px;
+    ${media.mobile} {
+      gap: 8px;
+      padding: 12px;
+    }
     .header {
       ${mixins.flexbox("row", "center", "space-between")};
       width: 100%;
@@ -56,6 +60,9 @@ export const LaunchpadClaimAllModalWrapper = styled.div`
       width: 100%;
       max-height: calc(80vh - 200px);
       overflow-y: auto;
+      ${media.mobile} {
+        padding: 0px;
+      }
     }
 
     .content {
@@ -101,9 +108,15 @@ export const LaunchpadClaimAllModalWrapper = styled.div`
       width: 100%;
       button {
         height: 57px;
+        ${media.mobile} {
+          height: 41px;
+        }
         span {
           font-size: 18px;
           font-weight: 500;
+          ${media.mobile} {
+            font-size: 16px;
+          }
         }
       }
     }

--- a/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/LaunchpadClaimAllModal.styles.ts
+++ b/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/LaunchpadClaimAllModal.styles.ts
@@ -9,6 +9,9 @@ export const LaunchpadClaimAllModalWrapper = styled.div`
   max-width: 500px;
   width: 90vw;
   gap: 16px;
+  ${media.mobile} {
+    width: 328px;
+  }
   .modal-body {
     ${mixins.flexbox("column", "flex-start", "flex-start")};
     background-color: ${({ theme }) => theme.color.background06};
@@ -87,6 +90,9 @@ export const LaunchpadClaimAllModalWrapper = styled.div`
             width: 100%;
             font-size: 14px;
             font-weight: 400;
+            ${media.mobile} {
+              font-size: 13px;
+            }
             .key {
               color: ${({ theme }) => theme.color.text04};
             }

--- a/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/launchpad-claim-amount-field/LaunchpadClaimAmountField.styled.ts
+++ b/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/launchpad-claim-amount-field/LaunchpadClaimAmountField.styled.ts
@@ -1,5 +1,6 @@
 import mixins from "@styles/mixins";
 import styled from "@emotion/styled";
+import { media } from "@styles/media";
 
 export const ClaimAllFieldWrapper = styled.div`
   ${mixins.flexbox("column", "flex-end", "center")}
@@ -10,6 +11,9 @@ export const ClaimAllFieldWrapper = styled.div`
     color: ${({ theme }) => theme.color.text03};
     font-size: 14px;
     font-weight: 400;
+    ${media.mobile} {
+      font-size: 13px;
+    }
     img {
       width: 24px;
       height: 24px;

--- a/packages/web/src/components/common/launchpad-modal/launchpad-deposit-modal/LaunchpadDepositModal.styles.ts
+++ b/packages/web/src/components/common/launchpad-modal/launchpad-deposit-modal/LaunchpadDepositModal.styles.ts
@@ -9,6 +9,9 @@ export const LaunchpadDepositModalWrapper = styled.div`
   max-width: 500px;
   width: 90vw;
   gap: 16px;
+  ${media.mobile} {
+    width: 328px;
+  }
   .modal-body {
     ${mixins.flexbox("column", "flex-start", "flex-start")};
     background-color: ${({ theme }) => theme.color.background06};
@@ -82,6 +85,7 @@ export const LaunchpadDepositModalWrapper = styled.div`
             theme.themeKey === "dark" ? theme.color.backgroundOpacity : ""};
           padding: 16px;
           ${media.mobile} {
+            padding: 12px;
             gap: 8px;
           }
           .data-row {
@@ -89,8 +93,12 @@ export const LaunchpadDepositModalWrapper = styled.div`
             width: 100%;
             font-size: 14px;
             font-weight: 400;
+            ${media.mobile} {
+              font-size: 13px;
+            }
             .key {
               color: ${({ theme }) => theme.color.text04};
+              ${media}
             }
             .value {
               ${mixins.flexbox("row", "center", "center")};
@@ -109,6 +117,9 @@ export const LaunchpadDepositModalWrapper = styled.div`
         border: 1px solid rgba(255, 159, 10, 0.1);
         background: rgba(255, 159, 10, 0.08);
         padding: 16px;
+        ${media.mobile} {
+          padding: 12px;
+        }
         .header {
           ${mixins.flexbox("row", "center", "flex-start")}
           gap: 8px;

--- a/packages/web/src/components/common/launchpad-modal/launchpad-deposit-modal/LaunchpadDepositModal.styles.ts
+++ b/packages/web/src/components/common/launchpad-modal/launchpad-deposit-modal/LaunchpadDepositModal.styles.ts
@@ -19,6 +19,10 @@ export const LaunchpadDepositModalWrapper = styled.div`
     width: 100%;
     gap: 16px;
     padding: 24px;
+    ${media.mobile} {
+      gap: 12px;
+      padding: 16px;
+    }
     .header {
       ${mixins.flexbox("row", "center", "space-between")};
       width: 100%;
@@ -55,6 +59,9 @@ export const LaunchpadDepositModalWrapper = styled.div`
       ${mixins.flexbox("column", "flex-start", "flex-start")};
       gap: 16px;
       width: 100%;
+      ${media.mobile} {
+        gap: 12px;
+      }
       .data {
         ${mixins.flexbox("column", "flex-start", "flex-start")};
         gap: 8px;
@@ -74,6 +81,9 @@ export const LaunchpadDepositModalWrapper = styled.div`
           background: ${({ theme }) =>
             theme.themeKey === "dark" ? theme.color.backgroundOpacity : ""};
           padding: 16px;
+          ${media.mobile} {
+            gap: 8px;
+          }
           .data-row {
             ${mixins.flexbox("row", "center", "space-between")};
             width: 100%;
@@ -142,9 +152,15 @@ export const LaunchpadDepositModalWrapper = styled.div`
       width: 100%;
       button {
         height: 57px;
+        ${media.mobile} {
+          height: 41px;
+        }
         span {
           font-size: 18px;
           font-weight: 500;
+          ${media.mobile} {
+            font-size: 16px;
+          }
         }
       }
     }

--- a/packages/web/src/components/common/table-skeleton/TableSkeleton.tsx
+++ b/packages/web/src/components/common/table-skeleton/TableSkeleton.tsx
@@ -7,16 +7,16 @@ import {
   emptyArrayInit,
   pulseSkeletonStyle,
   TableInfoType,
-  TABLE_TITLE
+  TABLE_TITLE,
 } from "@constants/skeleton.constant";
 import { DEVICE_TYPE } from "@styles/media";
 
 import {
   SkeletonItem,
   SkeletonWrapper,
-  UnLoadingItem
+  UnLoadingItem,
 } from "./TableSkeleton.styles";
-
+import SwapPageButton from "@components/launchpad/swap-page-button/SwapPageButton";
 
 interface TableSkeletonProps {
   info: TableInfoType;
@@ -31,20 +31,25 @@ const TableSkeleton: React.FC<TableSkeletonProps> = ({ info, className }) => {
     <>
       {emptyArrayInit(info.total).map((_, index) => (
         <SkeletonWrapper key={index} title={info.title} className={className}>
-          {info.list.filter(item => !item.hideSkeleton).map((item, idx) => (
-            <SkeletonItem
-              key={idx}
-              className={cx({
-                left: item.left,
-                [item.className as string]: true,
-              })}
-              tdWidth={info.list[idx].width}
-            >
-              <span
-                css={pulseSkeletonStyle({ w: item.skeletonWidth, type: item.type })}
-              />
-            </SkeletonItem>
-          ))}
+          {info.list
+            .filter(item => !item.hideSkeleton)
+            .map((item, idx) => (
+              <SkeletonItem
+                key={idx}
+                className={cx({
+                  left: item.left,
+                  [item.className as string]: true,
+                })}
+                tdWidth={info.list[idx].width}
+              >
+                <span
+                  css={pulseSkeletonStyle({
+                    w: item.skeletonWidth,
+                    type: item.type,
+                  })}
+                />
+              </SkeletonItem>
+            ))}
           {info.title === TABLE_TITLE.ASSET_TABLE && (
             <>
               <UnLoadingItem
@@ -60,6 +65,11 @@ const TableSkeleton: React.FC<TableSkeletonProps> = ({ info, className }) => {
                 <AssetSendButton onClick={() => false} disabled />
               </UnLoadingItem>
             </>
+          )}
+          {info.title === TABLE_TITLE.LAUNCHPAD_TABLE && (
+            <UnLoadingItem tdWidth={ASSET_TD[ASSET_TD.length - 1]}>
+              <SwapPageButton onClick={() => false} disabled />
+            </UnLoadingItem>
           )}
         </SkeletonWrapper>
       ))}

--- a/packages/web/src/components/launchpad/swap-page-button/SwapPageButton.styles.ts
+++ b/packages/web/src/components/launchpad/swap-page-button/SwapPageButton.styles.ts
@@ -1,0 +1,31 @@
+import styled from "@emotion/styled";
+import mixins from "@styles/mixins";
+
+export const SwapPageButtonWrapper = styled.button`
+  ${mixins.flexbox("row", "center", "center")}
+  gap: 4px;
+  color: ${({ theme }) => theme.color.text04};
+  font-weight: 400;
+  cursor: pointer;
+  .svg {
+    width: 16px;
+    height: 16px;
+    font-size: 0;
+    * {
+      fill: ${({ theme }) =>
+        theme.themeKey === "dark" ? "#596782" : "#90A2C0"};
+    }
+  }
+
+  &,
+  svg * {
+    transition: all 0.3s ease;
+  }
+
+  &:hover {
+    color: ${({ theme }) => theme.color.text03};
+    svg * {
+      fill: ${({ theme }) => theme.color.icon07};
+    }
+  }
+`;

--- a/packages/web/src/components/launchpad/swap-page-button/SwapPageButton.tsx
+++ b/packages/web/src/components/launchpad/swap-page-button/SwapPageButton.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+import IconChevronRight from "@components/common/icons/IconChevronRight";
+import { SwapPageButtonWrapper } from "./SwapPageButton.styles";
+
+const SwapPageButton = ({
+  className,
+  onClick,
+  disabled = false,
+}: {
+  className?: string;
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
+}) => {
+  return (
+    <SwapPageButtonWrapper
+      className={className ? className : ""}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <span>Swap</span>
+      <IconChevronRight />
+    </SwapPageButtonWrapper>
+  );
+};
+
+export default SwapPageButton;

--- a/packages/web/src/constants/skeleton.constant.ts
+++ b/packages/web/src/constants/skeleton.constant.ts
@@ -549,6 +549,7 @@ export const PROJECT_INFO = {
       type: SHAPE_TYPES.ROUNDED_SQUARE,
       left: false,
       skeletonWidth: 161,
+      hideSkeleton: true,
     },
   ],
 };

--- a/packages/web/src/constants/skeleton.constant.ts
+++ b/packages/web/src/constants/skeleton.constant.ts
@@ -548,7 +548,7 @@ export const PROJECT_INFO = {
       width: 200,
       type: SHAPE_TYPES.ROUNDED_SQUARE,
       left: false,
-      skeletonWidth: 161,
+      skeletonWidth: 200,
       hideSkeleton: true,
     },
   ],

--- a/packages/web/src/views/launchpad/LaunchpadLayout.styles.ts
+++ b/packages/web/src/views/launchpad/LaunchpadLayout.styles.ts
@@ -93,7 +93,7 @@ export const LaunchpadLayoutWrapper = styled.div`
       color: ${({ theme }) => theme.color.text02};
       ${media.tablet} {
         font-size: clamp(3rem, 1.8041rem + 1.6216vw, 3.75rem);
-        font-weight: 600;
+        font-weight: 700;
       }
       ${media.mobile} {
         font-size: clamp(2.25rem, 1.9207rem + 1.4634vw, 3rem);
@@ -221,8 +221,7 @@ export const LaunchpadLayoutWrapper = styled.div`
     ${mixins.flexbox("row", "center", "center")};
     width: 100%;
     .mobile-title {
-      color: ${({ theme }) =>
-        theme.themeKey === "dark" ? theme.color.border07 : theme.color.text03};
+      color: ${({ theme }) => theme.color.text02};
     }
     font-size: clamp(1.9375rem, 1.471rem + 2.0732vw, 3rem);
     font-weight: 600;

--- a/packages/web/src/views/launchpad/components/launchpad-active-projects/launchpad-active-projects-content/LaunchpadActiveProjectsContent.tsx
+++ b/packages/web/src/views/launchpad/components/launchpad-active-projects/launchpad-active-projects-content/LaunchpadActiveProjectsContent.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { LaunchpadProjectResponse } from "@repositories/launchpad/response";
 
 import LaunchpadActiveProjectsCardList from "./launchpad-active-projects-card-list/LaunchpadActiveProjectsCardList";
+import LaunchpadActiveProjectNoData from "./launchpad-active-project-no-data/LaunchpadActiveProjectNoData";
 
 export interface LaunchpadActiveProjectsContentProps {
   activeProjectList: LaunchpadProjectResponse[];
@@ -34,6 +35,9 @@ const LaunchpadActiveProjectsContent: React.FC<
   onClickLoadMore,
   moveProjectDetail,
 }) => {
+  if (isFetched && activeProjectList.length === 0) {
+    return <LaunchpadActiveProjectNoData />;
+  }
   return (
     <LaunchpadActiveProjectsCardList
       activeProjectList={activeProjectList}

--- a/packages/web/src/views/launchpad/components/launchpad-active-projects/launchpad-active-projects-content/launchpad-active-project-no-data/LaunchpadActiveProjectNoData.tsx
+++ b/packages/web/src/views/launchpad/components/launchpad-active-projects/launchpad-active-projects-content/launchpad-active-project-no-data/LaunchpadActiveProjectNoData.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   ActiveProjectsCardListWrapper,
   ActiveProjectsGridWrapper,
+  BlankProjectCard,
 } from "../launchpad-active-projects-card-list/LaunchpadActiveProjectsCardList.styles";
 
 const LaunchpadActiveProjectNoData = () => {
@@ -9,7 +10,7 @@ const LaunchpadActiveProjectNoData = () => {
     <ActiveProjectsCardListWrapper>
       <ActiveProjectsGridWrapper>
         {Array.from({ length: 4 }).map((_, idx) => {
-          return <div key={idx} className="nodata-card" />;
+          return <BlankProjectCard key={idx} />;
         })}
       </ActiveProjectsGridWrapper>
     </ActiveProjectsCardListWrapper>

--- a/packages/web/src/views/launchpad/components/launchpad-active-projects/launchpad-active-projects-content/launchpad-active-project-no-data/LaunchpadActiveProjectNoData.tsx
+++ b/packages/web/src/views/launchpad/components/launchpad-active-projects/launchpad-active-projects-content/launchpad-active-project-no-data/LaunchpadActiveProjectNoData.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import {
+  ActiveProjectsCardListWrapper,
+  ActiveProjectsGridWrapper,
+} from "../launchpad-active-projects-card-list/LaunchpadActiveProjectsCardList.styles";
+
+const LaunchpadActiveProjectNoData = () => {
+  return (
+    <ActiveProjectsCardListWrapper>
+      <ActiveProjectsGridWrapper>
+        {Array.from({ length: 4 }).map((_, idx) => {
+          return <div key={idx} className="nodata-card" />;
+        })}
+      </ActiveProjectsGridWrapper>
+    </ActiveProjectsCardListWrapper>
+  );
+};
+
+export default LaunchpadActiveProjectNoData;

--- a/packages/web/src/views/launchpad/components/launchpad-active-projects/launchpad-active-projects-content/launchpad-active-projects-card-list/LaunchpadActiveProjectsCardList.styles.ts
+++ b/packages/web/src/views/launchpad/components/launchpad-active-projects/launchpad-active-projects-content/launchpad-active-projects-card-list/LaunchpadActiveProjectsCardList.styles.ts
@@ -51,18 +51,21 @@ export const ActiveProjectsGridWrapper = styled.div`
     height: 317px;
     border-radius: 10px;
   }
+`;
 
-  .nodata-card {
-    min-width: 322px;
-    width: 100%;
-    height: 317px;
-    border-radius: 10px;
-    border-radius: 10px;
-    background: ${({ theme }) =>
-      theme.themeKey === "dark" ? "rgba(20, 26, 41, 0.5);" : ""};
-    border: ${({ theme }) =>
-      theme.themeKey === "dark" ? "none" : `1px solid ${theme.color.border01}`};
-    box-shadow: ${({ theme }) =>
-      theme.themeKey === "dark" ? "4px 4px 20px 0px rgba(0, 0, 0, 0.05)" : ""};
+export const BlankProjectCard = styled.div`
+  min-width: 322px;
+  width: 100%;
+  height: 317px;
+  border-radius: 10px;
+  border-radius: 10px;
+  background: ${({ theme }) =>
+    theme.themeKey === "dark" ? "rgba(20, 26, 41, 0.5);" : ""};
+  border: ${({ theme }) =>
+    theme.themeKey === "dark" ? "none" : `1px solid ${theme.color.border01}`};
+  box-shadow: ${({ theme }) =>
+    theme.themeKey === "dark" ? "4px 4px 20px 0px rgba(0, 0, 0, 0.05)" : ""};
+  ${media.tablet} {
+    height: 341px;
   }
 `;

--- a/packages/web/src/views/launchpad/components/launchpad-active-projects/launchpad-active-projects-content/launchpad-active-projects-card-list/LaunchpadActiveProjectsCardList.styles.ts
+++ b/packages/web/src/views/launchpad/components/launchpad-active-projects/launchpad-active-projects-content/launchpad-active-projects-card-list/LaunchpadActiveProjectsCardList.styles.ts
@@ -51,4 +51,18 @@ export const ActiveProjectsGridWrapper = styled.div`
     height: 317px;
     border-radius: 10px;
   }
+
+  .nodata-card {
+    min-width: 322px;
+    width: 100%;
+    height: 317px;
+    border-radius: 10px;
+    border-radius: 10px;
+    background: ${({ theme }) =>
+      theme.themeKey === "dark" ? "rgba(20, 26, 41, 0.5);" : ""};
+    border: ${({ theme }) =>
+      theme.themeKey === "dark" ? "none" : `1px solid ${theme.color.border01}`};
+    box-shadow: ${({ theme }) =>
+      theme.themeKey === "dark" ? "4px 4px 20px 0px rgba(0, 0, 0, 0.05)" : ""};
+  }
 `;

--- a/packages/web/src/views/launchpad/components/launchpad-active-projects/launchpad-active-projects-content/launchpad-active-projects-card-list/LaunchpadActiveProjectsCardList.tsx
+++ b/packages/web/src/views/launchpad/components/launchpad-active-projects/launchpad-active-projects-content/launchpad-active-projects-card-list/LaunchpadActiveProjectsCardList.tsx
@@ -6,6 +6,7 @@ import LaunchpadActiveProjectCard from "./launchpad-active-project-card/Launchpa
 import {
   ActiveProjectsCardListWrapper,
   ActiveProjectsGridWrapper,
+  BlankProjectCard,
 } from "./LaunchpadActiveProjectsCardList.styles";
 import LoadMoreButton from "@components/common/load-more-button/LoadMoreButton";
 import { pulseSkeletonStyle } from "@constants/skeleton.constant";
@@ -56,6 +57,13 @@ const LaunchpadActiveProjectsCardList: React.FC<
               />
             );
           })}
+        {isFetched &&
+          !isLoading &&
+          activeProjectList.length > 0 &&
+          activeProjectList.length < 4 &&
+          Array(4 - activeProjectList.length)
+            .fill(1)
+            .map((_, idx) => <BlankProjectCard key={idx} />)}
         {showLoading &&
           Array.from({ length: 4 }).map((_, index) => (
             <span

--- a/packages/web/src/views/launchpad/components/launchpad-main/LaunchpadMain.tsx
+++ b/packages/web/src/views/launchpad/components/launchpad-main/LaunchpadMain.tsx
@@ -72,7 +72,7 @@ const LaunchpadMain: React.FC<LaunchpadMainProps> = ({
           <div className="launchpad-data-list">
             {isLoading && (
               <span className="launchpad-data-value">
-                <span css={pulseSkeletonStyle({ w: "120px", h: 18 })} />
+                <span css={pulseSkeletonStyle({ w: "120px", h: 19.5 })} />
               </span>
             )}
             {!isLoading && (
@@ -87,7 +87,7 @@ const LaunchpadMain: React.FC<LaunchpadMainProps> = ({
           <div className="launchpad-data-list">
             {isLoading && (
               <span className="launchpad-data-value">
-                <span css={pulseSkeletonStyle({ w: "120px", h: 18 })} />
+                <span css={pulseSkeletonStyle({ w: "120px", h: 24 })} />
               </span>
             )}
             {!isLoading && (
@@ -103,7 +103,7 @@ const LaunchpadMain: React.FC<LaunchpadMainProps> = ({
           <div className="launchpad-data-list">
             {isLoading && (
               <span className="launchpad-data-value">
-                <span css={pulseSkeletonStyle({ w: "120px", h: 18 })} />
+                <span css={pulseSkeletonStyle({ w: "120px", h: 19.5 })} />
               </span>
             )}
             {!isLoading && (

--- a/packages/web/src/views/launchpad/components/launchpad-project-list/launchpad-project-list-table/LaunchpadProjectListTable.tsx
+++ b/packages/web/src/views/launchpad/components/launchpad-project-list/launchpad-project-list-table/LaunchpadProjectListTable.tsx
@@ -98,7 +98,7 @@ const LaunchpadProjectListTable: React.FC<LaunchpadProjectListTableProps> = ({
               />
             );
           })}
-        {isFetched && (
+        {!isFetched && (
           <TableSkeleton
             className="skeleton"
             breakpoint={breakpoint}

--- a/packages/web/src/views/launchpad/components/launchpad-project-list/launchpad-project-list-table/LaunchpadProjectListTable.tsx
+++ b/packages/web/src/views/launchpad/components/launchpad-project-list/launchpad-project-list-table/LaunchpadProjectListTable.tsx
@@ -98,7 +98,7 @@ const LaunchpadProjectListTable: React.FC<LaunchpadProjectListTableProps> = ({
               />
             );
           })}
-        {!isFetched && (
+        {isFetched && (
           <TableSkeleton
             className="skeleton"
             breakpoint={breakpoint}

--- a/packages/web/src/views/launchpad/components/launchpad-project-list/launchpad-project-list-table/launchpad-project-info/LaunchpadProjectInfo.styles.ts
+++ b/packages/web/src/views/launchpad/components/launchpad-project-list/launchpad-project-list-table/launchpad-project-info/LaunchpadProjectInfo.styles.ts
@@ -44,7 +44,7 @@ export const TableColumn = styled.div<{ tdWidth: number }>`
 export const ProjectInfoWrapper = styled.div`
   transition: background-color 0.3s ease;
   min-width: 100%;
-  height: 72px;
+  height: 68px;
   &.border-top {
     border-top: 1px solid ${({ theme }) => theme.color.border02};
   }

--- a/packages/web/src/views/launchpad/components/launchpad-project-list/launchpad-project-list-table/launchpad-project-info/LaunchpadProjectInfo.tsx
+++ b/packages/web/src/views/launchpad/components/launchpad-project-list/launchpad-project-list-table/launchpad-project-info/LaunchpadProjectInfo.tsx
@@ -14,6 +14,7 @@ import { LaunchpadPoolModel, LaunchpadProjectModel } from "@models/launchpad";
 import { ProjectInfoWrapper, TableColumn } from "./LaunchpadProjectInfo.styles";
 import LaunchpadProjectInfoChip from "./launchpad-project-info-chip/LaunchpadProjectInfoChip";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
+import SwapPageButton from "@components/launchpad/swap-page-button/SwapPageButton";
 
 interface LaunchpadProjectInfoProps {
   border?: boolean;
@@ -129,7 +130,7 @@ const LaunchpadProjectInfo: React.FC<LaunchpadProjectInfoProps> = ({
         </span>
       </TableColumn>
       <TableColumn tdWidth={cellWidths.list[6].width}>
-        <div
+        <SwapPageButton
           className="button-wrapper"
           onClick={e => {
             e.preventDefault();
@@ -137,23 +138,7 @@ const LaunchpadProjectInfo: React.FC<LaunchpadProjectInfoProps> = ({
 
             moveRewardTokenSwapPage(rewardTokenPath);
           }}
-        >
-          <span>Swap</span>
-          <span className="svg">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              viewBox="0 0 16 16"
-              fill="none"
-            >
-              <path
-                d="M5.72668 11.06L8.78002 8L5.72668 4.94L6.66668 4L10.6667 8L6.66668 12L5.72668 11.06Z"
-                fill="#596782"
-              />
-            </svg>
-          </span>
-        </div>
+        />
       </TableColumn>
     </ProjectInfoWrapper>
   );

--- a/packages/web/src/views/launchpad/launchpad-detail/LaunchpadDetail.tsx
+++ b/packages/web/src/views/launchpad/launchpad-detail/LaunchpadDetail.tsx
@@ -20,6 +20,7 @@ import LaunchpadParticipateContainer from "./containers/launchpad-participate-co
 import LaunchpadMyParticipationContainer from "./containers/launchpad-my-participation-container/LaunchpadMyParticipationContainer";
 import LaunchpadDetailClickHereContainer from "./containers/launchpad-detail-click-here-container/LaunchpadDetailClickHereContainer";
 import Footer from "@components/common/footer/Footer";
+import { useWindowSize } from "@hooks/common/use-window-size";
 
 export interface ProjectSummaryDataModel {
   totalAllocation: number;
@@ -61,6 +62,7 @@ const LaunchpadDetail: React.FC = () => {
   const [, setDepositConditions] = useAtom(LaunchpadState.depositConditions);
   const { updateBalances } = useTokenData();
 
+  const { breakpoint } = useWindowSize();
   const router = useCustomRouter();
   const projectPath = router.getProjectPath();
   const { account } = useWallet();
@@ -231,6 +233,7 @@ const LaunchpadDetail: React.FC = () => {
 
   return (
     <LaunchpadDetailLayout
+      breakpoint={breakpoint}
       header={<HeaderContainer />}
       breadcrumbs={
         <BreadcrumbsContainer

--- a/packages/web/src/views/launchpad/launchpad-detail/LaunchpadDetailLayout.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/LaunchpadDetailLayout.styles.ts
@@ -12,17 +12,20 @@ export const LaunchpadDetailLayoutWrapper = styled.div`
     width: 100%;
     max-width: 1440px;
     padding: 100px 40px;
+    ${media.tablet} {
+      gap: 24px;
+      padding: 60px 40px;
+    }
+    ${media.mobile} {
+      padding: 24px 16px;
+    }
   }
   .header-section {
     ${mixins.flexbox("column", "center", "center")}
     width: 100%;
     flex-grow: 1;
     margin: 0 auto;
-    ${media.tablet} {
-      /* padding: 118px 40px; */
-    }
     ${media.mobile} {
-      padding: 48px 0;
       ${mixins.flexbox("column", "center", "center")}
     }
   }
@@ -34,6 +37,12 @@ export const LaunchpadDetailLayoutWrapper = styled.div`
       color: ${({ theme }) => theme.color.text02};
       font-size: 36px;
       font-weight: 600;
+      ${media.tablet} {
+        font-size: clamp(2rem, 1.6014rem + 0.5405vw, 2.25rem);
+      }
+      ${media.mobile} {
+        font-size: clamp(1.5rem, 1.2805rem + 0.9756vw, 2rem);
+      }
     }
   }
 
@@ -48,7 +57,7 @@ export const LaunchpadDetailLayoutWrapper = styled.div`
 
     gap: 16px;
     width: 100%;
-    @media (max-width: 930px) {
+    ${media.tablet} {
       ${mixins.flexbox("column", "flex-start", "flex-start")};
     }
   }
@@ -58,14 +67,10 @@ export const LaunchpadDetailLayoutWrapper = styled.div`
     flex: 1;
     max-width: 914px;
     min-width: 722px;
-    @media (max-width: 1180px) {
-      max-width: 734px;
-      min-width: 568px;
-    }
-    @media (max-width: 930px) {
-      max-width: 100%;
-      min-width: auto;
+    ${media.tablet} {
+      max-width: none;
       width: 100%;
+      min-width: auto;
     }
     .pool-list {
       width: 100%;
@@ -88,11 +93,7 @@ export const LaunchpadDetailLayoutWrapper = styled.div`
     gap: 16px;
     max-width: 430px;
     width: 100%;
-    @media (max-width: 1180px) {
-      max-width: 360px;
-      min-width: 276px;
-    }
-    @media (max-width: 930px) {
+    ${media.tablet} {
       max-width: 100%;
       min-width: auto;
       width: 100%;

--- a/packages/web/src/views/launchpad/launchpad-detail/LaunchpadDetailLayout.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/LaunchpadDetailLayout.styles.ts
@@ -17,7 +17,7 @@ export const LaunchpadDetailLayoutWrapper = styled.div`
       padding: 60px 40px;
     }
     ${media.mobile} {
-      padding: 24px 16px;
+      padding: 24px 16px 48px;
     }
   }
   .header-section {
@@ -33,6 +33,10 @@ export const LaunchpadDetailLayoutWrapper = styled.div`
     ${mixins.flexbox("row", "center", "flex-start")};
     width: 100%;
     gap: 20px;
+    ${media.tablet} {
+      ${mixins.flexbox("column", "flex-start", "flex-start")};
+      gap: 8px;
+    }
     .title {
       color: ${({ theme }) => theme.color.text02};
       font-size: 36px;
@@ -60,6 +64,9 @@ export const LaunchpadDetailLayoutWrapper = styled.div`
     ${media.tablet} {
       ${mixins.flexbox("column", "flex-start", "flex-start")};
     }
+    ${media.mobile} {
+      ${mixins.flexbox("column-reverse", "flex-start", "flex-start")}
+    }
   }
   .main-section {
     ${mixins.flexbox("column", "center", "space-between")};
@@ -85,6 +92,9 @@ export const LaunchpadDetailLayoutWrapper = styled.div`
       border-radius: 8px;
       border: 1px solid ${({ theme }) => theme.color.border02};
       padding: 24px;
+      ${media.mobile} {
+        padding: 16px;
+      }
     }
   }
 
@@ -94,8 +104,11 @@ export const LaunchpadDetailLayoutWrapper = styled.div`
     max-width: 430px;
     width: 100%;
     ${media.tablet} {
-      max-width: 100%;
       min-width: auto;
+      max-width: none;
+      width: 100%;
+    }
+    .pool-list {
       width: 100%;
     }
     .participate {
@@ -104,6 +117,9 @@ export const LaunchpadDetailLayoutWrapper = styled.div`
       border: 1px solid ${({ theme }) => theme.color.border02};
       background: ${({ theme }) => theme.color.background06};
       padding: 24px;
+      ${media.mobile} {
+        padding: 16px;
+      }
     }
     .my-participation {
       width: 100%;

--- a/packages/web/src/views/launchpad/launchpad-detail/LaunchpadDetailLayout.tsx
+++ b/packages/web/src/views/launchpad/launchpad-detail/LaunchpadDetailLayout.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 
+import { DEVICE_TYPE } from "@styles/media";
+
 import { LaunchpadDetailLayoutWrapper } from "./LaunchpadDetailLayout.styles";
 
 interface LaunchpadDetailLayoutProps {
+  breakpoint: DEVICE_TYPE;
   header: React.ReactNode;
   breadcrumbs: React.ReactNode;
   contentsHeader: React.ReactNode;
@@ -16,6 +19,7 @@ interface LaunchpadDetailLayoutProps {
 }
 
 const LaunchpadDetailLayout: React.FC<LaunchpadDetailLayoutProps> = ({
+  breakpoint,
   header,
   breadcrumbs,
   contentsHeader,
@@ -42,11 +46,16 @@ const LaunchpadDetailLayout: React.FC<LaunchpadDetailLayoutProps> = ({
           {contentsHeader}
           <div className="main-container">
             <div className="main-section">
-              <div className="pool-list">{poolList}</div>
+              {breakpoint !== DEVICE_TYPE.MOBILE && (
+                <div className="pool-list">{poolList}</div>
+              )}
               <div className="project-summary">{projectSummary}</div>
               <div className="about-project">{aboutProject}</div>
             </div>
             <div className="right-section">
+              {breakpoint === DEVICE_TYPE.MOBILE && (
+                <div className="pool-list">{poolList}</div>
+              )}
               <div className="participate">{participate}</div>
               <div className="my-participation">{myParticipation}</div>
               <div className="click-here">{clickHere}</div>

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-about-project/LaunchpadAboutProject.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-about-project/LaunchpadAboutProject.styles.ts
@@ -21,6 +21,9 @@ export const LaunchpadAboutProjectWrapper = styled.div`
     color: ${({ theme }) => theme.color.text02};
     font-size: 18px;
     font-weight: 500;
+    ${media.mobile} {
+      font-size: 16px;
+    }
   }
 
   .contents {

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-about-project/LaunchpadAboutProject.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-about-project/LaunchpadAboutProject.styles.ts
@@ -1,14 +1,21 @@
 import styled from "@emotion/styled";
+import { media } from "@styles/media";
 import mixins from "@styles/mixins";
 
 export const LaunchpadAboutProjectWrapper = styled.div`
   ${mixins.flexbox("column", "center", "flex-start")}
   gap: 16px;
   width: 100%;
+  ${media.mobile} {
+    gap: 8px;
+  }
   .main-contents {
     ${mixins.flexbox("column", "center", "flex-start")}
     gap: 24px;
     width: 100%;
+    ${media.mobile} {
+      gap: 16px;
+    }
   }
   .header {
     color: ${({ theme }) => theme.color.text02};
@@ -20,6 +27,9 @@ export const LaunchpadAboutProjectWrapper = styled.div`
     width: 100%;
     ${mixins.flexbox("column", "flex-start", "flex-start")}
     gap: 16px;
+    ${media.mobile} {
+      gap: 8px;
+    }
     .description {
       max-width: 768px;
       color: ${({ theme }) => theme.color.text04};

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-about-project/LaunchpadAboutProject.tsx
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-about-project/LaunchpadAboutProject.tsx
@@ -26,7 +26,7 @@ const LaunchpadAboutProject: React.FC<LaunchpadAboutProjectProps> = ({
   return (
     <LaunchpadAboutProjectWrapper>
       <div className="header">
-        {isLoading && <div css={pulseSkeletonStyle({ w: 215, h: 20 })} />}
+        {isLoading && <div css={pulseSkeletonStyle({ w: 215, h: 25 })} />}
         {!isLoading && <h2>{`About ${data.name}`}</h2>}
       </div>
 

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-detail-click-here/LaunchpadDetailClickHere.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-detail-click-here/LaunchpadDetailClickHere.styles.ts
@@ -27,6 +27,7 @@ export const LinkButton = styled.div`
   font-weight: 500;
   gap: 4px;
   color: ${({ theme }) => theme.color.text04};
+  white-space: nowrap;
   ${media.mobile} {
     ${mixins.flexbox("column", "center", "center")};
   }

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-detail-click-here/LaunchpadDetailClickHere.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-detail-click-here/LaunchpadDetailClickHere.styles.ts
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 import mixins from "@styles/mixins";
 import { media } from "@styles/media";
-import { fonts } from "@constants/font.constant";
 
 export const DetailClickHereWrapper = styled.div`
   ${mixins.flexbox("row", "center", "center")};
@@ -24,11 +23,12 @@ export const DetailClickHereWrapper = styled.div`
 export const LinkButton = styled.div`
   ${mixins.flexbox("row", "center", "center")};
   width: 100%;
-  ${fonts.body11};
+  font-size: 14px;
+  font-weight: 500;
   gap: 4px;
   color: ${({ theme }) => theme.color.text04};
   ${media.mobile} {
-    ${fonts.p3};
+    ${mixins.flexbox("column", "center", "center")};
   }
   a {
     ${mixins.flexbox("row", "center", "center")};

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-detail-contents-header/LaunchpadDetailContentsHeader.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-detail-contents-header/LaunchpadDetailContentsHeader.styles.ts
@@ -1,10 +1,14 @@
 import styled from "@emotion/styled";
+import { media } from "@styles/media";
 import mixins from "@styles/mixins";
 
 export const ContentsHeaderWrapper = styled.div`
   width: 100%;
   ${mixins.flexbox("row", "center", "flex-start")};
   gap: 8px;
+  ${media.tablet} {
+    ${mixins.flexbox("column", "flex-start", "flex-start")};
+  }
   .symbol-icon {
     width: 36px;
     height: 36px;
@@ -12,6 +16,10 @@ export const ContentsHeaderWrapper = styled.div`
       width: 100%;
       height: 100%;
     }
+  }
+  .project-header {
+    ${mixins.flexbox("row", "center", "center")};
+    gap: 8px;
   }
   .project-name {
     color: ${({ theme }) => theme.color.text02};

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-detail-contents-header/LaunchpadDetailContentsHeader.tsx
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-detail-contents-header/LaunchpadDetailContentsHeader.tsx
@@ -32,15 +32,17 @@ const LaunchpadDetailContentsHeader: React.FC<
       {isLoading && <span css={pulseSkeletonStyle({ w: 200, h: 20 })}></span>}
       {!isLoading && (
         <>
-          <div className="symbol-icon">
-            <MissingLogo
-              symbol={rewardInfo.rewardTokenSymbol}
-              url={rewardInfo.rewardTokenLogoUrl}
-              width={36}
-              mobileWidth={36}
-            />
+          <div className="project-header">
+            <div className="symbol-icon">
+              <MissingLogo
+                symbol={rewardInfo.rewardTokenSymbol}
+                url={rewardInfo.rewardTokenLogoUrl}
+                width={36}
+                mobileWidth={36}
+              />
+            </div>
+            <div className="project-name">{data.name}</div>
           </div>
-          <div className="project-name">{data.name}</div>
           {data.projectStatus && (
             <LaunchpadStatusTimeChip
               startTime={data.startTime}

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-detail-contents-header/LaunchpadDetailContentsHeader.tsx
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-detail-contents-header/LaunchpadDetailContentsHeader.tsx
@@ -29,7 +29,7 @@ const LaunchpadDetailContentsHeader: React.FC<
 > = ({ data, isLoading, rewardInfo }) => {
   return (
     <ContentsHeaderWrapper className="contents-header">
-      {isLoading && <span css={pulseSkeletonStyle({ w: 200, h: 20 })}></span>}
+      {isLoading && <span css={pulseSkeletonStyle({ w: 200, h: 36 })}></span>}
       {!isLoading && (
         <>
           <div className="project-header">

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-my-participation/LaunchpadMyParticipation.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-my-participation/LaunchpadMyParticipation.styles.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { media } from "@styles/media";
 import mixins from "@styles/mixins";
 
 export const MyParticipationWrapper = styled.div`
@@ -10,6 +11,9 @@ export const MyParticipationWrapper = styled.div`
   ${mixins.flexbox("column", "center", "center")};
   gap: 16px;
   width: 100%;
+  ${media.mobile} {
+    padding: 16px;
+  }
   .my-participation-header {
     ${mixins.flexbox("row", "center", "space-between")};
     width: 100%;
@@ -35,20 +39,21 @@ export const MyParticipationWrapper = styled.div`
     ${mixins.flexbox("column", "center", "flex-start")};
     gap: 16px;
     width: 100%;
+    font-size: 14px;
+    font-weight: 400;
+    ${media.mobile} {
+      font-size: clamp(0.8125rem, 0.7851rem + 0.122vw, 0.875rem);
+    }
     .participation-box-data {
       ${mixins.flexbox("row", "center", "space-between")};
       width: 100%;
       .participation-box-data-key {
         color: ${({ theme }) => theme.color.text04};
-        font-size: 14px;
-        font-weight: 400;
       }
       .participation-box-data-value {
         ${mixins.flexbox("row", "center", "center")};
         gap: 4px;
         color: ${({ theme }) => theme.color.text03};
-        font-size: 14px;
-        font-weight: 400;
       }
     }
   }

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-my-participation/launchpad-my-participation-box/LaunchpadMyParticipationBox.tsx
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-my-participation/launchpad-my-participation-box/LaunchpadMyParticipationBox.tsx
@@ -69,16 +69,6 @@ const LaunchpadMyParticipationBox = ({
     return isClaimedReward && isClaimedDeposit;
   }, [item]);
 
-  const formatClaimedRewardAmount = React.useCallback(
-    (amount: number, decimalPlaces = 6) => {
-      const formatted = toNumberFormat(amount, decimalPlaces);
-      return Number(formatted.replace(/,/g, "")) < 0.01
-        ? "<0.01"
-        : formatted.toString();
-    },
-    [],
-  );
-
   return (
     <MyParticipationBoxWrapper key={item.id}>
       <div className="my-participation-box-header">
@@ -114,9 +104,7 @@ const LaunchpadMyParticipationBox = ({
               mobileWidth={24}
             />
             <>
-              {isClaimed
-                ? 0
-                : formatClaimedRewardAmount(item.claimableRewardAmount, 6)}{" "}
+              {isClaimed ? 0 : toNumberFormat(item.claimableRewardAmount, 6)}{" "}
               {rewardInfo?.rewardTokenSymbol}
             </>
           </div>

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-participate/LaunchpadParticipate.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-participate/LaunchpadParticipate.styles.ts
@@ -83,6 +83,9 @@ export const LaunchpadParticipateWrapper = styled.div`
       color: ${({ theme }) => theme.color.text04};
       font-size: 14px;
       font-weight: 400;
+      ${media.mobile} {
+        font-size: 13px;
+      }
       * {
         fill: ${({ theme }) =>
           theme.themeKey === "dark" ? "#596782" : "#90A2C0"};
@@ -94,6 +97,9 @@ export const LaunchpadParticipateWrapper = styled.div`
       color: ${({ theme }) => theme.color.text03};
       font-size: 14px;
       font-weight: 400;
+      ${media.mobile} {
+        font-size: 13px;
+      }
     }
   }
   .participate-button-wrapper {

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-participate/LaunchpadParticipate.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-participate/LaunchpadParticipate.styles.ts
@@ -100,9 +100,13 @@ export const LaunchpadParticipateWrapper = styled.div`
     ${mixins.flexbox("row", "flex-start", "flex-start")};
     position: relative;
     width: 100%;
+    height: 57px;
+    ${media.mobile} {
+      height: 41px;
+    }
     button {
+      height: 100%;
       cursor: default;
-      height: 57px;
     }
     .button-deposit {
       cursor: pointer;
@@ -111,7 +115,6 @@ export const LaunchpadParticipateWrapper = styled.div`
       ${fonts.body7}
     }
     ${media.mobile} {
-      height: 41px;
       span {
         ${fonts.body9}
       }

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-participate/LaunchpadParticipate.tsx
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-participate/LaunchpadParticipate.tsx
@@ -197,7 +197,7 @@ const LaunchpadParticipate: React.FC<LaunchpadParticipateProps> = ({
               )}
             </div>
           )}
-          {isLoading && <div css={pulseSkeletonStyle({ w: 103, h: 20 })} />}
+          {isLoading && <div css={pulseSkeletonStyle({ w: 103, h: 17 })} />}
         </div>
         <div className="participate-info">
           <div className="participate-info-key">
@@ -214,7 +214,7 @@ const LaunchpadParticipate: React.FC<LaunchpadParticipateProps> = ({
           {!isLoading && (
             <div className="participate-info-value">{claimableTimeFormat}</div>
           )}
-          {isLoading && <div css={pulseSkeletonStyle({ w: 103, h: 20 })} />}
+          {isLoading && <div css={pulseSkeletonStyle({ w: 103, h: 17 })} />}
         </div>
         <div className="participate-info">
           <div className="participate-info-key">
@@ -235,7 +235,7 @@ const LaunchpadParticipate: React.FC<LaunchpadParticipateProps> = ({
                 : "-"}
             </div>
           )}
-          {isLoading && <div css={pulseSkeletonStyle({ w: 103, h: 20 })} />}
+          {isLoading && <div css={pulseSkeletonStyle({ w: 103, h: 17 })} />}
         </div>
         <div className="participate-info">
           <div className="participate-info-key">Deposit Amount</div>
@@ -254,7 +254,7 @@ const LaunchpadParticipate: React.FC<LaunchpadParticipateProps> = ({
                 : "-"}
             </div>
           )}
-          {isLoading && <div css={pulseSkeletonStyle({ w: 103, h: 20 })} />}
+          {isLoading && <div css={pulseSkeletonStyle({ w: 103, h: 24 })} />}
         </div>
       </div>
 

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-pool-list/LaunchpadPoolList.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-pool-list/LaunchpadPoolList.styles.ts
@@ -1,11 +1,13 @@
 import styled from "@emotion/styled";
+import { media } from "@styles/media";
 import mixins from "@styles/mixins";
 
 export const LaunchpadPoolListWrapper = styled.div`
   ${mixins.flexbox("row", "center", "cetner")}
   width: 100%;
   gap: 16px;
-  .card {
-    width: 100%;
+  ${media.tablet} {
+    gap: 12px;
+    overflow-x: auto;
   }
 `;

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-pool-list/launchpad-pool-list-card/LaunchpadPoolListCard.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-pool-list/launchpad-pool-list-card/LaunchpadPoolListCard.styles.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { media } from "@styles/media";
 import mixins from "@styles/mixins";
 
 export const CardWrapper = styled.div`
@@ -9,6 +10,9 @@ export const CardWrapper = styled.div`
   border-radius: 10px;
   border: 1px solid ${({ theme }) => theme.color.border02};
   padding: 16px;
+  ${media.tablet} {
+    min-width: 260px;
+  }
   &.ongoing {
     cursor: pointer;
     &:hover {
@@ -38,6 +42,7 @@ export const CardWrapper = styled.div`
       color: ${({ theme }) => theme.color.text02};
       font-size: 22px;
       font-weight: 500;
+      white-space: nowrap;
     }
     .chip {
       color: ${({ theme }) =>
@@ -66,6 +71,9 @@ export const CardWrapper = styled.div`
     font-size: 14px;
     font-weight: 500;
     line-height: 18.2px;
+    ${media.tablet} {
+      font-size: clamp(0.8125rem, 0.7128rem + 0.1351vw, 0.875rem);
+    }
   }
 
   .data {
@@ -74,6 +82,9 @@ export const CardWrapper = styled.div`
     width: 100%;
     font-size: 16px;
     font-weight: 500;
+    ${media.tablet} {
+      font-size: clamp(0.875rem, 0.6757rem + 0.2703vw, 1rem);
+    }
     .key {
       color: ${({ theme }) => theme.color.text04};
     }

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-pool-list/launchpad-pool-list-card/LaunchpadPoolListCard.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-pool-list/launchpad-pool-list-card/LaunchpadPoolListCard.styles.ts
@@ -80,7 +80,7 @@ export const CardWrapper = styled.div`
     ${mixins.flexbox("column", "flex-start", "center")};
     gap: 8px;
     width: 100%;
-    font-size: 16px;
+    font-size: clamp(0.875rem, 0.6757rem + 0.2703vw, 1rem);
     font-weight: 500;
     ${media.tablet} {
       font-size: clamp(0.875rem, 0.6757rem + 0.2703vw, 1rem);
@@ -89,8 +89,9 @@ export const CardWrapper = styled.div`
       color: ${({ theme }) => theme.color.text04};
     }
     .value {
-      ${mixins.flexbox("row", "center", "center")};
+      ${mixins.flexbox("row", "center", "flex-start")};
       gap: 4px;
+      width: 100%;
       color: ${({ theme }) => theme.color.text03};
       &.ended {
         color: ${({ theme }) =>

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-pool-list/launchpad-pool-list-card/LaunchpadPoolListCard.tsx
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-pool-list/launchpad-pool-list-card/LaunchpadPoolListCard.tsx
@@ -69,7 +69,6 @@ const LaunchpadPoolListCard: React.FC<LaunchpadPoolListCardProps> = ({
           {data.status === "ENDED" && <div className="chip">Ended</div>}
         </div>
         {isActiveCard && isShowConditionTooltip && <DepositConditionsTooltip />}
-        <DepositConditionsTooltip />
       </div>
 
       <div className="card-description">

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-pool-list/launchpad-pool-list-card/LaunchpadPoolListCard.tsx
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-pool-list/launchpad-pool-list-card/LaunchpadPoolListCard.tsx
@@ -69,6 +69,7 @@ const LaunchpadPoolListCard: React.FC<LaunchpadPoolListCardProps> = ({
           {data.status === "ENDED" && <div className="chip">Ended</div>}
         </div>
         {isActiveCard && isShowConditionTooltip && <DepositConditionsTooltip />}
+        <DepositConditionsTooltip />
       </div>
 
       <div className="card-description">

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-pool-list/launchpad-pool-list-card/LaunchpadPoolListSkeletonCard.tsx
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-pool-list/launchpad-pool-list-card/LaunchpadPoolListSkeletonCard.tsx
@@ -32,19 +32,19 @@ export const LaunchpadPoolListSkeletonCard = ({ idx }: { idx: number }) => {
 
       <div className="data">
         <div className="key">Participants</div>
-        <div css={pulseSkeletonStyle({ w: 103, h: 20 })} />
+        <div css={pulseSkeletonStyle({ w: 103, h: 18 })} />
       </div>
       <div className="data">
         <div className="key">APR</div>
-        <div css={pulseSkeletonStyle({ w: 103, h: 20 })} />
+        <div css={pulseSkeletonStyle({ w: 103, h: 18 })} />
       </div>
       <div className="data">
         <div className="key">Total Deposits</div>
-        <div css={pulseSkeletonStyle({ w: 103, h: 20 })} />
+        <div css={pulseSkeletonStyle({ w: 103, h: 24 })} />
       </div>
       <div className="data">
         <div className="key">Token Distributed</div>
-        <div css={pulseSkeletonStyle({ w: 103, h: 20 })} />
+        <div css={pulseSkeletonStyle({ w: 103, h: 24 })} />
       </div>
     </CardWrapper>
   );

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-project-summary/LaunchpadProjectSummary.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-project-summary/LaunchpadProjectSummary.styles.ts
@@ -1,8 +1,18 @@
 import styled from "@emotion/styled";
+import { media } from "@styles/media";
 import mixins from "@styles/mixins";
 
 export const LaunchpadProjectSummaryWrapper = styled.div`
-  ${mixins.flexbox("row", "center", "center")}
+  ${mixins.flexbox("row", "center", "center")};
+  width: 100%;
+  ${media.tablet} {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0;
+  }
+  ${media.mobile} {
+    ${mixins.flexbox("column", "center", "center")}
+  }
   .card {
     ${mixins.flexbox("column", "flex-start", "center")}
     gap: 16px;
@@ -24,8 +34,40 @@ export const LaunchpadProjectSummaryWrapper = styled.div`
       font-size: 18px;
       font-weight: 400;
     }
+    ${media.tablet} {
+      &:nth-of-type(1),
+      &:nth-of-type(2) {
+        border-bottom: 1px solid ${({ theme }) => theme.color.border02};
+      }
+      &:nth-of-type(1),
+      &:nth-of-type(3) {
+        border-right: 1px solid ${({ theme }) => theme.color.border02};
+      }
+    }
+    ${media.mobile} {
+      ${media.mobile} {
+        &:nth-of-type(1),
+        &:nth-of-type(2),
+        &:nth-of-type(3),
+        &:nth-of-type(4) {
+          border-right: none;
+          border-bottom: none;
+        }
+
+        &:not(:last-child) {
+          border-bottom: 1px solid ${({ theme }) => theme.color.border02};
+      }
+    }
   }
   .border {
     border-right: 1px solid ${({ theme }) => theme.color.border02};
+    ${media.tablet} {
+      border-right: none;
+      border-bottom: none;
+    }
+    ${media.mobile} {
+      border-right: none;
+      border-bottom: none;
+    }
   }
 `;

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-project-summary/LaunchpadProjectSummary.styles.ts
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-project-summary/LaunchpadProjectSummary.styles.ts
@@ -24,6 +24,9 @@ export const LaunchpadProjectSummaryWrapper = styled.div`
       color: ${({ theme }) => theme.color.text04};
       font-size: 14px;
       font-weight: 400;
+      ${media.mobile} {
+        font-size: 13px;
+      }
       * {
         fill: ${({ theme }) =>
           theme.themeKey === "dark" ? "#596782" : "#90A2C0"};
@@ -33,6 +36,9 @@ export const LaunchpadProjectSummaryWrapper = styled.div`
       color: ${({ theme }) => theme.color.text02};
       font-size: 18px;
       font-weight: 400;
+      ${media.mobile} {
+        font-size: 16px;
+      }
     }
     ${media.tablet} {
       &:nth-of-type(1),
@@ -56,18 +62,19 @@ export const LaunchpadProjectSummaryWrapper = styled.div`
 
         &:not(:last-child) {
           border-bottom: 1px solid ${({ theme }) => theme.color.border02};
+        }
       }
     }
-  }
-  .border {
-    border-right: 1px solid ${({ theme }) => theme.color.border02};
-    ${media.tablet} {
-      border-right: none;
-      border-bottom: none;
-    }
-    ${media.mobile} {
-      border-right: none;
-      border-bottom: none;
+    .border {
+      border-right: 1px solid ${({ theme }) => theme.color.border02};
+      ${media.tablet} {
+        border-right: none;
+        border-bottom: none;
+      }
+      ${media.mobile} {
+        border-right: none;
+        border-bottom: none;
+      }
     }
   }
 `;

--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-project-summary/LaunchpadProjectSummary.tsx
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-project-summary/LaunchpadProjectSummary.tsx
@@ -33,7 +33,7 @@ const LaunchpadProjectSummary: React.FC<LaunchpadProjectSummaryProps> = ({
             }
           />
         </div>
-        {isLoading && <div css={pulseSkeletonStyle({ w: 160, h: 20 })} />}
+        {isLoading && <div css={pulseSkeletonStyle({ w: 160, h: 22 })} />}
         {!isLoading && (
           <div className="value">
             {data.totalAllocation
@@ -54,7 +54,7 @@ const LaunchpadProjectSummary: React.FC<LaunchpadProjectSummaryProps> = ({
             }
           />
         </div>
-        {isLoading && <div css={pulseSkeletonStyle({ w: 160, h: 20 })} />}
+        {isLoading && <div css={pulseSkeletonStyle({ w: 160, h: 22 })} />}
         {!isLoading && (
           <div className="value">{data.totalParticipants || "-"}</div>
         )}
@@ -71,7 +71,7 @@ const LaunchpadProjectSummary: React.FC<LaunchpadProjectSummaryProps> = ({
             }
           />
         </div>
-        {isLoading && <div css={pulseSkeletonStyle({ w: 160, h: 20 })} />}
+        {isLoading && <div css={pulseSkeletonStyle({ w: 160, h: 22 })} />}
         {!isLoading && (
           <div className="value">
             {data.totalDeposited
@@ -95,7 +95,7 @@ const LaunchpadProjectSummary: React.FC<LaunchpadProjectSummaryProps> = ({
             }
           />
         </div>
-        {isLoading && <div css={pulseSkeletonStyle({ w: 160, h: 20 })} />}
+        {isLoading && <div css={pulseSkeletonStyle({ w: 160, h: 22 })} />}
         {!isLoading && (
           <div className="value">
             {data.totalDistributed


### PR DESCRIPTION
- [GSW-1725](https://onbloc.atlassian.net/browse/GSW-1725): Apply a responsive design to the Launchpad details page.
- [GSW-1745](https://onbloc.atlassian.net/browse/GSW-1745): Add UI when Launchpad doesn't have active project data
- Skeleton UI improvements

[GSW-1725]: https://onbloc.atlassian.net/browse/GSW-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GSW-1745]: https://onbloc.atlassian.net/browse/GSW-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ