### PR TITLE
[GSW-2198] Earn > Add Position data

### DIFF
--- a/packages/web/src/hooks/pool/data/use-pool-add-serach-param.ts
+++ b/packages/web/src/hooks/pool/data/use-pool-add-serach-param.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 
 import useCustomRouter from "@hooks/common/use-custom-router";
 import { sortTokenPaths } from "@utils/sort-utils";
+import { checkGnotPath } from "@utils/common";
 
 export const usePoolAddSearchParams = () => {
   const router = useCustomRouter();
@@ -16,7 +17,11 @@ export const usePoolAddSearchParams = () => {
       const poolPathSplit = poolPathParam?.split(":");
       return [poolPathSplit[0], poolPathSplit[1]];
     }
-    return [tokenAPath, tokenBPath].sort(sortTokenPaths);
+
+    const processedTokenAPath = checkGnotPath(tokenAPath);
+    const processedTokenBPath = checkGnotPath(tokenBPath);
+
+    return [processedTokenAPath, processedTokenBPath].sort(sortTokenPaths);
   }, [poolPathParam, tokenAPath, tokenBPath]);
 
   const poolPath = useMemo(() => {

--- a/packages/web/src/utils/common.ts
+++ b/packages/web/src/utils/common.ts
@@ -207,7 +207,7 @@ export function randomData() {
 }
 
 export const checkGnotPath = (path: string) => {
-  if (path === "gnot") {
+  if (path === GNOT_TOKEN.path) {
     return WRAPPED_GNOT_PATH;
   } else {
     return path;
@@ -215,7 +215,7 @@ export const checkGnotPath = (path: string) => {
 };
 
 export const isGNOTPath = (path: string) => {
-  return path === WRAPPED_GNOT_PATH || path === "gnot";
+  return path === WRAPPED_GNOT_PATH || path === GNOT_TOKEN.path;
 };
 
 export const isWrapped = (path: string) => {
@@ -224,14 +224,14 @@ export const isWrapped = (path: string) => {
 
 export const toNativePath = (path: string) => {
   if (isWrapped(path)) {
-    return "gnot";
+    return GNOT_TOKEN.path;
   } else {
     return path;
   }
 };
 
 export const isGnotToken = (path: string): boolean => {
-  return path === "gnot" || path === WRAPPED_GNOT_PATH;
+  return path === GNOT_TOKEN.path || path === WRAPPED_GNOT_PATH;
 };
 
 export const isSameToken = (tokenAPath: string, tokenBPath: string): boolean => {


### PR DESCRIPTION
## Description
This PR resolves the mismatch issue between FE and BE regarding the PoolPath data. Previously, FE was processing the path as gnot, while BE was handling it as wugnot. This caused inconsistency in the data flow.

## Details
- Updated the usePoolAddSearchParams hook to:
  - Process tokenAPath and tokenBPath using checkGnotPath.
  - Ensure the processed paths are sorted correctly.