### PR TITLE
[GSW-2204] Referral Address closure issue

### DIFF
--- a/packages/web/src/hooks/common/use-referral.tsx
+++ b/packages/web/src/hooks/common/use-referral.tsx
@@ -25,7 +25,7 @@ export const useReferral = () => {
   const [referralAddress, setReferralAddress] = React.useState<string>("");
 
   const urlReferralAddress = router.getReferrerParameter();
-  const [storedReferralAddress, setStoredReferralAddress] = React.useState<string>("");
+  const [storedReferralAddress, setStoredReferralAddress] = React.useState<string | null>(null);
   const apiReferrerAddress = leaderboardMyInfo?.referrerAddress || "";
 
   const generateReferralLink = React.useCallback((): string => {
@@ -51,20 +51,17 @@ export const useReferral = () => {
     }
   }, []);
 
-  const saveToSessionStorage = React.useCallback(
-    (referrerAddress: string) => {
-      if (!account?.address) return;
+  const saveToSessionStorage = (referrerAddress: string) => {
+    if (!account?.address) return;
 
-      const data: StoredReferrerInfo = {
-        referrerAddress,
-        updatedAt: Date.now(),
-      };
+    const data: StoredReferrerInfo = {
+      referrerAddress,
+      updatedAt: Date.now(),
+    };
 
-      sessionStorage.setItem(GNOSWAP_REFERRAL_CODE, JSON.stringify(data));
-      setStoredReferralAddress(referrerAddress);
-    },
-    [account?.address],
-  );
+    sessionStorage.setItem(GNOSWAP_REFERRAL_CODE, JSON.stringify(data));
+    setStoredReferralAddress(referrerAddress);
+  };
 
   /**
    * Functions to store referrer addresses in session storage
@@ -74,11 +71,13 @@ export const useReferral = () => {
       if (!account?.address) return { success: false, error: "NO_ACCOUNT" };
 
       const trimmedAddress = referrerAddress.trim();
-      if (trimmedAddress && !isValidAddress(trimmedAddress)) {
+      const isNonEmptyAddress = trimmedAddress !== "";
+
+      if (isNonEmptyAddress && !isValidAddress(trimmedAddress)) {
         return { success: false, error: "INVALID_ADDRESS" };
       }
 
-      if (trimmedAddress === account.address) {
+      if (isNonEmptyAddress && trimmedAddress === account.address) {
         return { success: false, error: "SELF_REFERRAL" };
       }
 
@@ -89,35 +88,37 @@ export const useReferral = () => {
     [account?.address, saveToSessionStorage],
   );
 
-  // Loading referrer information from session storage when mounting components
-  React.useEffect(() => {
-    if (!account?.address) return;
-
-    const storedInfo = getStoredReferrerInfo();
-    if (storedInfo?.referrerAddress) {
-      setStoredReferralAddress(storedInfo.referrerAddress);
-    }
-  }, [account?.address, getStoredReferrerInfo]);
-
   // Handling URL parameters and session storage priorities
   React.useEffect(() => {
     // Rank 1: URL parameters
-    if (urlReferralAddress && isValidAddress(urlReferralAddress)) {
+    const isUrlReferralAddressEmpty = urlReferralAddress === null || urlReferralAddress === undefined;
+    if (!isUrlReferralAddressEmpty && isValidAddress(urlReferralAddress)) {
       setReferralAddress(urlReferralAddress);
       return;
     }
 
+    const storedInfo = getStoredReferrerInfo();
+    const storedAddress = storedInfo?.referrerAddress ?? null;
+
+    setStoredReferralAddress(storedAddress);
+
     // Rank 2: Session Storage
-    if (storedReferralAddress && isValidAddress(storedReferralAddress)) {
-      setReferralAddress(storedReferralAddress);
+    const isStoredReferralAddressEmpty = storedAddress === null || storedAddress === undefined;
+    if (!isStoredReferralAddressEmpty) {
+      if (storedAddress === "" || isValidAddress(storedAddress)) {
+        setReferralAddress(storedAddress);
+        return;
+      }
     }
 
     // Rank 3: API Resopnse(by leaderboard)
-    if (apiReferrerAddress && isValidAddress(apiReferrerAddress) && apiReferrerAddress !== account?.address) {
-      setReferralAddress(apiReferrerAddress);
+    if (isUrlReferralAddressEmpty && isStoredReferralAddressEmpty) {
+      if (apiReferrerAddress && isValidAddress(apiReferrerAddress) && apiReferrerAddress !== account?.address) {
+        setReferralAddress(apiReferrerAddress);
 
-      if (account?.address) {
-        saveToSessionStorage(apiReferrerAddress);
+        if (account?.address) {
+          saveToSessionStorage(apiReferrerAddress);
+        }
       }
     }
   }, [urlReferralAddress, storedReferralAddress, apiReferrerAddress, saveToSessionStorage, account?.address]);

--- a/packages/web/src/hooks/common/use-referral.tsx
+++ b/packages/web/src/hooks/common/use-referral.tsx
@@ -96,8 +96,8 @@ export const useReferral = () => {
   // Handling URL parameters and session storage priorities
   React.useEffect(() => {
     // Rank 1: URL parameters
-    const isUrlReferralAddressEmpty = urlReferralAddress === null || urlReferralAddress === undefined;
-    if (!isUrlReferralAddressEmpty && isValidAddress(urlReferralAddress)) {
+    const hasUrlReferralAddress = urlReferralAddress != null;
+    if (hasUrlReferralAddress && isValidAddress(urlReferralAddress)) {
       setReferralAddress(urlReferralAddress);
       return;
     }
@@ -108,8 +108,8 @@ export const useReferral = () => {
     setStoredReferralAddress(storedAddress);
 
     // Rank 2: Session Storage
-    const isStoredReferralAddressEmpty = storedAddress === null || storedAddress === undefined;
-    if (!isStoredReferralAddressEmpty) {
+    const hasStoredReferralAddress = storedAddress != null;
+    if (hasStoredReferralAddress) {
       if (storedAddress === "" || isValidAddress(storedAddress)) {
         setReferralAddress(storedAddress);
         return;
@@ -117,7 +117,7 @@ export const useReferral = () => {
     }
 
     // Rank 3: API Resopnse(by leaderboard)
-    if (isUrlReferralAddressEmpty && isStoredReferralAddressEmpty) {
+    if (!hasUrlReferralAddress && !hasStoredReferralAddress) {
       if (apiReferrerAddress && isValidAddress(apiReferrerAddress) && apiReferrerAddress !== account?.address) {
         setReferralAddress(apiReferrerAddress);
 

--- a/packages/web/src/hooks/common/use-referral.tsx
+++ b/packages/web/src/hooks/common/use-referral.tsx
@@ -23,6 +23,11 @@ export const useReferral = () => {
   const { data: leaderboardMyInfo } = useGetLeaderboardByAddress(account?.address || "");
 
   const [referralAddress, setReferralAddress] = React.useState<string>("");
+  const referralAddressRef = React.useRef(referralAddress);
+
+  React.useEffect(() => {
+    referralAddressRef.current = referralAddress;
+  }, [account?.address, referralAddress]);
 
   const urlReferralAddress = router.getReferrerParameter();
   const [storedReferralAddress, setStoredReferralAddress] = React.useState<string | null>(null);
@@ -41,7 +46,7 @@ export const useReferral = () => {
    */
   const getStoredReferrerInfo = React.useCallback((): StoredReferrerInfo | null => {
     try {
-      const storedData = sessionStorage.getItem(GNOSWAP_REFERRAL_CODE);
+      const storedData = sessionStorage.getItem(`${GNOSWAP_REFERRAL_CODE}_${account?.address}`);
       if (!storedData) return null;
 
       const parsed: StoredReferrerInfo = JSON.parse(storedData);
@@ -49,7 +54,7 @@ export const useReferral = () => {
     } catch {
       return null;
     }
-  }, []);
+  }, [account?.address]);
 
   const saveToSessionStorage = (referrerAddress: string) => {
     if (!account?.address) return;
@@ -59,7 +64,7 @@ export const useReferral = () => {
       updatedAt: Date.now(),
     };
 
-    sessionStorage.setItem(GNOSWAP_REFERRAL_CODE, JSON.stringify(data));
+    sessionStorage.setItem(`${GNOSWAP_REFERRAL_CODE}_${account.address}`, JSON.stringify(data));
     setStoredReferralAddress(referrerAddress);
   };
 
@@ -128,5 +133,6 @@ export const useReferral = () => {
     storedReferralAddress,
     saveReferrerAddress,
     generateReferralLink,
+    getCurrentReferralAddress: () => referralAddressRef.current,
   };
 };

--- a/packages/web/src/hooks/common/use-referral.tsx
+++ b/packages/web/src/hooks/common/use-referral.tsx
@@ -90,7 +90,7 @@ export const useReferral = () => {
 
       return { success: true };
     },
-    [account?.address, saveToSessionStorage],
+    [account?.address],
   );
 
   // Handling URL parameters and session storage priorities

--- a/packages/web/src/hooks/governance/data/use-governance-tx.tsx
+++ b/packages/web/src/hooks/governance/data/use-governance-tx.tsx
@@ -16,7 +16,7 @@ import { BROADCAST_ERROR_VALUE } from "@common/errors/broadcast/broadcast-error"
 import { useReferral } from "@hooks/common/use-referral";
 
 export const useGovernanceTx = () => {
-  const { referralAddress } = useReferral();
+  const { getCurrentReferralAddress } = useReferral();
 
   const { t } = useTranslation();
   const { account } = useWallet();
@@ -103,12 +103,14 @@ export const useGovernanceTx = () => {
       target: toName,
     };
 
+    const currentReferralAddress = getCurrentReferralAddress();
+
     processTx(
       () =>
         governanceRepository.sendDelegate({
           to: toAddress,
           amount: unitAmount.toString(),
-          referrerAddress: referralAddress,
+          referrerAddress: currentReferralAddress,
         }),
       DexEvent.DELEGATE,
       messageData,

--- a/packages/web/src/hooks/launchpad/data/use-launchpad-handler.ts
+++ b/packages/web/src/hooks/launchpad/data/use-launchpad-handler.ts
@@ -44,7 +44,7 @@ function calculateUSDValueBy(
 }
 
 export const useLaunchpadHandler = () => {
-  const { referralAddress } = useReferral();
+  const { getCurrentReferralAddress } = useReferral();
 
   const participateAmount = useAtomValue(LaunchpadState.participateAmount);
   const depositConditions = useAtomValue(LaunchpadState.depositConditions);
@@ -112,7 +112,6 @@ export const useLaunchpadHandler = () => {
     if (!account) {
       return;
     }
-    console.log(projectPoolId, "projectPoolId");
 
     const displayAmount = Number(depositAmount).toLocaleString("en");
     const unitAmount = makeRawTokenAmount(GNS_TOKEN, depositAmount) || "0";
@@ -122,9 +121,16 @@ export const useLaunchpadHandler = () => {
       tokenASymbol: GNS_TOKEN.symbol,
     };
 
+    const currentReferralAddress = getCurrentReferralAddress();
+
     processTx(
       () =>
-        launchpadRepository.depositLaunchpadPoolBy(projectPoolId, BigInt(unitAmount), account.address, referralAddress),
+        launchpadRepository.depositLaunchpadPoolBy(
+          projectPoolId,
+          BigInt(unitAmount),
+          account.address,
+          currentReferralAddress,
+        ),
       DexEvent.LAUNCHPAD_DEPOSIT,
       messageData,
       response => {
@@ -173,19 +179,21 @@ export const useLaunchpadHandler = () => {
       tokenAAmount: usdValueStr,
     };
 
+    const currentReferralAddress = getCurrentReferralAddress();
+
     processTx(
       () => {
         if (isWithdrawable) {
           return launchpadRepository.collectRewardWithDepositByDepositId(
             participationInfo.depositId,
             account.address,
-            referralAddress,
+            currentReferralAddress,
           );
         }
         return launchpadRepository.collectRewardByDepositId(
           participationInfo.depositId,
           account.address,
-          referralAddress,
+          currentReferralAddress,
         );
       },
       DexEvent.LAUNCHPAD_COLLECT_REWARD,
@@ -254,19 +262,21 @@ export const useLaunchpadHandler = () => {
       tokenAAmount: usdValueStr,
     };
 
+    const currentReferralAddress = getCurrentReferralAddress();
+
     processTx(
       () => {
         if (isWithdrawable) {
           return launchpadRepository.collectRewardWithDepositByProjectId(
             participationInfo.projectId,
             account.address,
-            referralAddress,
+            currentReferralAddress,
           );
         }
         return launchpadRepository.collectRewardByProjectId(
           participationInfo.projectId,
           account.address,
-          referralAddress,
+          currentReferralAddress,
         );
       },
       DexEvent.LAUNCHPAD_COLLECT_REWARD,

--- a/packages/web/src/hooks/pool/data/use-pool.tsx
+++ b/packages/web/src/hooks/pool/data/use-pool.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export const usePool = ({ compareToken, tokenA, tokenB, isReverted = false }: Props) => {
-  const { referralAddress } = useReferral();
+  const { getCurrentReferralAddress } = useReferral();
 
   const { account } = useWallet();
   const { poolRepository } = useGnoswapContext();
@@ -127,6 +127,7 @@ export const usePool = ({ compareToken, tokenA, tokenB, isReverted = false }: Pr
       if (!currentTokenData) {
         return null;
       }
+      const currentReferralAddress = getCurrentReferralAddress();
       return poolRepository
         .createPool({
           tokenA: currentTokenData.tokenA,
@@ -141,14 +142,14 @@ export const usePool = ({ compareToken, tokenA, tokenB, isReverted = false }: Pr
           caller: account.address,
           withStaking,
           createPoolFee,
-          referrerAddress: referralAddress,
+          referrerAddress: currentReferralAddress,
         })
         .catch(e => {
           console.error(e);
           return null;
         });
     },
-    [account, poolRepository, tokenA, tokenB, compareToken, createPoolFee, referralAddress],
+    [account, poolRepository, tokenA, tokenB, compareToken, createPoolFee, getCurrentReferralAddress],
   );
 
   const addLiquidity = useCallback(
@@ -176,6 +177,7 @@ export const usePool = ({ compareToken, tokenA, tokenB, isReverted = false }: Pr
       if (!currentTokenData) {
         return null;
       }
+      const currentReferralAddress = getCurrentReferralAddress();
       return poolRepository
         .addLiquidity({
           tokenA: currentTokenData.tokenA,
@@ -188,14 +190,14 @@ export const usePool = ({ compareToken, tokenA, tokenB, isReverted = false }: Pr
           slippage: Number(slippage),
           caller: account.address,
           withStaking,
-          referrerAddress: referralAddress,
+          referrerAddress: currentReferralAddress,
         })
         .catch(e => {
           console.error(e);
           return null;
         });
     },
-    [tokenA, tokenB, account, getCurrentTokenPairAmount, poolRepository, referralAddress],
+    [tokenA, tokenB, account, getCurrentTokenPairAmount, poolRepository, getCurrentReferralAddress],
   );
 
   useEffect(() => {

--- a/packages/web/src/hooks/pool/data/use-reposition-handle.tsx
+++ b/packages/web/src/hooks/pool/data/use-reposition-handle.tsx
@@ -45,7 +45,7 @@ export type REPOSITION_BUTTON_TYPE = "REPOSITION" | "LOADING" | "NON_SELECTED_RA
 
 export const useRepositionHandle = () => {
   const router = useRouter();
-  const { referralAddress } = useReferral();
+  const { getCurrentReferralAddress } = useReferral();
   const poolPath = router.getPoolPath();
   const positionId = router.getPositionId();
 
@@ -443,6 +443,7 @@ export const useRepositionHandle = () => {
       : BigNumber(estimatedRepositionAmounts?.amountA || 0).minus(BigNumber(currentAmounts?.amountA || 0));
 
     const deadline = Math.floor(Date.now() / 1000) + 300; // 5분
+    const currentReferralAddress = getCurrentReferralAddress();
 
     if (estimateSwapRequest.exactType === "EXACT_IN") {
       return swapRouterRepository.sendExactInSwapRoute({
@@ -454,7 +455,7 @@ export const useRepositionHandle = () => {
         originAmount: estimatedSwapResult.originAmount,
         tokenAmountLimit: outputAmount.toNumber() * ((100 - DEFAULT_SLIPPAGE) / 100),
         deadline,
-        referrerAddress: referralAddress,
+        referrerAddress: currentReferralAddress,
       });
     } else {
       return swapRouterRepository.sendExactOutSwapRoute({
@@ -466,7 +467,7 @@ export const useRepositionHandle = () => {
         originAmount: estimatedSwapResult.originAmount,
         tokenAmountLimit: inputAmount.toNumber() * ((100 + DEFAULT_SLIPPAGE) / 100),
         deadline,
-        referrerAddress: referralAddress,
+        referrerAddress: currentReferralAddress,
       });
     }
   }, [
@@ -477,6 +478,7 @@ export const useRepositionHandle = () => {
     estimatedSwapResult,
     selectedPosition?.pool.tokenA,
     swapRouterRepository,
+    getCurrentReferralAddress,
   ]);
 
   const reposition = useCallback(

--- a/packages/web/src/hooks/swap/data/use-swap.tsx
+++ b/packages/web/src/hooks/swap/data/use-swap.tsx
@@ -22,7 +22,7 @@ interface UseSwapProps {
 }
 
 export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: UseSwapProps) => {
-  const { referralAddress } = useReferral();
+  const { getCurrentReferralAddress } = useReferral();
 
   const store = useStore();
   const { account } = useWallet();
@@ -260,6 +260,8 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
         return null;
       }
 
+      const currentReferralAddress = getCurrentReferralAddress();
+
       if (direction === "EXACT_IN") {
         return swapRouterRepository.sendExactInSwapRoute({
           inputToken: tokenA,
@@ -270,7 +272,7 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
           originAmount: estimatedSwapResult?.originAmount || 0,
           tokenAmountLimit: tokenAmountLimit,
           deadline: Math.floor(Date.now() / 1000) + 60 * 5,
-          referrerAddress: referralAddress,
+          referrerAddress: currentReferralAddress,
         });
       }
 
@@ -284,7 +286,7 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
           originAmount: estimatedSwapResult?.originAmount || 0,
           tokenAmountLimit: tokenAmountLimit,
           deadline: Math.floor(Date.now() / 1000) + 60 * 5,
-          referrerAddress: referralAddress,
+          referrerAddress: currentReferralAddress,
         });
       }
     },
@@ -301,7 +303,7 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
       tokenB,
       exactOutPadding,
       store,
-      referralAddress,
+      getCurrentReferralAddress,
     ],
   );
 

--- a/packages/web/src/layouts/pool/pool-add/containers/earn-add-liquidity-container/EarnAddLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-add/containers/earn-add-liquidity-container/EarnAddLiquidityContainer.tsx
@@ -47,7 +47,7 @@ const EarnAddLiquidityContainer: React.FC = () => {
   const { i18n } = useTranslation();
   const router = useCustomRouter();
   useRouterBack();
-  const { referralAddress } = useReferral();
+  const { getCurrentReferralAddress } = useReferral();
 
   const [swapValue, setSwapValue] = useAtom(SwapState.swap);
   const { tokenA = null, tokenB = null, type = "EXACT_IN", isReverted, isKeepToken = false } = swapValue;
@@ -649,6 +649,8 @@ const EarnAddLiquidityContainer: React.FC = () => {
       return priceRange?.type;
     })()?.toString();
 
+    const currentReferralAddress = getCurrentReferralAddress();
+
     if (swapFeeTier && router.isReady) {
       const query = {
         tokenA: tokenA?.path,
@@ -657,7 +659,7 @@ const EarnAddLiquidityContainer: React.FC = () => {
         price_range_type: computedPriceRange,
         tickLower: nextTickLower,
         tickUpper: nextTickUpper,
-        ...(referralAddress ? { referrer: referralAddress } : {}),
+        ...(currentReferralAddress ? { referrer: currentReferralAddress } : {}),
       };
       router.replace(makeRouteUrl(PAGE_PATH.EARN_ADD, query), undefined, {
         shallow: true,
@@ -669,6 +671,7 @@ const EarnAddLiquidityContainer: React.FC = () => {
     tokenB,
     selectPool.minPosition,
     selectPool.maxPosition,
+    getCurrentReferralAddress,
     priceRange?.type,
     router.query.fee_tier,
     router.isReady,

--- a/packages/web/src/layouts/pool/pool-stake/containers/stake-position-modal-container/StakePositionModalContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-stake/containers/stake-position-modal-container/StakePositionModalContainer.tsx
@@ -35,7 +35,7 @@ const StakePositionModalContainer = ({ positions, refetchPositions }: StakePosit
 
   const { positionRepository } = useGnoswapContext();
   const router = useCustomRouter();
-  const { referralAddress } = useReferral();
+  const { getCurrentReferralAddress } = useReferral();
   const clearModal = useClearModal();
   const { updateBalances, tokenPrices } = useTokenData();
   const poolPath = router.getPoolPath();
@@ -89,6 +89,7 @@ const StakePositionModalContainer = ({ positions, refetchPositions }: StakePosit
     const lpTokenIds = positions.map(position => position.id.toString());
     const tokenA = pooledTokenInfos?.[0];
     const tokenB = pooledTokenInfos?.[1];
+    const currentReferralAddress = getCurrentReferralAddress();
     broadcastLoading(
       getMessage(DexEvent.STAKE, "pending", {
         tokenASymbol: tokenA?.token?.symbol,
@@ -107,7 +108,7 @@ const StakePositionModalContainer = ({ positions, refetchPositions }: StakePosit
       .stakePositions({
         lpTokenIds,
         caller: address,
-        referrerAddress: referralAddress,
+        referrerAddress: currentReferralAddress,
       })
       .catch(() => null);
 
@@ -181,7 +182,7 @@ const StakePositionModalContainer = ({ positions, refetchPositions }: StakePosit
       }
     }
     return result;
-  }, [account?.address, positionRepository, positions, router]);
+  }, [account?.address, positionRepository, positions, router, getCurrentReferralAddress]);
 
   return <StakePositionModal positions={positions} close={clearModal} onSubmit={onSubmit} pool={pool} />;
 };


### PR DESCRIPTION
## Description
This PR resolves an issue where the latest referralAddress value was not being properly reflected in various functions due to a closure issue. The functions were capturing the initial referralAddress value when they were defined, but were not updating when this value changed.

## What's changed
- Added a referralAddressRef using useRef to the useReferral hook so that we can always keep track of the latest referralAddress value.
- Added an effect to update referralAddressRef.current whenever the referralAddress changes.
- Added a getCurrentReferralAddress method to the return value of the useReferral hook that always returns the latest referral address value.
- This ensures that even if a component captures a function early in its lifecycle, calling that function will always return the latest value.
- We've pushed this improvement across the board so that it applies wherever referralAddress is used, not just in swap functions.