### PR TITLE
Fix [GSW-1966] Correct transaction message for wugnot unwrap

### DIFF
--- a/packages/web/src/repositories/swap/swap-router.message.ts
+++ b/packages/web/src/repositories/swap/swap-router.message.ts
@@ -17,7 +17,7 @@ import { makeRawTokenAmount } from "@utils/token-utils";
 enum TransactionMessageFunctionType {
   SwapRoute = "SwapRoute",
   Deposit = "Deposit",
-  Unwrap = "Unwrap",
+  Unwrap = "Withdraw",
 }
 
 export function makeSwapRouteMessageWithApproves(


### PR DESCRIPTION
### Purpose
Fix the transaction message field so that the WUGNOT to GNOT unwrap feature works properly.

### Description
- Modify the FUNC field in a transaction message
  - As-is: `func: 'Unwrap'`
  - To-be: `func: 'Withdraw'`