### PR TITLE
[GSW-2225] Update RewardTooltip TranslateKey

### DIFF
--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/stat-tooltip-contents/DailyEarningTooltipContent.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/stat-tooltip-contents/DailyEarningTooltipContent.tsx
@@ -79,7 +79,7 @@ export const DailyEarningTooltipContent: React.FC<DailyEarningTooltipContentProp
       {internalRewards && (
         <React.Fragment>
           <div className="list">
-            <span className="title">{t("business:rewardType.internal")}</span>
+            <span className="title">{t("business:rewardType.internal_reward")}</span>
             <span className="title"></span>
           </div>
           {internalRewards.map((reward, index) => (
@@ -105,7 +105,7 @@ export const DailyEarningTooltipContent: React.FC<DailyEarningTooltipContentProp
       {externalRewards && (
         <React.Fragment>
           <div className="list">
-            <span className="title">{t("business:rewardType.external")}</span>
+            <span className="title">{t("business:rewardType.external_reward")}</span>
             <span className="title"></span>
           </div>
           {externalRewards.map((reward, index) => (


### PR DESCRIPTION
## Description
This PR fixes translation key issues in the Daily Rewards tooltip content:

## Details
- Updated `business:rewardType.internal` to `business:rewardType.internal_reward`
- Updated `business:rewardType.external` to `business:rewardType.external_reward`
- Fixed tooltip display in Pool Details page