### PR TITLE
[GSW-2163] `hotfix` fix token price validation for string values

### DIFF
--- a/packages/web/src/hooks/swap/data/use-swap-handler.tsx
+++ b/packages/web/src/hooks/swap/data/use-swap-handler.tsx
@@ -270,7 +270,8 @@ export const useSwapHandler = () => {
 
   const getValidUSDValue = (token: TokenModel) => {
     const bnValue = BigNumber(tokenPrices[checkGnotPath(token.path)]?.usd);
-    return bnValue.isNaN() || !bnValue.gt(0) ? null : bnValue.toNumber();
+    if (bnValue.isNaN() || !bnValue.gt(0)) return null;
+    return bnValue.toNumber();
   };
 
   const priceImpact = useMemo(() => {

--- a/packages/web/src/hooks/swap/data/use-swap-handler.tsx
+++ b/packages/web/src/hooks/swap/data/use-swap-handler.tsx
@@ -269,8 +269,8 @@ export const useSwapHandler = () => {
   }, [tokenB, tokenBAmount, tokenPrices]);
 
   const getValidUSDValue = (token: TokenModel) => {
-    const usdValue = tokenPrices[checkGnotPath(token.path)]?.usd;
-    return typeof usdValue === "number" && usdValue > 0 ? usdValue : null;
+    const bnValue = BigNumber(tokenPrices[checkGnotPath(token.path)]?.usd);
+    return bnValue.isNaN() || !bnValue.gt(0) ? null : bnValue.toNumber();
   };
 
   const priceImpact = useMemo(() => {

--- a/packages/web/src/hooks/swap/data/use-swap-handler.tsx
+++ b/packages/web/src/hooks/swap/data/use-swap-handler.tsx
@@ -268,6 +268,11 @@ export const useSwapHandler = () => {
     return BigNumber(tokenBAmount).multipliedBy(tokenPrices[checkGnotPath(tokenB.priceID)].usd).toNumber();
   }, [tokenB, tokenBAmount, tokenPrices]);
 
+  const getValidUSDValue = (token: TokenModel) => {
+    const usdValue = tokenPrices[checkGnotPath(token.path)]?.usd;
+    return typeof usdValue === "number" && usdValue > 0 ? usdValue : null;
+  };
+
   const priceImpact = useMemo(() => {
     if (!tokenA || !tokenB) {
       return BigNumber(0);
@@ -283,15 +288,15 @@ export const useSwapHandler = () => {
       setTokenAAmount(estimatedAmount);
     }
 
-    const hasUSDPrice =
-      !!tokenPrices[checkGnotPath(tokenA.path)]?.usd && !!tokenPrices[checkGnotPath(tokenB.path)]?.usd;
+    const tokenAUSDValue = getValidUSDValue(tokenA);
+    const tokenBUSDValue = getValidUSDValue(tokenB);
+    const hasUSDPrice = tokenAUSDValue !== null && tokenBUSDValue !== null;
 
     if (hasUSDPrice) {
       const tokenAUSDValue = tokenPrices[checkGnotPath(tokenA.path)]?.usd || 0;
       const tokenBUSDValue = tokenPrices[checkGnotPath(tokenB.path)]?.usd || 0;
 
       const tokenAUSDAmount = (makeDisplayTokenAmount(tokenA, tokenAAmount) || 0) * Number(tokenAUSDValue);
-
       const tokenBUSDAmount = (makeDisplayTokenAmount(tokenB, tokenBAmount) || 0) * Number(tokenBUSDValue);
 
       const priceImpactNum =


### PR DESCRIPTION
## Description
This PR fixes a critical bug where token prices returned as string '0' from the API were incorrectly recognized as valid prices.

## Issue
The existing code used `!!tokenPrices[checkGnotPath(token.path)]?.usd` to validate prices. When the API returns a price as string '0', this evaluates to `true` with the `!!` operator since it's a non-empty string, causing the system to incorrectly treat it as a valid price.

## Solution
- Add helper function `getValidUSDValue` to properly handle price validation
- Implement type checking and convert string values to numbers
- Explicitly verify that prices are numeric and greater than zero
- Improve code readability and reusability