### PR TITLE
[GSW-2156] `Hotfix` implement auto-lock handling for Adena v1.15.0

### DIFF
--- a/packages/web/src/hooks/common/use-background.tsx
+++ b/packages/web/src/hooks/common/use-background.tsx
@@ -141,7 +141,7 @@ export const useBackground = () => {
    *
    */
   useEffect(() => {
-    if (!walletClient || !account) return;
+    if (!walletClient) return;
 
     const handleWalletConnection = async () => {
       const walletType = walletClient.getWalletType();
@@ -160,7 +160,7 @@ export const useBackground = () => {
 
     handleWalletConnection();
     updateWalletEvents(walletClient);
-  }, [walletClient?.getWalletType(), String(account)]);
+  }, [walletClient]);
 
   /**
    *

--- a/packages/web/src/hooks/wallet/data/use-wallet.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.ts
@@ -132,16 +132,14 @@ export const useWallet = () => {
       }
 
       if (savedWalletType === "ADENA") {
+        connectAdenaClient();
+
         const adena = AdenaClient.createAdenaClient();
         const data = await adena?.getAccount();
         if (data?.status === "failure") {
           disconnectWallet();
           return;
         }
-      }
-
-      if (walletClient === null) {
-        connectAdenaClient();
       }
     } catch (err) {
       console.log(err);
@@ -175,6 +173,7 @@ export const useWallet = () => {
     if (loadingConnect !== "initial") {
       setLoadingConnect("loading");
     }
+
     const adena = AdenaClient.createAdenaClient();
     if (adena !== null) {
       sessionStorage.setItem(GNOSWAP_WALLET_TYPE_KEY, "ADENA");
@@ -189,8 +188,11 @@ export const useWallet = () => {
     try {
       setLoadingConnect("loading");
 
-      const adena = AdenaClient.createAdenaClient();
-      setWalletClient(adena);
+      if (walletClient === null) {
+        const adena = AdenaClient.createAdenaClient();
+        setWalletClient(adena);
+        return;
+      }
 
       const established = await accountRepository.addEstablishedSite().catch(() => null);
 

--- a/packages/web/src/utils/transaction-utils.ts
+++ b/packages/web/src/utils/transaction-utils.ts
@@ -172,6 +172,9 @@ export const withTransactionGuard = async <T>(
     return executeTransaction(updatedTransaction);
   }
 
+  // Handle locked wallet state for Adena v1.15.0+ auto-lock compatibility
+  const SITE_NAME = "Gnoswap";
+  await walletClient.addEstablishedSite(SITE_NAME);
   return executeTransaction(transaction);
 };
 


### PR DESCRIPTION
## Description
- [GSW-2156] Implement handling for Adena Wallet v1.15.0's new auto-lock security feature to prevent transaction failures.
- [GSW-2154] Fixed account not updating when switching to Wallet extension

## Changes
- Add wallet lock status detection
- Implement pre-transaction lock status check
- Switch Account

[GSW-2156]: https://onbloc.atlassian.net/browse/GSW-2156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GSW-2154]: https://onbloc.atlassian.net/browse/GSW-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ