### PR TITLE
fix: fix current price area in graph tooltip

### DIFF
--- a/packages/web/src/components/common/pool-graph/pool-graph-tooltip/PoolGraphTooltip.styles.ts
+++ b/packages/web/src/components/common/pool-graph/pool-graph-tooltip/PoolGraphTooltip.styles.ts
@@ -24,6 +24,11 @@ export const PoolGraphTooltipContainer = styled.div`
         flex-direction: row;
         align-items: center;
 
+        &.price {
+          width: 100%;
+          justify-content: flex-end;
+        }
+
         &.price-range {
           justify-content: flex-end;
         }

--- a/packages/web/src/components/common/pool-graph/pool-graph-tooltip/PoolGraphTooltip.tsx
+++ b/packages/web/src/components/common/pool-graph/pool-graph-tooltip/PoolGraphTooltip.tsx
@@ -113,12 +113,7 @@ const PoolGraphTooltip: React.FC<React.PropsWithRef<PoolGraphTooltipProps>> = ({
               {tooltipInfo.tokenA.symbol} {t("common:price")}
             </span>
           </span>
-          <span
-            className={makeClassNameWithSmallFont(
-              "token-amount-value price-range",
-              displayTooltipInfo.tokenAPriceRange,
-            )}
-          >
+          <span className={"token-amount-value price"}>
             {displayTooltipInfo.tokenAPrice}
           </span>
         </div>
@@ -136,12 +131,7 @@ const PoolGraphTooltip: React.FC<React.PropsWithRef<PoolGraphTooltipProps>> = ({
               {tooltipInfo.tokenB.symbol} {t("common:price")}
             </span>
           </span>
-          <span
-            className={makeClassNameWithSmallFont(
-              "token-amount-value price-range",
-              displayTooltipInfo.tokenBPriceRange,
-            )}
-          >
+          <span className={"token-amount-value price"}>
             {displayTooltipInfo.tokenBPrice}
           </span>
         </div>

--- a/packages/web/src/components/common/pool-graph/pool-graph-tooltip/PoolGraphTooltip.tsx
+++ b/packages/web/src/components/common/pool-graph/pool-graph-tooltip/PoolGraphTooltip.tsx
@@ -113,8 +113,13 @@ const PoolGraphTooltip: React.FC<React.PropsWithRef<PoolGraphTooltipProps>> = ({
               {tooltipInfo.tokenA.symbol} {t("common:price")}
             </span>
           </span>
-          <span className={makeClassNameWithSmallFont("token-amount-value price-range", displayTooltipInfo.tokenAPriceRange)}>
-            {displayTooltipInfo.tokenAPriceRange}
+          <span
+            className={makeClassNameWithSmallFont(
+              "token-amount-value price-range",
+              displayTooltipInfo.tokenAPriceRange,
+            )}
+          >
+            {displayTooltipInfo.tokenAPrice}
           </span>
         </div>
 
@@ -131,8 +136,13 @@ const PoolGraphTooltip: React.FC<React.PropsWithRef<PoolGraphTooltipProps>> = ({
               {tooltipInfo.tokenB.symbol} {t("common:price")}
             </span>
           </span>
-          <span className={makeClassNameWithSmallFont("token-amount-value price-range", displayTooltipInfo.tokenBPriceRange)}>
-            {displayTooltipInfo.tokenBPriceRange}
+          <span
+            className={makeClassNameWithSmallFont(
+              "token-amount-value price-range",
+              displayTooltipInfo.tokenBPriceRange,
+            )}
+          >
+            {displayTooltipInfo.tokenBPrice}
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Descriptions

Modify the value in the current price area in the graph tooltip.

The current price area should show the current price of the pool.