### PR TITLE
[GSW-2234] Handle multiple reward types in token hover tooltip

### DIFF
--- a/packages/web/src/components/common/missing-logo/MissingLogo.styles.tsx
+++ b/packages/web/src/components/common/missing-logo/MissingLogo.styles.tsx
@@ -84,5 +84,6 @@ export const LogoWrapper = styled.div<Props>`
 `;
 
 export const TokenSymbolWrapper = styled.div`
-  ${fonts.p1}
+  ${fonts.p1};
+  white-space: pre;
 `;

--- a/packages/web/src/components/common/missing-logo/MissingLogo.tsx
+++ b/packages/web/src/components/common/missing-logo/MissingLogo.tsx
@@ -65,16 +65,7 @@ const MissingLogo: React.FC<Props> = ({
       placement="top"
       className={tokenTooltipClassName}
       forcedClose={!showTooltip}
-      FloatingContent={
-        <TokenSymbolWrapper>
-          {tooltipContent.split("\n").map((line, i) => (
-            <React.Fragment key={i}>
-              {i > 0 && <br />}
-              {line}
-            </React.Fragment>
-          ))}
-        </TokenSymbolWrapper>
-      }
+      FloatingContent={<TokenSymbolWrapper>{tooltipContent}</TokenSymbolWrapper>}
     >
       {url ? (
         <Image mobileWidth={mobileWidth} width={width} src={url} alt="logo" className={className} />

--- a/packages/web/src/components/common/missing-logo/MissingLogo.tsx
+++ b/packages/web/src/components/common/missing-logo/MissingLogo.tsx
@@ -48,17 +48,33 @@ const MissingLogo: React.FC<Props> = ({
   };
 
   const tooltipContent = React.useMemo(() => {
-    if (showRewardType && rewardType) {
-      return `$${symbol} ${rewardTypeToDisplayText(rewardType)}`;
+    if (!showRewardType || !rewardType) {
+      return symbol;
     }
-    return symbol;
+
+    if (Array.isArray(rewardType)) {
+      const rewardTypesText = rewardType.map(rt => rewardTypeToDisplayText(rt)).join(", \n");
+      return `$${symbol} (${rewardTypesText})`;
+    }
+
+    return `$${symbol} (${rewardTypeToDisplayText(rewardType)})`;
   }, [showRewardType, rewardType, symbol]);
+
   return (
     <Tooltip
       placement="top"
       className={tokenTooltipClassName}
       forcedClose={!showTooltip}
-      FloatingContent={<TokenSymbolWrapper>{tooltipContent}</TokenSymbolWrapper>}
+      FloatingContent={
+        <TokenSymbolWrapper>
+          {tooltipContent.split("\n").map((line, i) => (
+            <React.Fragment key={i}>
+              {i > 0 && <br />}
+              {line}
+            </React.Fragment>
+          ))}
+        </TokenSymbolWrapper>
+      }
     >
       {url ? (
         <Image mobileWidth={mobileWidth} width={width} src={url} alt="logo" className={className} />

--- a/packages/web/src/layouts/earn/components/incentivized-pool-card-list/incentivized-pool-card/IncentivizedPoolCard.tsx
+++ b/packages/web/src/layouts/earn/components/incentivized-pool-card-list/incentivized-pool-card/IncentivizedPoolCard.tsx
@@ -12,10 +12,10 @@ import { IncentivizePoolCardInfo } from "@models/pool/info/pool-card-info";
 import { formatRate } from "@utils/new-number-utils";
 import { numberToFormat } from "@utils/string-utils";
 import { useGetBinsByPath } from "@query/pools";
+import { getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
 
 import { PoolCardWrapper, PoolCardWrapperWrapperBorder } from "./IncentivizedPoolCard.styles";
 import LoadingSpinner from "@components/common/loading-spinner/LoadingSpinner";
-import { getUniqueRewardTokensByPath } from "@utils/token-utils";
 
 export interface IncentivizedPoolCardProps {
   pool: IncentivizePoolCardInfo;
@@ -45,8 +45,7 @@ const IncentivizedPoolCard: React.FC<IncentivizedPoolCardProps> = ({ pool, route
   const rewardTokenLogos = useMemo(() => {
     if (!pool.incentivized) return null;
 
-    const tokenData = getUniqueRewardTokensByPath(pool.rewardTokens, getGnotPath);
-
+    const tokenData = getUniqueRewardTokensWithMultipleRewardTypes(pool.rewardTokens, getGnotPath);
     return <OverlapTokenLogo tokens={tokenData} size={16} showRewardType={true} />;
   }, [getGnotPath, pool.rewardTokens, pool.incentivized]);
 

--- a/packages/web/src/layouts/earn/components/pool-list/pool-list-table/pool-info/PoolInfo.tsx
+++ b/packages/web/src/layouts/earn/components/pool-list/pool-list-table/pool-info/PoolInfo.tsx
@@ -9,7 +9,7 @@ import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { PoolListInfo } from "@models/pool/info/pool-list-info";
 import { DEVICE_TYPE } from "@styles/media";
 import { formatRate } from "@utils/new-number-utils";
-import { RewardTokenModel } from "@models/position/reward-model";
+import { getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
 
 import PoolInfoLazyChart from "./pool-info-lazy-chart/PoolInfoLazyChart";
 
@@ -40,20 +40,7 @@ const PoolInfo: React.FC<PoolInfoProps> = ({ pool, routeItem, breakpoint }) => {
   const rewardTokenLogos = useMemo(() => {
     if (!incentivized) return null;
 
-    const tokenData = rewardTokens.reduce((acc, current) => {
-      const existToken = acc.some(item => item.path === getGnotPath(current).path);
-
-      if (!existToken) {
-        acc.push({
-          ...current,
-          logoURI: getGnotPath(current).logoURI,
-          symbol: getGnotPath(current).symbol,
-          path: getGnotPath(current).path,
-        });
-      }
-
-      return acc;
-    }, [] as RewardTokenModel[]);
+    const tokenData = getUniqueRewardTokensWithMultipleRewardTypes(rewardTokens, getGnotPath);
 
     return <OverlapTokenLogo tokens={tokenData} size={20} showRewardType={true} />;
   }, [getGnotPath, rewardTokens, incentivized, hasPoolStaking]);

--- a/packages/web/src/layouts/pool/pool-add/components/additional-info/quick-pool-info/QuickPoolInfo.tsx
+++ b/packages/web/src/layouts/pool/pool-add/components/additional-info/quick-pool-info/QuickPoolInfo.tsx
@@ -15,10 +15,10 @@ import { TokenModel } from "@models/token/token-model";
 import { checkGnotPath } from "@utils/common";
 import { formatOtherPrice, formatRate } from "@utils/new-number-utils";
 import { formatUsdNumber } from "@utils/stake-position-utils";
+import { getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
 
 import { Divider, QuickPoolInfoWrapper } from "./QuickPoolInfo.styles";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
-import { RewardTokenModel } from "@models/position/reward-model";
 
 interface Props {
   tokenPair: string[];
@@ -97,20 +97,7 @@ const QuickPoolInfo: React.FC<Props> = ({
   }, [isLoadingPool, pool.feeUsd24h]);
 
   const rewardTokens = useMemo(() => {
-    return pool?.rewardTokens.reduce((acc, current) => {
-      const existToken = acc.some(item => item.path === getGnotPath(current).path);
-
-      if (!existToken) {
-        acc.push({
-          ...current,
-          logoURI: getGnotPath(current).logoURI,
-          symbol: getGnotPath(current).symbol,
-          path: getGnotPath(current).path,
-        });
-      }
-
-      return acc;
-    }, [] as RewardTokenModel[]);
+    return getUniqueRewardTokensWithMultipleRewardTypes(pool?.rewardTokens, getGnotPath);
   }, [getGnotPath, pool?.rewardTokens]);
 
   const feeApr = useMemo(() => {

--- a/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-header/PoolPairInfoHeader.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-header/PoolPairInfoHeader.tsx
@@ -6,7 +6,7 @@ import OverlapTokenLogo from "@components/common/overlap-token-logo/OverlapToken
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { TokenModel } from "@models/token/token-model";
 import { RewardTokenModel } from "@models/position/reward-model";
-import { getUniqueRewardTokensByPath } from "@utils/token-utils";
+import { getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
 
 import { PoolInfoHeaderWrapper } from "./PoolPairInfoHeader.styles";
 
@@ -32,7 +32,7 @@ const PoolPairInfoHeader: React.FC<PoolPairInfoHeaderProps> = ({
   }, [incentivzed, t]);
 
   const rewardTokenLogos = useMemo(() => {
-    return getUniqueRewardTokensByPath(rewardTokens, getGnotPath);
+    return getUniqueRewardTokensWithMultipleRewardTypes(rewardTokens, getGnotPath);
   }, [getGnotPath, rewardTokens]);
 
   return (

--- a/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/StakingContent.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/StakingContent.tsx
@@ -13,7 +13,7 @@ import { PoolDetailModel } from "@models/pool/pool-detail-model";
 import { PoolStakingModel } from "@models/pool/pool-staking";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { DEVICE_TYPE } from "@styles/media";
-import { getUniqueRewardTokensByPath } from "@utils/token-utils";
+import { getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
 
 import IncentivizeTokenDetailTooltipContent from "./incentivized-token-detail-tooltip-content/IncentivizeTokenDetailTooltipContent";
 import StakingContentCard, { SummuryApr } from "./staking-content-card/StakingContentCard";
@@ -96,7 +96,7 @@ const StakingContent: React.FC<StakingContentProps> = ({
 
   const rewardTokenLogos = useMemo(() => {
     const rewardTokens = pool?.rewardTokens || [];
-    return getUniqueRewardTokensByPath(rewardTokens, getGnotPath);
+    return getUniqueRewardTokensWithMultipleRewardTypes(rewardTokens, getGnotPath);
   }, [getGnotPath, pool?.rewardTokens]);
 
   const stakingPositionMap = useMemo(() => {

--- a/packages/web/src/utils/token-utils.ts
+++ b/packages/web/src/utils/token-utils.ts
@@ -4,6 +4,11 @@ import BigNumber from "bignumber.js";
 import { formatOtherPrice } from "./new-number-utils";
 import { roundDownDecimalNumber } from "./regex";
 import { STATIC_TEXT } from "@common/values";
+import { RewardType } from "@constants/option.constant";
+
+export interface RewardTokenModelWithMultipleTypes extends Omit<RewardTokenModel, "rewardType"> {
+  rewardType: RewardType | RewardType[];
+}
 
 export function makeRawTokenAmount(token: TokenModel, amount: string | number) {
   const number = BigNumber(amount.toString());
@@ -98,6 +103,95 @@ export function getUniqueRewardTokensByPath<
 ) {
   return rewardTokens.reduce((acc, current) => {
     const existToken = acc.some(item => item.path === getGnotPath(current as unknown as T).path);
+
+    if (!existToken) {
+      acc.push({
+        ...current,
+        logoURI: getGnotPath(current as unknown as T).logoURI,
+        symbol: getGnotPath(current as unknown as T).symbol,
+        path: getGnotPath(current as unknown as T).path,
+      });
+    }
+
+    return acc;
+  }, [] as RewardTokenModel[]);
+}
+
+/**
+ * Groups reward tokens by path and combines their reward types.
+ * Tokens with the same path but different reward types will be merged into a single token
+ * with an array of reward types.
+ *
+ * @param rewardTokens Array of tokens to process
+ * @param getGnotPath GNOT path conversion function
+ */
+export function getUniqueRewardTokensWithMultipleRewardTypes<
+  T extends { path?: string; name?: string; logoURI?: string; symbol?: string },
+>(
+  rewardTokens: RewardTokenModel[],
+  getGnotPath: (token: T | null | undefined) => {
+    path: string;
+    name: string;
+    symbol: string;
+    logoURI: string;
+    wrappedPath: string;
+  },
+): RewardTokenModelWithMultipleTypes[] {
+  const tokensByPath = rewardTokens.reduce((acc, current) => {
+    const convertedToken = {
+      ...current,
+      logoURI: getGnotPath(current as unknown as T).logoURI,
+      symbol: getGnotPath(current as unknown as T).symbol,
+      path: getGnotPath(current as unknown as T).path,
+    };
+
+    const path = convertedToken.path;
+    if (!acc[path]) {
+      acc[path] = [];
+    }
+    acc[path].push(convertedToken);
+
+    return acc;
+  }, {} as Record<string, RewardTokenModel[]>);
+
+  return Object.values(tokensByPath).map(tokens => {
+    const baseToken = tokens[0];
+
+    const uniqueRewardTypes = Array.from(
+      new Set(tokens.map(token => token.rewardType).filter(Boolean)),
+    ) as RewardType[];
+
+    return {
+      ...baseToken,
+      rewardType: uniqueRewardTypes.length > 1 ? uniqueRewardTypes : baseToken.rewardType,
+    } as RewardTokenModelWithMultipleTypes;
+  });
+}
+
+/**
+ * Groups reward tokens by path and combines their reward types.
+ * Tokens with the same path but different reward types will be merged into a single token
+ * with an array of reward types.
+ *
+ * @param rewardTokens Array of tokens to process
+ * @param getGnotPath GNOT path conversion function
+ */
+export function getUniqueRewardTokensByPathWithTypes<
+  T extends { path?: string; name?: string; logoURI?: string; symbol?: string },
+>(
+  rewardTokens: RewardTokenModel[],
+  getGnotPath: (token: T | null | undefined) => {
+    path: string;
+    name: string;
+    symbol: string;
+    logoURI: string;
+    wrappedPath: string;
+  },
+) {
+  return rewardTokens.reduce((acc, current) => {
+    const existToken = acc.some(
+      item => item.path === getGnotPath(current as unknown as T).path && item.rewardType === current.rewardType,
+    );
 
     if (!existToken) {
       acc.push({

--- a/packages/web/src/utils/token-utils.ts
+++ b/packages/web/src/utils/token-utils.ts
@@ -138,11 +138,13 @@ export function getUniqueRewardTokensWithMultipleRewardTypes<
   },
 ): RewardTokenModelWithMultipleTypes[] {
   const tokensByPath = rewardTokens.reduce((acc, current) => {
+    const tokenInfo = getGnotPath(current as unknown as T);
+
     const convertedToken = {
       ...current,
-      logoURI: getGnotPath(current as unknown as T).logoURI,
-      symbol: getGnotPath(current as unknown as T).symbol,
-      path: getGnotPath(current as unknown as T).path,
+      logoURI: tokenInfo.logoURI,
+      symbol: tokenInfo.symbol,
+      path: tokenInfo.path,
     };
 
     const path = convertedToken.path;
@@ -166,44 +168,6 @@ export function getUniqueRewardTokensWithMultipleRewardTypes<
       rewardType: uniqueRewardTypes.length > 1 ? uniqueRewardTypes : baseToken.rewardType,
     } as RewardTokenModelWithMultipleTypes;
   });
-}
-
-/**
- * Groups reward tokens by path and combines their reward types.
- * Tokens with the same path but different reward types will be merged into a single token
- * with an array of reward types.
- *
- * @param rewardTokens Array of tokens to process
- * @param getGnotPath GNOT path conversion function
- */
-export function getUniqueRewardTokensByPathWithTypes<
-  T extends { path?: string; name?: string; logoURI?: string; symbol?: string },
->(
-  rewardTokens: RewardTokenModel[],
-  getGnotPath: (token: T | null | undefined) => {
-    path: string;
-    name: string;
-    symbol: string;
-    logoURI: string;
-    wrappedPath: string;
-  },
-) {
-  return rewardTokens.reduce((acc, current) => {
-    const existToken = acc.some(
-      item => item.path === getGnotPath(current as unknown as T).path && item.rewardType === current.rewardType,
-    );
-
-    if (!existToken) {
-      acc.push({
-        ...current,
-        logoURI: getGnotPath(current as unknown as T).logoURI,
-        symbol: getGnotPath(current as unknown as T).symbol,
-        path: getGnotPath(current as unknown as T).path,
-      });
-    }
-
-    return acc;
-  }, [] as RewardTokenModel[]);
 }
 
 /**


### PR DESCRIPTION
## Description
This PR implements the tooltip text change for reward tokens as specified in the requirements

## Details
- Changed tooltip format from simple {token_name} to ${token_name} (Internal Reward-Tier1 / External Reward)
- Added special case handling for GNS tokens that are provided as both Internal and External rewards
- For special cases, tooltip displays as ${token_name} (Internal Reward, <br> External Reward)
- Updated token grouping logic to properly combine multiple reward types