### PR TITLE
[GSW-2227] unify token ratio formatting in Pool Details

### DIFF
--- a/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-content/PoolPairInfoContent.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-content/PoolPairInfoContent.tsx
@@ -69,16 +69,14 @@ const PoolPairInfoContent: React.FC<PoolPairInfoContentProps> = ({ pool, loading
   const depositRatioStrOfTokenA = useMemo(() => {
     if (Number.isNaN(depositRatio)) return "(0%)";
 
-    const depositStr = formatRate(depositRatio * 100, { decimals: 0 });
-
+    const depositStr = `${Math.round(depositRatio * 100)}%`;
     return `(${depositStr})`;
   }, [depositRatio]);
 
   const depositRatioStrOfTokenB = useMemo(() => {
     if (Number.isNaN(depositRatio)) return "(0%)";
 
-    const depositStr = formatRate((1 - depositRatio) * 100, { decimals: 0 });
-
+    const depositStr = `${Math.round((1 - depositRatio) * 100)}%`;
     return `(${depositStr})`;
   }, [depositRatio]);
 


### PR DESCRIPTION
## Description
This PR standardizes the token ratio formatting in Pool Details page

## Details
- Replaced `formatRate(depositRatio * 100, { decimals: 0 })` with `Math.round(depositRatio * 100)`
- Applied the same formatting logic to both tokens in the pool
