### PR TITLE
Fix [GSW-1960] Token Price NaN

### DIFF
--- a/packages/web/src/containers/home-swap-container/HomeSwapContainer.tsx
+++ b/packages/web/src/containers/home-swap-container/HomeSwapContainer.tsx
@@ -48,14 +48,20 @@ const HomeSwapContainer: React.FC = () => {
     if (!Number(tokenAAmount) || !tokenA || !tokenPrices[checkGnotPath(tokenA.priceID)]) {
       return null;
     }
-    return BigNumber(tokenAAmount).multipliedBy(tokenPrices[checkGnotPath(tokenA.priceID)].usd).toNumber();
+    const calculateValue = BigNumber(tokenAAmount)
+      .multipliedBy(tokenPrices[checkGnotPath(tokenA.priceID)].usd)
+      .toNumber();
+    return isNaN(calculateValue) ? null : calculateValue;
   }, [tokenA, tokenAAmount, tokenPrices]);
 
   const tokenBUSD = useMemo(() => {
     if (!Number(tokenBAmount) || !tokenB || !tokenPrices[checkGnotPath(tokenB.priceID)]) {
       return null;
     }
-    return BigNumber(tokenBAmount).multipliedBy(tokenPrices[checkGnotPath(tokenB.priceID)].usd).toNumber();
+    const calculateValue = BigNumber(tokenBAmount)
+      .multipliedBy(tokenPrices[checkGnotPath(tokenB.priceID)].usd)
+      .toNumber();
+    return isNaN(calculateValue) ? null : calculateValue;
   }, [tokenB, tokenBAmount, tokenPrices]);
 
   const swapTokenInfo: SwapTokenInfo = useMemo(() => {


### PR DESCRIPTION
### Purpose
Fixes an issue where an invalid result (NaN) is displayed directly in the UI when calculating the USD value of a token on the HomeSwap page.

### Description
- 'NaN' was exposed directly in the UI when calculating the USD value of a token resulted in an invalid result
- Technical error messages that break user experience
- Modify logic to return null if the result of a calculation is invalid (NaN)
