### PR TITLE
Fix [GSW-1983] Remove disabled for One-click staking

### DIFF
--- a/packages/web/src/views/pool/pool-add/components/one-click-staking-modal/OneClickStakingModal.tsx
+++ b/packages/web/src/views/pool/pool-add/components/one-click-staking-modal/OneClickStakingModal.tsx
@@ -60,9 +60,7 @@ const OneClickStakingModal: React.FC<Props> = ({
   }, [close]);
 
   const onClickConfirm = useCallback(() => {
-    if (!feeInfo.errorMsg) {
-      confirm();
-    }
+    confirm();
   }, [confirm, feeInfo.errorMsg]);
 
   return (

--- a/packages/web/src/views/pool/pool-add/components/one-click-staking-modal/OneClickStakingModal.tsx
+++ b/packages/web/src/views/pool/pool-add/components/one-click-staking-modal/OneClickStakingModal.tsx
@@ -91,7 +91,6 @@ const OneClickStakingModal: React.FC<Props> = ({
               text={t("AddPosition:confirmAddModal.title_oneClick", {
                 context: "oneClick",
               })}
-              disabled={!!feeInfo.errorMsg}
               style={{
                 hierarchy: ButtonHierarchy.Primary,
                 fullWidth: true,


### PR DESCRIPTION
### Purpose
To fix the incorrect button disable behavior in One-Click-staking functionality that was sharing the same validation logic with Pool-Add feature.

### Description
The button disable logic was incorrectly shared between Pool-Add and One-Click-staking features, causing unintended behavior. This PR addresses the following issues:
- When GNS is selected as either Token A or B
- Button becomes disabled when Creation Fee(100) + user input exceeds user's GNS balance
- This validation was unnecessarily applied to One-Click-staking