### PR TITLE
[GSW-2162] social wallet connect issue

### DIFF
--- a/packages/web/src/hooks/common/use-background.tsx
+++ b/packages/web/src/hooks/common/use-background.tsx
@@ -152,7 +152,8 @@ export const useBackground = () => {
 
       if (walletType === "SOCIAL_WALLET") {
         const socialLoginType = walletClient.getLoginType?.();
-        if (socialLoginType && connectingState !== "error" && connectingState !== "done") {
+        const invalidStates = ["error", "done"];
+        if (socialLoginType && !invalidStates.includes(connectingState)) {
           await connectSocialAccount(socialLoginType);
         }
       }

--- a/packages/web/src/hooks/common/use-background.tsx
+++ b/packages/web/src/hooks/common/use-background.tsx
@@ -14,7 +14,7 @@ import { useAutoDisconnect } from "./use-auto-disconnect";
 export const useBackground = () => {
   const router = useRouter();
   const { account, initSession, connectAccount: connectAdenaAccount, updateWalletEvents } = useWallet();
-  const { connect: connectSocialAccount } = useSocialWalletContext();
+  const { connect: connectSocialAccount, connectingState } = useSocialWalletContext();
   const [walletClient] = useAtom(WalletState.client);
   const [sessionId] = useAtom(CommonState.sessionId);
   const [isViewMorePositions, setIsViewMorePositions] = useAtom(EarnState.isViewMorePositions);
@@ -152,7 +152,7 @@ export const useBackground = () => {
 
       if (walletType === "SOCIAL_WALLET") {
         const socialLoginType = walletClient.getLoginType?.();
-        if (socialLoginType) {
+        if (socialLoginType && connectingState !== "error" && connectingState !== "done") {
           await connectSocialAccount(socialLoginType);
         }
       }

--- a/packages/web/src/providers/social-wallet-provider/SocialWalletProvider.tsx
+++ b/packages/web/src/providers/social-wallet-provider/SocialWalletProvider.tsx
@@ -64,7 +64,7 @@ export const SocialWalletProvider = ({ children }: { children: React.ReactNode }
         setConnectingState("loading");
       }
       const socialWallet = await SocialWalletClient.createSocialWalletClient(loginType, email);
-      if (socialWallet !== null) {
+      if (sessionStorage.getItem(GNOSWAP_WALLET_TYPE_KEY) !== "ADENA" && socialWallet !== null) {
         sessionStorage.setItem(GNOSWAP_WALLET_TYPE_KEY, "SOCIAL_WALLET");
         sessionStorage.setItem(GNOSWAP_SOCIAL_LOGIN_TYPE_KEY, loginType);
         socialWallet.initSocialWallet(loginType, email);
@@ -87,9 +87,6 @@ export const SocialWalletProvider = ({ children }: { children: React.ReactNode }
           throw new Error("Failed to create social wallet client");
         }
 
-        sessionStorage.setItem(GNOSWAP_WALLET_TYPE_KEY, "SOCIAL_WALLET");
-        sessionStorage.setItem(GNOSWAP_SOCIAL_LOGIN_TYPE_KEY, loginType);
-        setWalletClient(socialWalletClient);
         accountRepository.setWalletClient(socialWalletClient);
 
         const established = await accountRepository.addEstablishedSite().catch(() => null);
@@ -103,9 +100,14 @@ export const SocialWalletProvider = ({ children }: { children: React.ReactNode }
             throw new Error("Failed to get account");
           }
 
-          sessionStorage.setItem(ACCOUNT_SESSION_INFO_KEY, JSON.stringify(account));
+          setWalletClient(socialWalletClient);
           setWalletAccount(account);
           accountRepository.setConnectedWallet(true);
+
+          sessionStorage.setItem(GNOSWAP_WALLET_TYPE_KEY, "SOCIAL_WALLET");
+          sessionStorage.setItem(GNOSWAP_SOCIAL_LOGIN_TYPE_KEY, loginType);
+          sessionStorage.setItem(ACCOUNT_SESSION_INFO_KEY, JSON.stringify(account));
+
           setConnectingState("done");
 
           openConnectedModal();


### PR DESCRIPTION
## Description
- Web3auth Continuous Calls: When users attempt to log in via Google or X (Twitter) and then cancel the login process, Web3auth continues to be called repeatedly.
- Email Login Failure: Email login attempts are not triggering Web3auth calls at all.

## Changes
- Fixed the event handling for social login cancellation to prevent recursive Web3auth calls
- Resolved the issue with Email login not triggering Web3auth integration
- Corrected logo display logic to maintain proper authentication method visualization
- Ensured Adena login state is properly preserved when social login is canceled