### PR TITLE
[GSW-2246] Add default SEO title for better UX during page loading

### DIFF
--- a/packages/web/src/constants/common.constant.ts
+++ b/packages/web/src/constants/common.constant.ts
@@ -56,6 +56,7 @@ export type StringParamsArr = (string | undefined)[];
 export type StringWithParamsArr = (params?: StringParamsArr) => TranslationKey;
 
 export const DefaultTitle = "Metatag(title):seo.title.default";
+export const DEFAULT_SEO_TITLE = "The One-stop Gnoland DeFi Platform | GnoSwap";
 
 export const SEOInfo: Record<
   PageKey,
@@ -117,7 +118,7 @@ export const SEOInfo: Record<
         const [tokenASymbol, tokenBSymbol, feeTier] = params;
         return `${tokenASymbol}/${tokenBSymbol} ${feeTier} | Earn on GnoSwap`;
       }
-      return DefaultTitle;
+      return DEFAULT_SEO_TITLE;
     },
     desc: () =>
       "Provide liquidity to earn trading fees and staking rewards. GnoSwap's concentrated liquidity maximizes your earnings by amplifying your capital efficiency.",
@@ -128,7 +129,7 @@ export const SEOInfo: Record<
         const [address, tokenASymbol, tokenBSymbol, feeTier] = params;
         return `${address} | ${tokenASymbol}/${tokenBSymbol} ${feeTier} | Earn on GnoSwap`;
       }
-      return DefaultTitle;
+      return DEFAULT_SEO_TITLE;
     },
     desc: () => "Create your own positions and provide liquidity to earn trading fees.",
   },
@@ -225,7 +226,7 @@ export const SEOInfo: Record<
 
       if (tokenName && tokenSymbol && tokenPrice) return titleDisplay;
 
-      return DefaultTitle;
+      return DEFAULT_SEO_TITLE;
     },
     desc: (params = []) => {
       if (params.length === 1) {


### PR DESCRIPTION
## Description
This PR fixes the issue with SEO meta titles showing "seo.title.default" during initial page load, which creates a poor user experience and might affect SEO performance.

## Details
- Added a new constant `DEFAULT_SEO_TITLE` with value "The One-stop Gnoland DeFi Platform | GnoSwap"
- Replaced all occurrences of `DefaultTitle` with `DEFAULT_SEO_TITLE` in SEO-related functions
- This ensures that a meaningful title is displayed during the initial page load before the dynamic content is ready