### PR TITLE
[GSW-2232] SwapRateAction type

### DIFF
--- a/packages/web/src/components/swap/confirm-swap-modal/ConfirmSwapModal.styles.ts
+++ b/packages/web/src/components/swap/confirm-swap-modal/ConfirmSwapModal.styles.ts
@@ -194,6 +194,7 @@ export const ConfirmModal = styled.div`
           width: 100%;
           gap: 4px;
           .gnos-price {
+            cursor: pointer;
             display: flex;
             ${fonts.body12};
             ${media.mobile} {

--- a/packages/web/src/components/swap/confirm-swap-modal/ConfirmSwapModal.tsx
+++ b/packages/web/src/components/swap/confirm-swap-modal/ConfirmSwapModal.tsx
@@ -4,7 +4,7 @@ import { useAtomValue } from "jotai";
 import { useTheme } from "@emotion/react";
 
 import { SwapState } from "@states/index";
-import { PriceImpactStatus } from "@hooks/swap/data/use-swap-handler";
+import { PriceImpactStatus, SwapRateAction } from "@hooks/swap/data/use-swap-handler";
 import { SwapResultInfo } from "@models/swap/swap-result-info";
 import { swapDirectionToGuaranteedType } from "@models/swap/swap-summary-info";
 import { SwapTokenInfo } from "@models/swap/swap-token-info";
@@ -35,6 +35,7 @@ interface ConfirmSwapModalProps {
   isWrapOrUnwrap: boolean;
   priceImpactStatus: PriceImpactStatus;
 
+  setSwapRateAction: (type: SwapRateAction) => void;
   swap: (swapTokenInfo: SwapTokenInfo, estimatedAmount: string | null) => void;
   close: () => void;
 }
@@ -45,6 +46,7 @@ const ConfirmSwapModal: React.FC<ConfirmSwapModalProps> = ({
   swap,
   close,
   title,
+  setSwapRateAction,
   isWrapOrUnwrap,
   priceImpactStatus,
 }) => {
@@ -59,7 +61,7 @@ const ConfirmSwapModal: React.FC<ConfirmSwapModalProps> = ({
 
     const { tokenA, tokenB, swapRate, swapRateAction } = swapSummaryInfo;
 
-    if (swapRateAction === "ATOB") {
+    if (swapRateAction === SwapRateAction.ATOB) {
       return (
         <>
           1&nbsp;{tokenA.symbol}&nbsp;=&nbsp;
@@ -77,6 +79,12 @@ const ConfirmSwapModal: React.FC<ConfirmSwapModalProps> = ({
       </>
     );
   }, [swapSummaryInfo]);
+
+  const handleSwapRateDescription = useCallback(() => {
+    setSwapRateAction(
+      swapSummaryInfo?.swapRateAction === SwapRateAction.ATOB ? SwapRateAction.BTOA : SwapRateAction.ATOB,
+    );
+  }, [swapSummaryInfo?.swapRateAction]);
 
   const priceImpactStr = useMemo(() => {
     if (!swapSummaryInfo) return;
@@ -140,7 +148,7 @@ const ConfirmSwapModal: React.FC<ConfirmSwapModalProps> = ({
 
     const { swapRateAction, swapRate } = swapSummaryInfo;
     const { tokenAUSD, tokenBUSD, tokenAAmount, tokenBAmount } = swapTokenInfo;
-    if (swapRateAction === "ATOB") {
+    if (swapRateAction === SwapRateAction.ATOB) {
       if (!tokenBUSD || tokenBUSD === 0) return "-";
       return `($${convertToKMB(floorNumber((tokenBUSD / Number(tokenBAmount)) * swapRate).toFixed(3), {
         isIgnoreKFormat: true,
@@ -231,7 +239,9 @@ const ConfirmSwapModal: React.FC<ConfirmSwapModalProps> = ({
           </div>
           <div className="swap-info">
             <div className="coin-info">
-              <span className="gnos-price">{swapRateDescription}</span>
+              <span className="gnos-price" onClick={handleSwapRateDescription}>
+                {swapRateDescription}
+              </span>
               <span className="exchange-price">{unitSwapPrice}</span>
             </div>
           </div>

--- a/packages/web/src/components/swap/swap-card-content-detail/SwapCardContentDetail.spec.tsx
+++ b/packages/web/src/components/swap/swap-card-content-detail/SwapCardContentDetail.spec.tsx
@@ -1,6 +1,8 @@
 import { render } from "@testing-library/react";
 import { Provider as JotaiProvider } from "jotai";
 
+import { SwapRateAction } from "@hooks/swap/data/use-swap-handler";
+
 import { SwapSummaryInfo } from "@models/swap/swap-summary-info";
 import { SwapTokenInfo } from "@models/swap/swap-token-info";
 import { TokenModel } from "@models/token/token-model";
@@ -59,7 +61,7 @@ const swapSummaryInfo: SwapSummaryInfo = {
   },
   gasFeeUSD: 0.1,
   protocolFee: "0.15",
-  swapRateAction: "ATOB",
+  swapRateAction: SwapRateAction.ATOB,
 };
 
 const swapTokenInfo: SwapTokenInfo = {
@@ -85,7 +87,7 @@ describe("SwapCardContentDetail Component", () => {
       swapSummaryInfo,
       swapRouteInfos: [],
       swapTokenInfo: swapTokenInfo,
-      setSwapRateAction: (type: "ATOB" | "BTOA") => {
+      setSwapRateAction: (type: SwapRateAction) => {
         console.log(type);
       },
       isLoading: false,

--- a/packages/web/src/components/swap/swap-card-content-detail/SwapCardContentDetail.stories.tsx
+++ b/packages/web/src/components/swap/swap-card-content-detail/SwapCardContentDetail.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import { SwapRateAction } from "@hooks/swap/data/use-swap-handler";
 import { SwapRouteInfo } from "@models/swap/swap-route-info";
 import { SwapSummaryInfo } from "@models/swap/swap-summary-info";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
@@ -42,7 +43,7 @@ const swapSummaryInfo: SwapSummaryInfo = {
     currency: "GNOT",
   },
   gasFeeUSD: 0.1,
-  swapRateAction: "ATOB",
+  swapRateAction: SwapRateAction.ATOB,
   swapRate1USD: 1,
   protocolFee: "0%",
 };

--- a/packages/web/src/components/swap/swap-card-content-detail/SwapCardContentDetail.tsx
+++ b/packages/web/src/components/swap/swap-card-content-detail/SwapCardContentDetail.tsx
@@ -7,7 +7,7 @@ import IconStrokeArrowDown from "@components/common/icons/IconStrokeArrowDown";
 import IconStrokeArrowUp from "@components/common/icons/IconStrokeArrowUp";
 import LoadingSpinner from "@components/common/loading-spinner/LoadingSpinner";
 import { useWindowSize } from "@hooks/common/use-window-size";
-import { PriceImpactStatus } from "@hooks/swap/data/use-swap-handler";
+import { PriceImpactStatus, SwapRateAction } from "@hooks/swap/data/use-swap-handler";
 import { SwapRouteInfo } from "@models/swap/swap-route-info";
 import { SwapSummaryInfo } from "@models/swap/swap-summary-info";
 import { SwapTokenInfo } from "@models/swap/swap-token-info";
@@ -24,7 +24,7 @@ export interface SwapCardContentDetailProps {
   swapSummaryInfo: SwapSummaryInfo;
   swapRouteInfos: SwapRouteInfo[];
   isLoading: boolean;
-  setSwapRateAction: (type: "ATOB" | "BTOA") => void;
+  setSwapRateAction: (type: SwapRateAction) => void;
   priceImpactStatus: PriceImpactStatus;
   swapTokenInfo: SwapTokenInfo;
 }
@@ -48,7 +48,7 @@ const SwapCardContentDetail: React.FC<SwapCardContentDetailProps> = ({
 
   const swapRateDescription = useMemo(() => {
     const { tokenA, tokenB, swapRate, swapRateAction } = swapSummaryInfo;
-    if (swapRateAction === "ATOB") {
+    if (swapRateAction === SwapRateAction.ATOB) {
       return (
         <>
           1 {tokenA.symbol} =&nbsp;
@@ -70,7 +70,7 @@ const SwapCardContentDetail: React.FC<SwapCardContentDetailProps> = ({
   const unitSwapPrice = useMemo(() => {
     const { swapRateAction, swapRate } = swapSummaryInfo;
     const { tokenAUSD, tokenBUSD, tokenAAmount, tokenBAmount } = swapTokenInfo;
-    if (swapRateAction === "ATOB") {
+    if (swapRateAction === SwapRateAction.ATOB) {
       if (!tokenBUSD || tokenBUSD === 0) return "-";
       return convertToKMB(floorNumber((tokenBUSD / Number(tokenBAmount)) * swapRate).toFixed(3), {
         isIgnoreKFormat: true,
@@ -96,7 +96,9 @@ const SwapCardContentDetail: React.FC<SwapCardContentDetailProps> = ({
   }, [openedDetailInfo]);
 
   const handleSwapRate = useCallback(() => {
-    setSwapRateAction(swapSummaryInfo.swapRateAction === "ATOB" ? "BTOA" : "ATOB");
+    setSwapRateAction(
+      swapSummaryInfo.swapRateAction === SwapRateAction.ATOB ? SwapRateAction.BTOA : SwapRateAction.ATOB,
+    );
   }, [swapSummaryInfo.swapRateAction]);
 
   return (

--- a/packages/web/src/components/swap/swap-card-content-detail/swap-button-tooltip/SwapButtonTooltip.stories.tsx
+++ b/packages/web/src/components/swap/swap-card-content-detail/swap-button-tooltip/SwapButtonTooltip.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import { SwapRateAction } from "@hooks/swap/data/use-swap-handler";
 import { SwapSummaryInfo } from "@models/swap/swap-summary-info";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import SwapButtonTooltip from "./SwapButtonTooltip";
@@ -41,7 +42,7 @@ const swapSummaryInfo: SwapSummaryInfo = {
     currency: "GNOT",
   },
   gasFeeUSD: 0.1,
-  swapRateAction: "ATOB",
+  swapRateAction: SwapRateAction.ATOB,
   swapRate1USD: 1,
   protocolFee: "0%",
 };

--- a/packages/web/src/components/swap/swap-card-content-detail/swap-card-fee-info/SwapCardFeeInfo.spec.tsx
+++ b/packages/web/src/components/swap/swap-card-content-detail/swap-card-fee-info/SwapCardFeeInfo.spec.tsx
@@ -1,4 +1,4 @@
-import { PriceImpactStatus } from "@hooks/swap/data/use-swap-handler";
+import { PriceImpactStatus, SwapRateAction } from "@hooks/swap/data/use-swap-handler";
 import { SwapSummaryInfo } from "@models/swap/swap-summary-info";
 import { SwapTokenInfo } from "@models/swap/swap-token-info";
 import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
@@ -45,7 +45,7 @@ const swapSummaryInfo: SwapSummaryInfo = {
   },
   gasFeeUSD: 0.1,
   swapRate1USD: 0,
-  swapRateAction: "ATOB",
+  swapRateAction: SwapRateAction.ATOB,
   protocolFee: "",
 };
 

--- a/packages/web/src/components/swap/swap-card-content-detail/swap-card-fee-info/SwapCardFeeInfo.stories.tsx
+++ b/packages/web/src/components/swap/swap-card-content-detail/swap-card-fee-info/SwapCardFeeInfo.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import { SwapRateAction } from "@hooks/swap/data/use-swap-handler";
 import { SwapSummaryInfo } from "@models/swap/swap-summary-info";
 import { SwapTokenInfo } from "@models/swap/swap-token-info";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
@@ -42,7 +43,7 @@ const swapSummaryInfo: SwapSummaryInfo = {
     currency: "GNOT",
   },
   gasFeeUSD: 0.1,
-  swapRateAction: "ATOB",
+  swapRateAction: SwapRateAction.ATOB,
   swapRate1USD: 1,
   protocolFee: "0%",
 };

--- a/packages/web/src/hooks/swap/data/use-swap-handler.tsx
+++ b/packages/web/src/hooks/swap/data/use-swap-handler.tsx
@@ -55,6 +55,11 @@ type SwapButtonStateType =
 
 export type PriceImpactStatus = "LOW" | "HIGH" | "MEDIUM" | "POSITIVE" | "NONE";
 
+export enum SwapRateAction {
+  ATOB = "ATOB",
+  BTOA = "BTOA",
+}
+
 function estimatePriceImpactByRoutes(
   tokenInPath: string,
   routes: EstimatedRoute[],
@@ -161,7 +166,7 @@ export const useSwapHandler = () => {
   const { t } = useTranslation();
   const { enqueueEvent } = useTransactionEventStore();
 
-  const [swapRateAction, setSwapRateAction] = useState<"ATOB" | "BTOA">("BTOA");
+  const [swapRateAction, setSwapRateAction] = useState<SwapRateAction>(SwapRateAction.BTOA);
   const [tokenAAmount = "", setTokenAAmount] = useState(defaultTokenAAmount ?? undefined);
 
   const estimateFlagRef = useRef(0);
@@ -489,7 +494,7 @@ export const useSwapHandler = () => {
       return null;
     }
     const swapRate1USD =
-      swapRateAction === "ATOB"
+      swapRateAction === SwapRateAction.ATOB
         ? getTokenUSDPrice(checkGnotPath(tokenA.path), 1) || 1
         : getTokenUSDPrice(checkGnotPath(tokenB.path), 1) || 1;
 
@@ -522,7 +527,7 @@ export const useSwapHandler = () => {
     const tokenBUSDValue = tokenPrices[checkGnotPath(tokenB.path)]?.usd || 1;
 
     const swapRate =
-      swapRateAction === "ATOB"
+      swapRateAction === SwapRateAction.ATOB
         ? Number(tokenBAmount) / Number(tokenAAmount)
         : Number(tokenAAmount) / Number(tokenBAmount);
     const swapRateUSD =
@@ -601,6 +606,7 @@ export const useSwapHandler = () => {
       <ConfirmSwapModal
         submitted={true}
         swapResult={swapResult}
+        setSwapRateAction={setSwapRateAction}
         swap={executeSwap}
         close={closeModal}
         isWrapOrUnwrap={swapButtonState === "WRAP" || swapButtonState === "UNWRAP"}
@@ -621,7 +627,17 @@ export const useSwapHandler = () => {
         })()}
       />,
     );
-  }, [submitted, swapResult, swapSummaryInfo, swapTokenInfo, swapButtonState, priceImpactStatus, isLoading, t]);
+  }, [
+    submitted,
+    swapResult,
+    swapSummaryInfo,
+    swapTokenInfo,
+    swapButtonState,
+    priceImpactStatus,
+    isLoading,
+    setSwapRateAction,
+    t,
+  ]);
 
   const openConnectWallet = useCallback(() => {
     openModal();

--- a/packages/web/src/layouts/swap/components/swap-card/SwapCard.stories.tsx
+++ b/packages/web/src/layouts/swap/components/swap-card/SwapCard.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import { SwapRateAction } from "@hooks/swap/data/use-swap-handler";
 import { SwapRouteInfo } from "@models/swap/swap-route-info";
 import { SwapSummaryInfo } from "@models/swap/swap-summary-info";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
@@ -42,7 +43,7 @@ const swapSummaryInfo: SwapSummaryInfo = {
     currency: "GNOT",
   },
   gasFeeUSD: 0.1,
-  swapRateAction: "ATOB",
+  swapRateAction: SwapRateAction.ATOB,
   swapRate1USD: 1,
   protocolFee: "0%",
 };

--- a/packages/web/src/layouts/swap/components/swap-card/SwapCard.tsx
+++ b/packages/web/src/layouts/swap/components/swap-card/SwapCard.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import Button, { ButtonHierarchy } from "@components/common/button/Button";
 import { IconTriangleWarningOutlined } from "@components/common/icons/IconTriangleWarningOutlined";
 import WarningCard from "@components/common/warning-card/WarningCard";
-import { PriceImpactStatus } from "@hooks/swap/data/use-swap-handler";
+import { PriceImpactStatus, SwapRateAction } from "@hooks/swap/data/use-swap-handler";
 import { SwapResultInfo } from "@models/swap/swap-result-info";
 import { SwapRouteInfo } from "@models/swap/swap-route-info";
 import { SwapSummaryInfo } from "@models/swap/swap-summary-info";
@@ -48,7 +48,7 @@ interface SwapCardProps {
   copyURL: () => void;
   swap: (swapTokenInfo: SwapTokenInfo, estimatedAmount: string) => void;
   switchNetwork: () => void;
-  setSwapRateAction: (type: "ATOB" | "BTOA") => void;
+  setSwapRateAction: (type: SwapRateAction) => void;
   priceImpactStatus: PriceImpactStatus;
 }
 

--- a/packages/web/src/layouts/swap/components/swap-card/swap-card-content/SwapCardContent.spec.tsx
+++ b/packages/web/src/layouts/swap/components/swap-card/swap-card-content/SwapCardContent.spec.tsx
@@ -1,4 +1,4 @@
-import { PriceImpactStatus } from "@hooks/swap/data/use-swap-handler";
+import { PriceImpactStatus, SwapRateAction } from "@hooks/swap/data/use-swap-handler";
 import { SwapTokenInfo } from "@models/swap/swap-token-info";
 import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
 import { render } from "@testing-library/react";
@@ -62,7 +62,7 @@ describe("SwapCardContent Component", () => {
       switchSwapDirection: () => null,
       connectedWallet: false,
       isLoading: false,
-      setSwapRateAction: (type: "ATOB" | "BTOA") => {
+      setSwapRateAction: (type: SwapRateAction) => {
         console.log(type);
       },
       isSwitchNetwork: false,

--- a/packages/web/src/layouts/swap/components/swap-card/swap-card-content/SwapCardContent.tsx
+++ b/packages/web/src/layouts/swap/components/swap-card/swap-card-content/SwapCardContent.tsx
@@ -8,7 +8,7 @@ import { IconTriangleWarningOutlined } from "@components/common/icons/IconTriang
 import SelectPairButton from "@components/common/select-pair-button/SelectPairButton";
 import SwapCardContentDetail from "@components/swap/swap-card-content-detail/SwapCardContentDetail";
 import { useTheme } from "@emotion/react";
-import { PriceImpactStatus } from "@hooks/swap/data/use-swap-handler";
+import { PriceImpactStatus, SwapRateAction } from "@hooks/swap/data/use-swap-handler";
 import { SwapRouteInfo } from "@models/swap/swap-route-info";
 import { SwapSummaryInfo } from "@models/swap/swap-summary-info";
 import { SwapTokenInfo } from "@models/swap/swap-token-info";
@@ -36,7 +36,7 @@ interface ContentProps {
   resetEstimatedLiquidity: () => void;
   connectedWallet: boolean;
   isLoading: boolean;
-  setSwapRateAction: (type: "ATOB" | "BTOA") => void;
+  setSwapRateAction: (type: SwapRateAction) => void;
   isSwitchNetwork: boolean;
   priceImpactStatus: PriceImpactStatus;
   isSameToken: boolean;

--- a/packages/web/src/layouts/token-detail/components/token-swap/TokenSwap.tsx
+++ b/packages/web/src/layouts/token-detail/components/token-swap/TokenSwap.tsx
@@ -9,7 +9,7 @@ import IconSettings from "@components/common/icons/IconSettings";
 import IconSwapArrowDown from "@components/common/icons/IconSwapArrowDown";
 import SelectPairButton from "@components/common/select-pair-button/SelectPairButton";
 import SwapCardContentDetail from "@components/swap/swap-card-content-detail/SwapCardContentDetail";
-import { PriceImpactStatus } from "@hooks/swap/data/use-swap-handler";
+import { PriceImpactStatus, SwapRateAction } from "@hooks/swap/data/use-swap-handler";
 import { SwapRouteInfo } from "@models/swap/swap-route-info";
 import { SwapSummaryInfo } from "@models/swap/swap-summary-info";
 import { SwapTokenInfo } from "@models/swap/swap-token-info";
@@ -44,7 +44,7 @@ export interface TokenSwapProps {
   changeTokenBAmount: (value: string, none?: boolean) => void;
   switchSwapDirection: () => void;
   switchNetwork: () => void;
-  setSwapRateAction: (type: "ATOB" | "BTOA") => void;
+  setSwapRateAction: (type: SwapRateAction) => void;
   priceImpactStatus: PriceImpactStatus;
 }
 

--- a/packages/web/src/models/swap/swap-summary-info.ts
+++ b/packages/web/src/models/swap/swap-summary-info.ts
@@ -1,4 +1,5 @@
 import { SwapDirectionType } from "@common/values";
+import { SwapRateAction } from "@hooks/swap/data/use-swap-handler";
 import { AmountModel } from "@models/common/amount-model";
 import { TokenModel } from "@models/token/token-model";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
@@ -22,7 +23,7 @@ export interface SwapSummaryInfo {
 
   gasFeeUSD: number;
 
-  swapRateAction: "ATOB" | "BTOA";
+  swapRateAction: SwapRateAction;
 
   swapRate1USD: number;
 


### PR DESCRIPTION
## Description
This PR replaces string literals ("ATOB" and "BTOA") with a proper enum type SwapRateAction for representing swap rate direction throughout the codebase. This change improves type safety, prevents potential typos, and enhances code maintainability.

## Details
- Created a new SwapRateAction enum with values ATOB and BTOA
- Updated state definitions in useSwapHandler hook to use the enum type
- Modified relevant components to use the enum instead of string literals
- Updated type definitions in interfaces and function parameters
- Ensured backward compatibility with existing functionality