### PR TITLE
Fix [GSW-1974] Update Gnoscan Support offcial URL

### DIFF
--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -28,6 +28,7 @@ NEXT_PUBLIC_PACKAGE_LAUNCHPAD_PATH="gno.land/r/gnoswap/v2/launchpad"
 
 # Webpage Config
 NEXT_PUBLIC_BLOCKED_PAGES="leaderboard, governance"
+NEXT_PUBLIC_GNOSCAN_OFFICIAL_CHAIN_IDS="portal-loop,test5"
 
 NEXT_PUBLIC_UMAMI_SCRIPT_URL=""
 NEXT_PUBLIC_UMAMI_WEBSITE_ID=""

--- a/packages/web/src/constants/environment.constant.ts
+++ b/packages/web/src/constants/environment.constant.ts
@@ -44,5 +44,6 @@ export const PACKAGE_LAUNCHPAD_ADDRESS = getAddressByPackagePath(PACKAGE_LAUNCHP
 
 // Webpage Config
 export const BLOCKED_PAGES = process.env.NEXT_PUBLIC_BLOCKED_PAGES?.split(",") || [];
+export const GNOSCAN_OFFICIAL_CHAIN_IDS = process.env.NEXT_PUBLIC_GNOSCAN_OFFICIAL_CHAIN_IDS?.split(",") || [];
 export const UMAMI_SCRIPT_URL = process.env.NEXT_PUBLIC_UMAMI_SCRIPT_URL;
 export const UMAMI_WEBSITE_ID = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;

--- a/packages/web/src/hooks/common/use-gnoscan-url.tsx
+++ b/packages/web/src/hooks/common/use-gnoscan-url.tsx
@@ -1,5 +1,7 @@
-import { CommonState } from "@states/index";
 import { useAtomValue } from "jotai";
+
+import { CommonState } from "@states/index";
+import { GNOSCAN_OFFICIAL_CHAIN_IDS } from "@constants/environment.constant";
 
 export enum GnoscanDataType {
   Blocks = "/blocks",
@@ -19,7 +21,7 @@ export const useGnoscanUrl = () => {
     const chainId = network.chainId || "";
     const baseUrl = network.scannerUrl || "";
     let chainParams = "";
-    if (["portal-loop", "test4"].includes(chainId)) {
+    if (GNOSCAN_OFFICIAL_CHAIN_IDS.includes(chainId)) {
       chainParams = `chainId=${chainId}`;
     } else {
       chainParams = "type=custom";


### PR DESCRIPTION
### Purpose
- Update to the Official Chain URL supported by Gnoscan

### Description
- Manage the URLs supported by Gnoscan as environment variables.
  - `NEXT_PUBLIC_GNOSCAN_OFFICIAL_CHAIN_IDS`