### PR TITLE
[GSW-2232, GSW-2233] Fix Swap Feature

### DIFF
--- a/packages/web/src/components/swap/confirm-swap-modal/ConfirmSwapModal.tsx
+++ b/packages/web/src/components/swap/confirm-swap-modal/ConfirmSwapModal.tsx
@@ -151,14 +151,14 @@ const ConfirmSwapModal: React.FC<ConfirmSwapModalProps> = ({
     const { tokenAUSD, tokenBUSD, tokenAAmount, tokenBAmount } = swapTokenInfo;
     if (swapRateAction === SwapRateAction.ATOB) {
       if (!tokenBUSD || tokenBUSD === 0) return "-";
-      return `($${convertToKMB(floorNumber((tokenBUSD / Number(tokenBAmount)) * swapRate).toFixed(3), {
+      return convertToKMB(floorNumber((tokenBUSD / Number(tokenBAmount)) * swapRate).toFixed(3), {
         isIgnoreKFormat: true,
-      })})`;
+      });
     } else {
       if (!tokenAUSD || tokenAUSD === 0) return "-";
-      return `($${convertToKMB(floorNumber((tokenAUSD / Number(tokenAAmount)) * swapRate).toFixed(3), {
+      return convertToKMB(floorNumber((tokenAUSD / Number(tokenAAmount)) * swapRate).toFixed(3), {
         isIgnoreKFormat: true,
-      })})`;
+      });
     }
   }, [swapSummaryInfo, swapTokenInfo]);
 
@@ -286,7 +286,7 @@ const ConfirmSwapModal: React.FC<ConfirmSwapModalProps> = ({
               <button className="gnos-price" onClick={handleSwapRateDescription}>
                 {swapRateDescription}
               </button>
-              <span className="exchange-price">{unitSwapPrice}</span>
+              <span className="exchange-price">{`($${unitSwapPrice})`}</span>
             </div>
           </div>
           <div className="gas-info">

--- a/packages/web/src/components/swap/swap-card-content-detail/swap-card-fee-info/SwapCardFeeInfo.tsx
+++ b/packages/web/src/components/swap/swap-card-content-detail/swap-card-fee-info/SwapCardFeeInfo.tsx
@@ -82,13 +82,10 @@ const SwapCardFeeInfo: React.FC<ContentProps> = ({ swapSummaryInfo, isLoading, p
       return swapSummaryInfo.protocolFee;
     }
 
-    const { direction } = swapTokenInfo;
-    const isExactIn = direction === "EXACT_IN";
-
-    const tokenAmount = isExactIn ? swapTokenInfo.tokenAAmount : swapTokenInfo.tokenBAmount;
-    const tokenUSD = isExactIn ? swapTokenInfo.tokenAUSD : swapTokenInfo.tokenBUSD;
-    const tokenSymbol = isExactIn ? swapTokenInfo.tokenA?.symbol : swapTokenInfo.tokenB?.symbol;
-    const tokenDecimals = isExactIn ? swapTokenInfo.tokenADecimals : swapTokenInfo.tokenBDecimals;
+    const tokenAmount = swapTokenInfo.tokenBAmount;
+    const tokenUSD = swapTokenInfo.tokenBUSD;
+    const tokenSymbol = swapTokenInfo.tokenB?.symbol;
+    const tokenDecimals = swapTokenInfo.tokenBDecimals;
 
     if (!tokenAmount) {
       return swapSummaryInfo.protocolFee;


### PR DESCRIPTION
## Description
This PR fixes features related to Swap.

## Details
- GSW-2232
  - Fix to display the same format (`$-`) as the exchange rate in the swap window even when there is no dollar equivalent
  - Added dollar signs to the exchange rate display to provide a consistent UI
- GSW-2233
  - Fixed to always calculate the fee based on the output token (tokenB).