### PR TITLE
[GSW-2161] `hotfix` Token GraphData mapping issue

### DIFF
--- a/packages/web/src/containers/token-list-container/TokenListContainer.tsx
+++ b/packages/web/src/containers/token-list-container/TokenListContainer.tsx
@@ -220,10 +220,11 @@ const TokenListContainer: React.FC = () => {
         const data1day = checkPositivePrice(transferData.pricesBefore?.latestPrice, transferData.pricesBefore?.price1d);
 
         const data7day = checkPositivePrice(transferData.pricesBefore?.latestPrice, transferData.pricesBefore?.price7d);
-        const graphStatus = checkPositivePrice(
-          transferData.pricesBefore?.latestPrice,
-          tempTokenPrice.last7d?.sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime())?.[0].price,
-        ).status;
+        const latestGraphPrice =
+          tempTokenPrice.last7d.length > 0
+            ? tempTokenPrice.last7d[tempTokenPrice.last7d.length - 1].price
+            : tempTokenPrice.pricesBefore.latestPrice;
+        const graphStatus = checkPositivePrice(transferData.pricesBefore?.latestPrice, latestGraphPrice).status;
 
         const data30D = checkPositivePrice(transferData.pricesBefore?.latestPrice, transferData.pricesBefore?.price30d);
 


### PR DESCRIPTION
## What's changed
Improve the way the token price graph data is mapped to improve data accuracy.

## Details
- Improved logic for calculating graphStatus
  - Old: used the first element after sorting
  - Changed: to use the last element of the array (latest data)
- Added latestGraphPrice variable
  - Introduced variable to clearly extract the latest price of graph data
  - Use the price of the last element only if there is data in the array
- Improve conditional handling
  - Check the length of the tempTokenPrice.last7d array to access if safely