### PR TITLE
fix: [GSW-1965] Add same token exception handling for swap route

### DIFF
--- a/packages/web/src/hooks/swap/use-swap.tsx
+++ b/packages/web/src/hooks/swap/use-swap.tsx
@@ -50,7 +50,7 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
       tokenAmount: direction === "EXACT_IN" ? swapAmount : swapAmount ? swapAmount * exactOutPadding : swapAmount,
     },
     {
-      enabled: !!swapAmount && swapAmount > 0 && !!tokenA && !!tokenA.path && !!tokenB && !!tokenB.path,
+      enabled: !!swapAmount && swapAmount > 0 && !!tokenA && !!tokenA.path && !!tokenB && !!tokenB.path && !isSameToken,
     },
   );
 


### PR DESCRIPTION
### Purpose
Resolves runtime errors and unnecessary API calls when swapping the same token (GNOT ↔ WUGNOT) that occurred after the Swap Route API change.

### Description
- Added error return exception handling for same token swaps to the server-side Swap Route API
- When attempting to swap tokens with the same wrappedPath, such as GNOT ↔ WUGNOT:
  - Unnecessary API calls occurred
  - Runtime error due to server error response
  - Normal wrap/unwrap functionality not available