### PR TITLE
fix: change the gnoscan link in the UI update snackbar

### DIFF
--- a/packages/web/src/hooks/common/use-transaction-event-store.ts
+++ b/packages/web/src/hooks/common/use-transaction-event-store.ts
@@ -85,7 +85,7 @@ export const useTransactionEventStore = () => {
         if (visibleEmitResult && event.status === "SUCCESS") {
           wait<boolean>(async () => true, TX_RESULT_SNACKBAR_TIMEOUT).then(
             () => {
-              enqueue(undefined, updatingSnackbarConfig);
+              enqueue({ txHash: message.txHash }, updatingSnackbarConfig);
 
               if (alreadyEmitted) {
                 change(updatingSnackbarConfig.id, "updating-done");


### PR DESCRIPTION
# Descriptions

After UI update, 
the Gnoscan link in the snack bar now links to the transaction detail page instead of the transaction list. 