### PR TITLE
[GSW-2238, GSW-2239] TX-multi message, ClaimAll

### DIFF
--- a/packages/web/src/hooks/pool/data/use-reposition-handle.tsx
+++ b/packages/web/src/hooks/pool/data/use-reposition-handle.tsx
@@ -71,9 +71,9 @@ export const useRepositionHandle = () => {
   );
 
   const calculatedLiquidity = useMemo(() => {
-    if (!selectedPosition?.liquidity) return "0";
+    if (!selectedPosition?.liquidity) return BigNumber(0);
 
-    return BigNumber(selectedPosition.liquidity.toString()).integerValue(BigNumber.ROUND_DOWN).toString();
+    return BigNumber(selectedPosition.liquidity.toString());
   }, [selectedPosition?.liquidity]);
 
   const defaultPositionMinPrice = useMemo(() => {
@@ -413,10 +413,14 @@ export const useRepositionHandle = () => {
 
     const deadline = (Math.floor(Date.now() / 1000) + 60 * 5).toString();
 
+    const positionLiquidity = {
+      [selectedPosition.lpTokenId]: calculatedLiquidity,
+    };
+
     return positionRepository
       .removeLiquidity({
         lpTokenIds: [selectedPosition.lpTokenId],
-        calculatedLiquidity,
+        positionLiquidities: positionLiquidity,
         caller: address,
         tokenPaths: [selectedPosition.pool.tokenA.path, selectedPosition.pool.tokenB.path],
         isGetWGNOT: false,

--- a/packages/web/src/hooks/pool/ui/use-remove-position-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-remove-position-modal.tsx
@@ -1,5 +1,6 @@
 import { useAtom } from "jotai";
 import { useCallback, useMemo } from "react";
+import BigNumber from "bignumber.js";
 
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { CommonState } from "@states/index";
@@ -10,7 +11,7 @@ export interface Props {
   positions: PoolPositionModel[];
   selectedIds: number[];
   isGetWGNOT: boolean;
-  calculatedLiquidity: string;
+  positionLiquidities: Record<string, BigNumber>;
   refetchPositions: () => Promise<void>;
 }
 
@@ -18,7 +19,7 @@ export const useRemovePositionModal = ({
   positions,
   selectedIds,
   isGetWGNOT,
-  calculatedLiquidity,
+  positionLiquidities,
   refetchPositions,
 }: Props) => {
   const [, setOpenedModal] = useAtom(CommonState.openedModal);
@@ -35,7 +36,7 @@ export const useRemovePositionModal = ({
         allPosition={positions}
         selectedPositions={selectedPositions}
         isGetWGNOT={isGetWGNOT}
-        calculatedLiquidity={calculatedLiquidity}
+        positionLiquidities={positionLiquidities}
         refetchPositions={refetchPositions}
       />,
     );

--- a/packages/web/src/layouts/pool/pool-remove/containers/remove-liquidity-container/RemoveLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-remove/containers/remove-liquidity-container/RemoveLiquidityContainer.tsx
@@ -41,17 +41,18 @@ const RemoveLiquidityContainer: React.FC = () => {
     return unstakedPositions.filter(position => checkedList.includes(position.id));
   }, [checkedList, unstakedPositions]);
 
-  const calculatedLiquidity = useMemo(() => {
-    return selectedPositions
-      .reduce((total, position) => {
-        return total.plus(BigNumber(position.liquidity.toString()));
-      }, BigNumber(0))
-      .toString();
+  const positionLiquidities = useMemo(() => {
+    const liquidityMap: { [key: string]: BigNumber } = {};
+
+    selectedPositions.forEach(position => {
+      liquidityMap[position.lpTokenId] = BigNumber(position.liquidity.toString());
+    });
+    return liquidityMap;
   }, [selectedPositions]);
 
   const { openModal } = useRemovePositionModal({
     positions: positions,
-    calculatedLiquidity,
+    positionLiquidities,
     selectedIds: checkedList,
     isGetWGNOT,
     refetchPositions: async () => {

--- a/packages/web/src/layouts/pool/pool-remove/containers/remove-position-modal-container/RemovePositionModalContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-remove/containers/remove-position-modal-container/RemovePositionModalContainer.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from "react";
+import BigNumber from "bignumber.js";
 
 import { ERROR_VALUE } from "@common/errors/adena";
 import { GNOT_TOKEN, WUGNOT_TOKEN } from "@common/values/token-constant";
@@ -26,7 +27,7 @@ interface RemovePositionModalContainerProps {
   selectedPositions: PoolPositionModel[];
   allPosition: PoolPositionModel[];
   isGetWGNOT: boolean;
-  calculatedLiquidity: string;
+  positionLiquidities: Record<string, BigNumber>;
   refetchPositions: () => Promise<void>;
 }
 
@@ -34,7 +35,7 @@ const RemovePositionModalContainer = ({
   selectedPositions,
   allPosition,
   isGetWGNOT,
-  calculatedLiquidity,
+  positionLiquidities,
   refetchPositions,
 }: RemovePositionModalContainerProps) => {
   const { account } = useWallet();
@@ -129,7 +130,7 @@ const RemovePositionModalContainer = ({
     const result = await positionRepository
       .removeLiquidity({
         lpTokenIds,
-        calculatedLiquidity,
+        positionLiquidities,
         tokenPaths: approveTokenPaths,
         caller: address,
         isGetWGNOT: willWrap,

--- a/packages/web/src/layouts/portfolio/containers/wallet-balance-container/WalletBalanceContainer.tsx
+++ b/packages/web/src/layouts/portfolio/containers/wallet-balance-container/WalletBalanceContainer.tsx
@@ -22,6 +22,7 @@ import { DexEvent } from "@repositories/common";
 import { formatOtherPrice } from "@utils/new-number-utils";
 import { toUnitFormat } from "@utils/number-utils";
 import { isEmptyObject } from "@utils/validation-utils";
+import { PoolPositionModel } from "@models/position/pool-position-model";
 
 import AssetSendModal from "../../components/asset-send-modal/AssetSendModal";
 import WalletBalance from "../../components/wallet-balance/WalletBalance";
@@ -44,9 +45,16 @@ const WalletBalanceContainer: React.FC = () => {
 
   const { positions, loading: loadingPositions, refetch: refetchPositions } = usePositionData();
 
+  const isClaimablePosition = (position: PoolPositionModel) => position.liquidity > 0 && !position.closed;
+
+  const claimablePositions = useMemo(() => {
+    if (!positions || positions.length === 0) return [];
+    return positions.filter(isClaimablePosition);
+  }, [positions]);
+
   const isLoadingPosition = useMemo(() => connected && loadingPositions, [connected, loadingPositions]);
 
-  const { claimAll } = usePosition(positions);
+  const { claimAll } = usePosition(claimablePositions);
   const { broadcastSuccess, broadcastError, broadcastRejected, broadcastLoading } = useBroadcastHandler();
   const { enqueueEvent } = useTransactionEventStore();
 
@@ -78,7 +86,9 @@ const WalletBalanceContainer: React.FC = () => {
   }, [connected, address]);
 
   const claimAllReward = useCallback(() => {
-    const amount = positions.flatMap(item => item.rewards).reduce((acc, item) => acc + Number(item.claimableUsd), 0);
+    const amount = claimablePositions
+      .flatMap(item => item.rewards)
+      .reduce((acc, item) => acc + Number(item.claimableUsd), 0);
 
     const messageData = {
       tokenAAmount: toUnitFormat(amount, true, false),
@@ -121,7 +131,7 @@ const WalletBalanceContainer: React.FC = () => {
         }
       }
     });
-  }, [claimAll, setLoadingTransactionClaim, positions, openModal]);
+  }, [claimAll, setLoadingTransactionClaim, claimablePositions, openModal]);
 
   const loadingTotalBalance = useMemo(() => {
     return (
@@ -149,7 +159,7 @@ const WalletBalanceContainer: React.FC = () => {
     return availableBalance;
   }, [availableBalance]);
 
-  const { stakedBalance, unStakedBalance, claimableRewards, totalClaimedRewards } = positions.reduce(
+  const { stakedBalance, unStakedBalance, claimableRewards, totalClaimedRewards } = claimablePositions.reduce(
     (acc, curPosition) => {
       acc.totalClaimedRewards = BigNumber(acc.totalClaimedRewards)
         .plus(Number(curPosition.totalClaimedUsd ?? "0"))

--- a/packages/web/src/repositories/position/position.message.ts
+++ b/packages/web/src/repositories/position/position.message.ts
@@ -498,14 +498,14 @@ export function makeRepositionLiquidityMessagesWithApproves(
 export function makeRemoveLiquidityMessagesWithApproves(
   {
     lpTokenIds,
-    calculatedLiquidity,
+    positionLiquidities,
     tokenPaths,
     caller,
     isGetWGNOT,
     deadline = (Math.floor(Date.now() / 1000) + 60 * 5).toString(),
   }: {
     lpTokenIds: string[];
-    calculatedLiquidity: string;
+    positionLiquidities: Record<string, BigNumber>;
     tokenPaths: string[];
     caller: string;
     isGetWGNOT: boolean;
@@ -531,22 +531,23 @@ export function makeRemoveLiquidityMessagesWithApproves(
     });
   }
 
-  const removeLiquidityMessages = lpTokenIds.map(lpTokenId =>
-    makeTransactionMessage({
+  const removeLiquidityMessages = lpTokenIds.map(lpTokenId => {
+    const positionLiquidity = positionLiquidities[lpTokenId] || new BigNumber(0);
+    return makeTransactionMessage({
       send: "",
       func: TransactionMessageFunctionType.DecreaseLiquidity,
       packagePath: PACKAGE_POSITION_PATH,
       args: [
         lpTokenId, // LP Token ID
-        calculatedLiquidity.toString(), // Liquidity amount to remove (100%)
+        positionLiquidity.toString(), // Liquidity amount to remove (100%)
         "0", // Minimum quantity of tokenA to decrease liquidity
         "0", // Minimum quantity of tokenB to decrease liquidity
         deadline, // Deadline UTC time
         `${!isGetWGNOT}`, // whether unwrap token : isGetWGNOT == true => wrap
       ],
       caller,
-    }),
-  );
+    });
+  });
 
   return makeTransactionMessagesWithApproves(removeLiquidityMessages, approveMessageInfos, fetchAllowance);
 }

--- a/packages/web/src/repositories/position/request/remove-liquidity-request.ts
+++ b/packages/web/src/repositories/position/request/remove-liquidity-request.ts
@@ -1,7 +1,9 @@
+import BigNumber from "bignumber.js";
+
 export interface RemoveLiquidityRequest {
   lpTokenIds: string[];
 
-  calculatedLiquidity: string;
+  positionLiquidities: Record<string, BigNumber>;
 
   tokenPaths: string[];
 


### PR DESCRIPTION
## Description
- This PR fixes an issue with the liquidity removal functionality where all positions were using the same liquidity value. Now each position uses its own specific liquidity value.
- This PR fixes an issue where the claim functionality was attempting to process positions with no rewards, causing errors. Now only active positions (with liquidity > 0 and not closed) are passed to the claim functionality.

## Details
- Modified `makeRemoveLiquidityMessagesWithApproves` function to accept a mapping of position IDs to liquidity values
- Updated `RemoveLiquidityRequest` interface to use `positionLiquidities` instead of a single `calculatedLiquidity`
- Fixed a syntax error in the `map` function where the return statement was missing
- Added `claimablePositions` using useMemo to filter positions that have liquidity > 0 and are not closed
- Updated `usePosition` hook to use filtered `claimablePositions` instead of all positions
- Modified reward calculation to use `claimablePositions` instead of all positions