### PR TITLE
[GSW-2132] pool specific position display

### DIFF
--- a/packages/web/src/layouts/pool/pool-add/containers/additional-info-container/AdditionalInfoContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-add/containers/additional-info-container/AdditionalInfoContainer.tsx
@@ -98,12 +98,12 @@ const AdditionalInfoContainer: React.FC = () => {
 
   const stakedPositions = useMemo(() => {
     if (!poolPath || !account || !connected) return [];
-    return positions.filter(position => position.poolPath === poolPath).filter(position => position.staked);
+    return positions.filter(position => position.poolPath === poolPath && position.staked);
   }, [poolPath, account, connected, positions]);
 
   const unstakedPositions = useMemo(() => {
     if (!poolPath || !account || !connected) return [];
-    return positions.filter(position => position.poolPath === poolPath).filter(position => !position.staked);
+    return positions.filter(position => position.poolPath === poolPath && !position.staked);
   }, [poolPath, account, connected, positions]);
 
   const isReversed = useMemo(() => {

--- a/packages/web/src/layouts/pool/pool-add/containers/additional-info-container/AdditionalInfoContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-add/containers/additional-info-container/AdditionalInfoContainer.tsx
@@ -98,12 +98,12 @@ const AdditionalInfoContainer: React.FC = () => {
 
   const stakedPositions = useMemo(() => {
     if (!poolPath || !account || !connected) return [];
-    return positions.filter(position => position.staked);
+    return positions.filter(position => position.poolPath === poolPath).filter(position => position.staked);
   }, [poolPath, account, connected, positions]);
 
   const unstakedPositions = useMemo(() => {
     if (!poolPath || !account || !connected) return [];
-    return positions.filter(position => !position.staked);
+    return positions.filter(position => position.poolPath === poolPath).filter(position => !position.staked);
   }, [poolPath, account, connected, positions]);
 
   const isReversed = useMemo(() => {

--- a/packages/web/src/layouts/pool/pool-remove/containers/remove-liquidity-container/RemoveLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-remove/containers/remove-liquidity-container/RemoveLiquidityContainer.tsx
@@ -42,8 +42,8 @@ const RemoveLiquidityContainer: React.FC = () => {
 
   const unstakedPositions = useMemo(() => {
     if (!connected) return [];
-    return positions.filter(position => !position.staked);
-  }, [positions, connected]);
+    return positions.filter(position => position.poolPath === poolPath).filter(position => !position.staked);
+  }, [positions, connected, poolPath]);
 
   const checkedAll = useMemo(() => {
     if (unstakedPositions.length === 0) {

--- a/packages/web/src/layouts/pool/pool-remove/containers/remove-liquidity-container/RemoveLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-remove/containers/remove-liquidity-container/RemoveLiquidityContainer.tsx
@@ -37,12 +37,12 @@ const RemoveLiquidityContainer: React.FC = () => {
 
   const stakedPositions = useMemo(() => {
     if (!connected) return [];
-    return positions.filter(position => position.staked);
+    return positions.filter(position => position.poolPath === poolPath && position.staked);
   }, [positions, connected]);
 
   const unstakedPositions = useMemo(() => {
     if (!connected) return [];
-    return positions.filter(position => position.poolPath === poolPath).filter(position => !position.staked);
+    return positions.filter(position => position.poolPath === poolPath && !position.staked);
   }, [positions, connected, poolPath]);
 
   const checkedAll = useMemo(() => {

--- a/packages/web/src/layouts/pool/pool-stake/containers/stake-position-container/StakePositionContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-stake/containers/stake-position-container/StakePositionContainer.tsx
@@ -31,7 +31,7 @@ const StakePositionContainer: React.FC = () => {
   const [checkedList, setCheckedList] = useState<number[]>(positionId ? [Number(positionId)] : []);
   // For this domain only show `closed = false` && `staked = false` position
   const unstakedPositions = useMemo(
-    () => allPositionData.filter(item => item.poolPath === poolPath).filter(item => !item.staked),
+    () => allPositionData.filter(position => position.poolPath === poolPath && !position.staked),
     [allPositionData],
   );
 

--- a/packages/web/src/layouts/pool/pool-stake/containers/stake-position-container/StakePositionContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-stake/containers/stake-position-container/StakePositionContainer.tsx
@@ -30,7 +30,10 @@ const StakePositionContainer: React.FC = () => {
   });
   const [checkedList, setCheckedList] = useState<number[]>(positionId ? [Number(positionId)] : []);
   // For this domain only show `closed = false` && `staked = false` position
-  const unstakedPositions = useMemo(() => allPositionData.filter(item => !item.staked), [allPositionData]);
+  const unstakedPositions = useMemo(
+    () => allPositionData.filter(item => item.poolPath === poolPath).filter(item => !item.staked),
+    [allPositionData],
+  );
 
   const { openModal } = useStakePositionModal({
     positions: unstakedPositions,


### PR DESCRIPTION
• Show only positions available in the selected pool instead of showing all positions
• Apply consistent filtering logic across Add/Remove Position/Unstake/Stake actions
• Prevent transaction failures by limiting position visibility to relevant pool
• Update both modal views and Earn section right panel