### PR TITLE
[GSW-2030] Main page renewal (Animation)

### DIFF
--- a/packages/web/src/components/common/select-pair-button/SelectPairButton.styles.ts
+++ b/packages/web/src/components/common/select-pair-button/SelectPairButton.styles.ts
@@ -17,10 +17,13 @@ export const wrapper = (hasToken: boolean, disabled?: boolean, isHiddenArrow?: b
         transition: 0.2s;
         &:hover { background-color: ${theme.color.backgroundGradient}; }
       `};
-    > div {
+    > .token-info {
       ${mixins.flexbox("row", "center", "center")}
       gap: 8px;
       ${isHiddenArrow && "padding-right: 6px;"}
+      &.isChanging {
+        animation: fadeInOut 0.5s ease-in-out;
+      }
     }
     span {
       ${fonts.body9};
@@ -43,5 +46,13 @@ export const wrapper = (hasToken: boolean, disabled?: boolean, isHiddenArrow?: b
     }
     .token-label-select {
       white-space: nowrap;
+    }
+    @keyframes fadeInOut {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
     }
   `;

--- a/packages/web/src/components/common/select-pair-button/SelectPairButton.tsx
+++ b/packages/web/src/components/common/select-pair-button/SelectPairButton.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+import { cx } from "@emotion/css";
 import IconStrokeArrowDown from "@components/common/icons/IconStrokeArrowDown";
 import { wrapper } from "./SelectPairButton.styles";
 import { useSelectTokenModal } from "@hooks/token/ui/use-select-token-modal";
@@ -14,6 +15,7 @@ interface SelectPairButtonProps {
   callback?: (value: boolean) => void;
   isHiddenArrow?: boolean;
   className?: string;
+  isChanging?: boolean;
 }
 
 const SelectPairButton: React.FC<SelectPairButtonProps> = ({
@@ -24,6 +26,7 @@ const SelectPairButton: React.FC<SelectPairButtonProps> = ({
   callback,
   isHiddenArrow,
   className,
+  isChanging,
 }) => {
   const { t } = useTranslation();
   const { openModal } = useSelectTokenModal({ changeToken, callback });
@@ -40,12 +43,16 @@ const SelectPairButton: React.FC<SelectPairButtonProps> = ({
     <div
       css={wrapper(Boolean(token), disabled || hiddenModal, isHiddenArrow)}
       onClick={onClickButton}
-      className={`${className} ${token ? "selected-token" : "not-selected-token"}`}
+      className={cx(className, {
+        isChanging: Boolean(isChanging),
+        "selected-token": Boolean(token),
+        "not-selected-token": !token,
+      })}
     >
       {token ? (
-        <div>
+        <div className={cx("token-info", { isChanging: isChanging })}>
           <MissingLogo symbol={token.symbol} url={token.logoURI} className="token-logo" width={24} mobileWidth={24} />
-          <span className="token-symbol">{token.symbol}</span>
+          <span className={"token-symbol"}>{token.symbol}</span>
         </div>
       ) : (
         <span>{t("common:selectPairBtn.select")}</span>

--- a/packages/web/src/components/home/home-swap/HomeSwap.styles.ts
+++ b/packages/web/src/components/home/home-swap/HomeSwap.styles.ts
@@ -103,7 +103,6 @@ export const wrapper = (theme: Theme) => css`
       overflow: hidden;
     }
     .balance-text-disabled {
-      cursor: pointer;
       z-index: 1;
     }
 
@@ -129,9 +128,8 @@ export const wrapper = (theme: Theme) => css`
         background-color: ${theme.color.background01};
         border: 1px solid ${theme.color.border02};
         border-radius: 50%;
-        cursor: pointer;
         :hover {
-          background-color: ${theme.color.backgroundGradient};
+          /* background-color: ${theme.color.backgroundGradient}; */
         }
         .shape-icon {
           width: 16px;
@@ -148,5 +146,15 @@ export const wrapper = (theme: Theme) => css`
     ${mixins.flexbox("row", "center", "space-between")};
     width: 100%;
     padding-top: 16px;
+    .swap-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      svg {
+        width: 24px;
+        height: 24px;
+      }
+    }
   }
 `;

--- a/packages/web/src/components/home/home-swap/HomeSwap.styles.ts
+++ b/packages/web/src/components/home/home-swap/HomeSwap.styles.ts
@@ -56,6 +56,14 @@ export const wrapper = (theme: Theme) => css`
       ${mixins.flexbox("row", "center", "space-between")};
       width: 100%;
       margin-bottom: 5px;
+      .skeleton {
+        width: 100px;
+        height: 24px;
+
+        border-radius: 2px;
+        background: linear-gradient(0deg, rgba(20, 26, 41, 0.5) 0%, rgba(20, 26, 41, 0.5) 100%);
+        box-shadow: 8px 8px 20px 0px rgba(0, 0, 0, 0.2);
+      }
     }
 
     .token {
@@ -64,6 +72,11 @@ export const wrapper = (theme: Theme) => css`
         margin-right: 0;
       }
       > div {
+        border: 1px solid transparent;
+        transition: border 0.5s ease-in-out;
+        &.isChanging {
+          border: 1px solid var(--gradient-dark-border-gradient, #536cd7);
+        }
         padding: 5px 6px 5px 6px;
         height: 34px;
       }
@@ -90,10 +103,22 @@ export const wrapper = (theme: Theme) => css`
       }
     }
 
+    .skeleton-small {
+      width: 77px;
+      height: 17px;
+
+      border-radius: 2px;
+      background: linear-gradient(0deg, rgba(20, 26, 41, 0.5) 0%, rgba(20, 26, 41, 0.5) 100%);
+      box-shadow: 8px 8px 20px 0px rgba(0, 0, 0, 0.2);
+    }
+
     .price-text,
     .balance-text {
       ${fonts.p1};
       color: ${theme.color.text04};
+      &.isChanging {
+        animation: fadeInOut 0.5s ease-in-out;
+      }
     }
     .price-text {
       flex-shrink: 0;
@@ -108,7 +133,6 @@ export const wrapper = (theme: Theme) => css`
 
     .token {
       ${mixins.flexbox("row", "center", "center")}
-      width: 112px;
       height: 30px;
       font-size: 15px;
       font-weight: 500;
@@ -155,6 +179,15 @@ export const wrapper = (theme: Theme) => css`
         width: 24px;
         height: 24px;
       }
+    }
+  }
+
+  @keyframes fadeInOut {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
     }
   }
 `;

--- a/packages/web/src/components/home/home-swap/HomeSwap.tsx
+++ b/packages/web/src/components/home/home-swap/HomeSwap.tsx
@@ -1,22 +1,33 @@
 import React, { useCallback } from "react";
+import { cx } from "@emotion/css";
 import { wrapper } from "./HomeSwap.styles";
 import Button, { ButtonHierarchy } from "@components/common/button/Button";
 import SelectPairButton from "@components/common/select-pair-button/SelectPairButton";
 import IconSwapArrowDown from "@components/common/icons/IconSwapArrowDown";
 import { SwapTokenInfo } from "@models/swap/swap-token-info";
 import { useWindowSize } from "@hooks/common/use-window-size";
-import { SwapValue } from "@states/swap";
 import { useTranslation } from "next-i18next";
 import IconRightArrow from "@components/common/icons/IconRightArrow";
+import { TokenModel } from "@models/token/token-model";
 
 interface HomeSwapProps {
   swapTokenInfo: SwapTokenInfo;
   swapNow: () => void;
   connected: boolean;
-  swapValue: SwapValue;
+  tokenBTransition?: {
+    isChanging: boolean;
+    prevToken: TokenModel | null;
+  };
+  defaultTokenAAmount?: string;
 }
 
-const HomeSwap: React.FC<HomeSwapProps> = ({ swapTokenInfo, swapNow, connected, swapValue }) => {
+const HomeSwap: React.FC<HomeSwapProps> = ({
+  swapTokenInfo,
+  swapNow,
+  connected,
+  tokenBTransition,
+  defaultTokenAAmount,
+}) => {
   const { t } = useTranslation();
   const { breakpoint } = useWindowSize();
 
@@ -32,13 +43,7 @@ const HomeSwap: React.FC<HomeSwapProps> = ({ swapTokenInfo, swapNow, connected, 
       <div className="inputs">
         <div className="from">
           <div className="amount">
-            <input
-              className="amount-text"
-              value={swapValue.tokenAAmount}
-              placeholder="0"
-              autoComplete={"off"}
-              spellCheck={"false"}
-            />
+            <div className="amount-text">{defaultTokenAAmount}</div>
             <div className="token">
               <SelectPairButton token={swapTokenInfo.tokenA} hiddenModal isHiddenArrow />
             </div>
@@ -46,21 +51,31 @@ const HomeSwap: React.FC<HomeSwapProps> = ({ swapTokenInfo, swapNow, connected, 
           <div className="info">
             <span className="price-text">{swapTokenInfo.tokenAUSDStr}</span>
             <span className={`balance-text ${connected ? "balance-text-disabled" : ""}`}>
-              {`${t("Main:bal")}: ${swapTokenInfo.tokenABalance}`}
+              {swapTokenInfo.tokenA?.name}
             </span>
           </div>
         </div>
         <div className="to">
           <div className="amount">
-            <input className="amount-text" value={"0"} placeholder="0" autoComplete={"off"} spellCheck={"false"} />
+            <div className="skeleton" />
             <div className="token">
-              <SelectPairButton token={swapTokenInfo.tokenB} hiddenModal isHiddenArrow />
+              <SelectPairButton
+                token={swapTokenInfo.tokenB}
+                hiddenModal
+                isHiddenArrow
+                isChanging={tokenBTransition?.isChanging}
+              />
             </div>
           </div>
           <div className="info">
-            <span className="price-text">{swapTokenInfo.tokenBUSDStr}</span>
-            <span className={`balance-text ${connected ? "balance-text-disabled" : ""}`}>
-              {t("Main:bal")}: {swapTokenInfo.tokenBBalance}
+            <div className="skeleton-small" />
+            <span
+              className={cx("balance-text", {
+                "balance-text-disabled": connected,
+                isChanging: tokenBTransition?.isChanging,
+              })}
+            >
+              {swapTokenInfo.tokenB?.name}
             </span>
           </div>
         </div>

--- a/packages/web/src/components/home/home-swap/HomeSwap.tsx
+++ b/packages/web/src/components/home/home-swap/HomeSwap.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { wrapper } from "./HomeSwap.styles";
 import Button, { ButtonHierarchy } from "@components/common/button/Button";
 import SelectPairButton from "@components/common/select-pair-button/SelectPairButton";
@@ -7,77 +7,22 @@ import { SwapTokenInfo } from "@models/swap/swap-token-info";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { SwapValue } from "@states/swap";
 import { useTranslation } from "next-i18next";
+import IconRightArrow from "@components/common/icons/IconRightArrow";
 
 interface HomeSwapProps {
-  changeTokenAAmount: (value: string) => void;
-  changeTokenBAmount: (value: string) => void;
   swapTokenInfo: SwapTokenInfo;
   swapNow: () => void;
-  onSubmitSwapValue: () => void;
   connected: boolean;
   swapValue: SwapValue;
 }
 
-function isAmount(str: string) {
-  const regex = /^\d+(\.\d*)?$/;
-  return regex.test(str);
-}
-
-const HomeSwap: React.FC<HomeSwapProps> = ({
-  swapTokenInfo,
-  swapNow,
-  onSubmitSwapValue,
-  changeTokenAAmount,
-  connected,
-  changeTokenBAmount,
-}) => {
+const HomeSwap: React.FC<HomeSwapProps> = ({ swapTokenInfo, swapNow, connected, swapValue }) => {
   const { t } = useTranslation();
   const { breakpoint } = useWindowSize();
-  const [fromAmount, setFromAmount] = useState("");
-  const [toAmount, setToAmount] = useState("");
-
-  const onChangeFromAmount = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    if (value !== "" && !isAmount(value)) return;
-    const temp = value.replace(/^0+(?=\d)|(\.\d*)$/g, "$1");
-    setFromAmount(temp);
-    changeTokenAAmount(temp);
-  }, []);
-
-  const onChangeToAmount = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-
-    if (value !== "" && !isAmount(value)) return;
-    const temp = value.replace(/^0+(?=\d)|(\.\d*)$/g, "$1");
-    setToAmount(temp);
-    changeTokenBAmount(temp);
-  }, []);
 
   const onClickSwapNow = useCallback(() => {
     swapNow();
   }, [swapNow]);
-
-  const handleSwap = () => {
-    setFromAmount(toAmount);
-    setToAmount(fromAmount);
-    onSubmitSwapValue();
-  };
-
-  const handleAutoFillTokenA = useCallback(() => {
-    if (connected) {
-      const formatValue = parseFloat(swapTokenInfo.tokenABalance.replace(/,/g, "")).toString();
-      setFromAmount(formatValue);
-      changeTokenAAmount(formatValue);
-    }
-  }, [connected, swapTokenInfo.tokenABalance, changeTokenAAmount]);
-
-  const handleAutoFillTokenB = useCallback(() => {
-    if (connected) {
-      const formatValue = parseFloat(swapTokenInfo.tokenBBalance.replace(/,/g, "")).toString();
-      setToAmount(formatValue);
-      changeTokenBAmount(formatValue);
-    }
-  }, [swapTokenInfo.tokenBBalance, connected, setToAmount, changeTokenBAmount]);
 
   return breakpoint === "tablet" || breakpoint === "web" ? (
     <div css={wrapper}>
@@ -89,8 +34,7 @@ const HomeSwap: React.FC<HomeSwapProps> = ({
           <div className="amount">
             <input
               className="amount-text"
-              value={fromAmount}
-              onChange={onChangeFromAmount}
+              value={swapValue.tokenAAmount}
               placeholder="0"
               autoComplete={"off"}
               spellCheck={"false"}
@@ -101,34 +45,27 @@ const HomeSwap: React.FC<HomeSwapProps> = ({
           </div>
           <div className="info">
             <span className="price-text">{swapTokenInfo.tokenAUSDStr}</span>
-            <span className={`balance-text ${connected ? "balance-text-disabled" : ""}`} onClick={handleAutoFillTokenA}>
+            <span className={`balance-text ${connected ? "balance-text-disabled" : ""}`}>
               {`${t("Main:bal")}: ${swapTokenInfo.tokenABalance}`}
             </span>
           </div>
         </div>
         <div className="to">
           <div className="amount">
-            <input
-              className="amount-text"
-              value={toAmount}
-              onChange={onChangeToAmount}
-              placeholder="0"
-              autoComplete={"off"}
-              spellCheck={"false"}
-            />
+            <input className="amount-text" value={"0"} placeholder="0" autoComplete={"off"} spellCheck={"false"} />
             <div className="token">
               <SelectPairButton token={swapTokenInfo.tokenB} hiddenModal isHiddenArrow />
             </div>
           </div>
           <div className="info">
             <span className="price-text">{swapTokenInfo.tokenBUSDStr}</span>
-            <span className={`balance-text ${connected ? "balance-text-disabled" : ""}`} onClick={handleAutoFillTokenB}>
+            <span className={`balance-text ${connected ? "balance-text-disabled" : ""}`}>
               {t("Main:bal")}: {swapTokenInfo.tokenBBalance}
             </span>
           </div>
         </div>
         <div className="arrow">
-          <div className="shape" onClick={handleSwap}>
+          <div className="shape">
             <IconSwapArrowDown className="shape-icon" />
           </div>
         </div>
@@ -136,7 +73,12 @@ const HomeSwap: React.FC<HomeSwapProps> = ({
 
       <div className="footer">
         <Button
-          text={t("Main:swapNowBtn")}
+          text={
+            <div className="swap-button">
+              Go to Swap <IconRightArrow />
+            </div>
+          }
+          // text={t("Main:swapNowBtn")}
           style={{
             fullWidth: true,
             height: 50,

--- a/packages/web/src/containers/home-swap-container/HomeSwapContainer.tsx
+++ b/packages/web/src/containers/home-swap-container/HomeSwapContainer.tsx
@@ -12,19 +12,31 @@ import { SwapState } from "@states/index";
 import { checkGnotPath } from "@utils/common";
 import { GNOT_TOKEN, GNS_TOKEN } from "@common/values/token-constant";
 import { formatPrice } from "@utils/new-number-utils";
+import { useInterval } from "@hooks/common/use-interval";
 
 const DEFAULT_TOKEN_A_AMOUNT = "1000" as const;
+const TOKEN_ROTATION_INTERVAL = 2000 as const;
+
+interface TokenTransition {
+  isChanging: boolean;
+  prevToken: TokenModel | null;
+}
 
 const HomeSwapContainer: React.FC = () => {
   const router = useRouter();
-  const { tokenPrices, displayBalanceMap } = useTokenData();
+  const { tokenPrices, displayBalanceMap, tokens } = useTokenData();
   const [tokenA] = useState<TokenModel | null>(GNOT_TOKEN);
   const [tokenAAmount] = useState<string>(DEFAULT_TOKEN_A_AMOUNT);
-  const [tokenB] = useState<TokenModel | null>(GNS_TOKEN);
+  const [tokenB, setTokenB] = useState<TokenModel | null>(GNS_TOKEN);
+  const [currentTokenIndex, setCurrentTokenIndex] = React.useState(0);
+  const [tokenBTransition, setTokenBTransition] = useState<TokenTransition>({
+    isChanging: false,
+    prevToken: null,
+  });
   const [tokenBAmount] = useState<string>("");
   const { slippage } = useSlippage();
   const { connected, isSwitchNetwork } = useWallet();
-  const [swapValue, setSwapValue] = useAtom(SwapState.swap);
+  const [, setSwapValue] = useAtom(SwapState.swap);
 
   const tokenABalance = useMemo(() => {
     if (!connected || isSwitchNetwork || !tokenA) return "-";
@@ -47,14 +59,14 @@ const HomeSwapContainer: React.FC = () => {
   }, [isSwitchNetwork, connected, displayBalanceMap, tokenB]);
 
   const tokenAUSD = useMemo(() => {
-    if (!Number(tokenAAmount) || !tokenA || !tokenPrices[checkGnotPath(tokenA.priceID)]) {
+    if (!Number(DEFAULT_TOKEN_A_AMOUNT) || !tokenA || !tokenPrices[checkGnotPath(tokenA.priceID)]) {
       return null;
     }
-    const calculateValue = BigNumber(tokenAAmount)
+    const calculateValue = BigNumber(DEFAULT_TOKEN_A_AMOUNT)
       .multipliedBy(tokenPrices[checkGnotPath(tokenA.priceID)].usd)
       .toNumber();
     return isNaN(calculateValue) ? null : calculateValue;
-  }, [tokenA, tokenAAmount, tokenPrices]);
+  }, [tokenA, tokenPrices]);
 
   const tokenBUSD = useMemo(() => {
     if (!Number(tokenBAmount) || !tokenB || !tokenPrices[checkGnotPath(tokenB.priceID)]) {
@@ -65,6 +77,44 @@ const HomeSwapContainer: React.FC = () => {
       .toNumber();
     return isNaN(calculateValue) ? null : calculateValue;
   }, [tokenB, tokenBAmount, tokenPrices]);
+
+  useInterval(() => {
+    if (tokens && tokens.length > 0) {
+      const nextIndex = (currentTokenIndex + 1) % tokens.length;
+      setCurrentTokenIndex(nextIndex);
+      const nextToken = tokens[nextIndex];
+
+      if (nextToken.path !== tokenA?.path) {
+        setTokenB(nextToken);
+      } else {
+        setCurrentTokenIndex((nextIndex + 1) % tokens.length);
+        setTokenB(tokens[(nextIndex + 1) % tokens.length]);
+      }
+    }
+  }, TOKEN_ROTATION_INTERVAL);
+
+  useEffect(() => {
+    if (tokenB && tokenBTransition.prevToken && tokenBTransition.prevToken.path !== tokenB.path) {
+      setTokenBTransition(prev => ({
+        isChanging: true,
+        prevToken: prev.prevToken,
+      }));
+
+      const timer = setTimeout(() => {
+        setTokenBTransition({
+          isChanging: false,
+          prevToken: tokenB,
+        });
+      }, 500);
+
+      return () => clearTimeout(timer);
+    } else if (tokenB && !tokenBTransition.prevToken) {
+      setTokenBTransition({
+        isChanging: false,
+        prevToken: tokenB,
+      });
+    }
+  }, [tokenB]);
 
   const swapTokenInfo: SwapTokenInfo = useMemo(() => {
     return {
@@ -98,10 +148,6 @@ const HomeSwapContainer: React.FC = () => {
     const queriesString = queries.join("&");
     if (!!tokenAAmount) {
       router.push(`/swap?${queriesString}`);
-      setSwapValue(prev => ({
-        ...prev,
-        tokenAAmount: "",
-      }));
     }
   }, [router, tokenA, tokenB, tokenAAmount, tokenBAmount]);
 
@@ -110,11 +156,19 @@ const HomeSwapContainer: React.FC = () => {
       tokenA: null,
       tokenB: null,
       type: "EXACT_IN",
-      tokenAAmount: DEFAULT_TOKEN_A_AMOUNT,
+      tokenAAmount: "",
       tokenBAmount: "",
     });
   }, []);
-  return <HomeSwap swapTokenInfo={swapTokenInfo} swapNow={swapNow} swapValue={swapValue} connected={connected} />;
+  return (
+    <HomeSwap
+      swapTokenInfo={swapTokenInfo}
+      swapNow={swapNow}
+      connected={connected}
+      tokenBTransition={tokenBTransition}
+      defaultTokenAAmount={DEFAULT_TOKEN_A_AMOUNT}
+    />
+  );
 };
 
 export default HomeSwapContainer;

--- a/packages/web/src/containers/home-swap-container/HomeSwapContainer.tsx
+++ b/packages/web/src/containers/home-swap-container/HomeSwapContainer.tsx
@@ -13,13 +13,15 @@ import { checkGnotPath } from "@utils/common";
 import { GNOT_TOKEN, GNS_TOKEN } from "@common/values/token-constant";
 import { formatPrice } from "@utils/new-number-utils";
 
+const DEFAULT_TOKEN_A_AMOUNT = "1000" as const;
+
 const HomeSwapContainer: React.FC = () => {
   const router = useRouter();
   const { tokenPrices, displayBalanceMap } = useTokenData();
-  const [tokenA, setTokenA] = useState<TokenModel | null>(GNOT_TOKEN);
-  const [tokenAAmount, setTokenAAmount] = useState<string>("");
-  const [tokenB, setTokenB] = useState<TokenModel | null>(GNS_TOKEN);
-  const [tokenBAmount, setTokenBAmount] = useState<string>("");
+  const [tokenA] = useState<TokenModel | null>(GNOT_TOKEN);
+  const [tokenAAmount] = useState<string>(DEFAULT_TOKEN_A_AMOUNT);
+  const [tokenB] = useState<TokenModel | null>(GNS_TOKEN);
+  const [tokenBAmount] = useState<string>("");
   const { slippage } = useSlippage();
   const { connected, isSwitchNetwork } = useWallet();
   const [swapValue, setSwapValue] = useAtom(SwapState.swap);
@@ -92,65 +94,27 @@ const HomeSwapContainer: React.FC = () => {
       return "EXACT_IN";
     })();
 
-    const queries = [
-      `from=${tokenA?.path}`,
-      `to=${tokenB?.path}`,
-      `direction=${direction}`,
-      ...(tokenAAmount ? [`token_a_amount=${tokenAAmount}`] : []),
-      ...(tokenBAmount ? [`token_b_amount=${tokenBAmount}`] : []),
-    ];
+    const queries = [`from=${tokenA?.path}`, `to=${tokenB?.path}`, `direction=${direction}`];
     const queriesString = queries.join("&");
-    if (!!tokenAAmount || !!tokenBAmount) {
+    if (!!tokenAAmount) {
       router.push(`/swap?${queriesString}`);
+      setSwapValue(prev => ({
+        ...prev,
+        tokenAAmount: "",
+      }));
     }
   }, [router, tokenA, tokenB, tokenAAmount, tokenBAmount]);
-
-  const onSubmitSwapValue = () => {
-    setTokenA(tokenB);
-    setTokenB(tokenA);
-    setTokenAAmount(tokenBAmount);
-    setTokenBAmount(tokenAAmount);
-  };
-
-  const changeTokenAAmount = useCallback((value: string) => {
-    setSwapValue(prev => ({
-      ...prev,
-      tokenAAmount: value,
-      tokenBAmount: "",
-    }));
-    setTokenAAmount(value);
-  }, []);
-
-  const changeTokenBAmount = useCallback((value: string) => {
-    setSwapValue(prev => ({
-      ...prev,
-      tokenBAmount: value,
-      tokenAAmount: "",
-      type: "EXACT_OUT",
-    }));
-    setTokenBAmount(value);
-  }, []);
 
   useEffect(() => {
     setSwapValue({
       tokenA: null,
       tokenB: null,
       type: "EXACT_IN",
-      tokenAAmount: "",
+      tokenAAmount: DEFAULT_TOKEN_A_AMOUNT,
       tokenBAmount: "",
     });
   }, []);
-  return (
-    <HomeSwap
-      swapTokenInfo={swapTokenInfo}
-      swapNow={swapNow}
-      swapValue={swapValue}
-      onSubmitSwapValue={onSubmitSwapValue}
-      changeTokenAAmount={changeTokenAAmount}
-      connected={connected}
-      changeTokenBAmount={changeTokenBAmount}
-    />
-  );
+  return <HomeSwap swapTokenInfo={swapTokenInfo} swapNow={swapNow} swapValue={swapValue} connected={connected} />;
 };
 
 export default HomeSwapContainer;

--- a/packages/web/src/hooks/common/use-interval.tsx
+++ b/packages/web/src/hooks/common/use-interval.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+export const useInterval = (callback: () => void, delay: number) => {
+  const savedCallback = React.useRef<() => void>();
+
+  React.useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  React.useEffect(() => {
+    function tick() {
+      savedCallback.current?.();
+    }
+    if (delay !== null) {
+      const id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+};

--- a/packages/web/src/layouts/swap/components/swap-card/swap-card-content/SwapCardContent.tsx
+++ b/packages/web/src/layouts/swap/components/swap-card/swap-card-content/SwapCardContent.tsx
@@ -59,6 +59,7 @@ const SwapCardContent: React.FC<ContentProps> = ({
   resetEstimatedLiquidity,
   isRefetching,
 }) => {
+  console.log(swapTokenInfo, "swapTokenINfo in swappagestate");
   const { t } = useTranslation();
 
   const theme = useTheme();


### PR DESCRIPTION
## Description
- Improved UX by adding animations to the auto-convert token feature on the main page.

## Details
- Apply a fade in/out animation when automatically switching tokens on the main page
- Add a border animation to indicate that the token is being switched
- Added useInterval hook to control periodic token switching
- Added tokenBTransition state to manage token transition states