### PR TITLE
[GSW-2135] sync-info

### DIFF
--- a/packages/web/src/react-query/common/use-emit-transaction-events.ts
+++ b/packages/web/src/react-query/common/use-emit-transaction-events.ts
@@ -21,7 +21,7 @@ export const useEmitTransactionEvents = (options?: UseQueryOptions<Event<string[
 
       const result = await statusRepository.getSyncInfo().catch(() => null);
 
-      const blockHeight = result?.syncInfo.height;
+      const blockHeight = result?.height;
       if (!blockHeight) {
         return [];
       }

--- a/packages/web/src/repositories/status/response/sync-info-response.ts
+++ b/packages/web/src/repositories/status/response/sync-info-response.ts
@@ -1,5 +1,3 @@
 export interface SyncInfoResponse {
-  syncInfo: {
-    height: number;
-  };
+  height: number;
 }

--- a/packages/web/src/repositories/status/status-repository-impl.ts
+++ b/packages/web/src/repositories/status/status-repository-impl.ts
@@ -1,8 +1,8 @@
 import { NetworkClient } from "@common/clients/network-client";
+import { CommonError } from "@common/errors";
+import { APIResponse } from "@repositories/common";
 import { SyncInfoResponse } from "./response";
 import { StatusRepository } from "./status-repository";
-import { APIResponse } from "@repositories/common";
-import { CommonError } from "@common/errors";
 
 export class StatusRepositoryImpl implements StatusRepository {
   private networkClient: NetworkClient | null;
@@ -20,7 +20,7 @@ export class StatusRepositoryImpl implements StatusRepository {
       url: "/util/sync-info",
     });
 
-    if (!data || data.error.code !== undefined) {
+    if (!data) {
       throw new CommonError("NOT_FOUND_DATA");
     }
 


### PR DESCRIPTION
## Description
Fix continuous sync-info API calls after transaction execution

The sync-info API is currently being called continuously even after transaction updates are completed. This PR implements a mechanism to stop the sync-info polling once the transaction update is confirmed.

## Details
### Current Behavior (AS-IS)
sync-info API is continuously called every 1 second after transaction execution

### New Behavior (TO-BE)
Maintains the 1-second interval polling of sync-info API after transaction execution
Stops sync-info API calls once transaction update is confirmed complete