### PR TITLE
[GSW-2218] `hotfix` Update query param from 'bins' to 'binSize' Liquidity Graph

### DIFF
--- a/packages/web/src/repositories/pool/pool-repository-impl.ts
+++ b/packages/web/src/repositories/pool/pool-repository-impl.ts
@@ -195,7 +195,7 @@ export class PoolRepositoryImpl implements PoolRepository {
     }
     return this.networkClient
       .get<{ data: PoolBinModel[] }>({
-        url: `/pools/${encodeURIComponent(poolPath)}/bins?bins=${count || 40}`,
+        url: `/pools/${encodeURIComponent(poolPath)}/bins?binSize=${count || 40}`,
       })
       .then(response => response.data.data);
   };


### PR DESCRIPTION
## Description
This PR fixes the zoom functionality in the liquidity bar graph on the Add Position page. The issue was caused by a mismatch in the API query parameter name. The endpoint was expecting 'binSize' but our code was using 'bins'.

## Details
- Updated API query parameter from 'bins' to 'binSize' in the pool bins endpoint
- Ensured proper zoom functionality with varying bin sizes (40, 80, 160, 320, 640)
- Verified that + and - buttons correctly increase and decrease bin size