### PR TITLE
fix: map a claimable reward token to gnot

### DIFF
--- a/packages/web/src/views/governance/components/my-delegation/MyDelegation.tsx
+++ b/packages/web/src/views/governance/components/my-delegation/MyDelegation.tsx
@@ -7,9 +7,9 @@ import Button, { ButtonHierarchy } from "@components/common/button/Button";
 import IconSwap from "@components/common/icons/IconSwap";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import Tooltip from "@components/common/tooltip/Tooltip";
+import { useTokenData } from "@hooks/token/use-token-data";
 import { DelegateeInfo, MyDelegationInfo } from "@repositories/governance";
 import { formatOtherPrice } from "@utils/new-number-utils";
-import { useTokenData } from "@hooks/token/use-token-data";
 import { toNumberFormat } from "@utils/number-utils";
 
 import InfoBox from "../info-box/InfoBox";
@@ -18,6 +18,7 @@ import MyDelegationDelegateModal from "./my-delegation-modals/MyDelegationDelega
 import MyDelegationUndelegateModal from "./my-delegation-modals/MyDelegationUndelegateModal";
 
 import IconLinkOff from "@components/common/icons/IconLinkOff";
+import { useGnotToGnot } from "@hooks/token/use-gnot-wugnot";
 import {
   MyDelegationRewardTooltipContent,
   MyDelegationTooltipContent,
@@ -54,6 +55,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
   collectReward,
 }) => {
   const { t } = useTranslation();
+  const { getGnotPath } = useGnotToGnot();
   const [isOpenDelegateModal, setIsOpenDelegateModal] = useState(false);
   const [isOpenUndelegateModal, setIsOpenUndelegateModal] = useState(false);
   const { getTokenUSDPrice, tokens } = useTokenData();
@@ -98,14 +100,17 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
       .map(reward => {
         const usdValue = getTokenUSDPrice(reward.tokenPath, reward.amount) || 0;
         const tokenInfo = tokens.find(token => token.path === reward.tokenPath);
+        const unwrappedTokenInfo = { ...tokenInfo, ...getGnotPath(tokenInfo) };
+
         return {
           ...reward,
+          tokenPath: unwrappedTokenInfo.path,
           usdValue,
-          tokenInfo,
+          tokenInfo: unwrappedTokenInfo,
         };
       })
       .sort((a, b) => b.usdValue - a.usdValue);
-  }, [myDelegationInfo.claimableRewards, getTokenUSDPrice, tokens]);
+  }, [myDelegationInfo.claimableRewards, getTokenUSDPrice, tokens, getGnotPath]);
   /**
    * A delimiter showing voting weight information or undelegation information.
    */


### PR DESCRIPTION
## Descriptions

Mapping in the interface to preserve the look of the existing reward tooltip

- The actual contractual token is a wrapped GNOT (`gno.land/r/demo/wugnot`), 
Implementations of existing interfaces and APIs are not converted to GNOT separately and passed in the reward token list. 

- When claiming, whether to receive `GNOT` or `WUGNOT` is only operated by the flag of whether to wrap or unwrap in the contract method, so if the API converts it, it will be arbitrarily changed, so modify the interface according to the current implementation.