### PR TITLE
Fix [GSW-1977] Update Launchpad Click Here Path

### DIFF
--- a/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-detail-click-here/LaunchpadDetailClickHere.tsx
+++ b/packages/web/src/views/launchpad/launchpad-detail/components/launchpad-detail-click-here/LaunchpadDetailClickHere.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
 
+import { GNS_TOKEN_PATH } from "@constants/environment.constant";
+
 import IconArrowRight from "@components/common/icons/IconArrowRight";
 import { DetailClickHereWrapper, LinkButton } from "./LaunchpadDetailClickHere.styles";
 
@@ -12,7 +14,7 @@ const LaunchpadDetailClickHere = () => {
     <DetailClickHereWrapper>
       <LinkButton>
         <span>{t("Launchpad:clickHere.text")}</span>
-        <Link href="/swap?to=gno.land/r/gnoswap/v2/gns">
+        <Link href={`/swap?to=${GNS_TOKEN_PATH}`}>
           {t("Launchpad:clickHere.button")} <IconArrowRight />
         </Link>
       </LinkButton>

--- a/packages/web/src/views/pool/pool-detail/components/my-liquidity/my-liquidity-header/MyLiquidityHeader.tsx
+++ b/packages/web/src/views/pool/pool-detail/components/my-liquidity/my-liquidity-header/MyLiquidityHeader.tsx
@@ -152,7 +152,6 @@ const MyLiquidityHeader: React.FC<MyLiquidityHeaderProps> = ({
               padding: "10px 16px",
               fontType: "p1",
             }}
-            className="full-width"
           />
         )}
         <Button
@@ -164,7 +163,7 @@ const MyLiquidityHeader: React.FC<MyLiquidityHeaderProps> = ({
             padding: "10px 16px",
             fontType: "p1",
           }}
-          className={!showClosePositionButton ? "full-width" : ""}
+          className={!showClosePositionButton || !isShowRemovePositionButton ? "full-width" : ""}
         />
       </div>
     </HeaderWrapper>


### PR DESCRIPTION
### Purpose
- Update the redirection link in the project page's "Get GNS to participate" button to ensure users are directed to the correct GNS token selection page.
- Enhance Earn > Pool buttons layout (Add, Remove)

### Description
- Modified the destination URL from `gno.land/r/gnoswap/v2/gns` to `gno.land/r/gnoswap/v1/gns`
- This change ensures that users are redirected to the page where GNS is pre-selected as Token