### PR TITLE
[GSW-2266] Filter position rewards to include only claimable amounts

### DIFF
--- a/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustom.styles.ts
+++ b/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustom.styles.ts
@@ -151,7 +151,7 @@ export const SelectPriceRangeCustomWrapper = styled.div`
     position: relative;
     > * {
       flex: 1;
-      width: 50%;
+      width: 100%;
     }
     .dim-content-3 {
       position: absolute;

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
@@ -37,6 +37,7 @@ import { makeRouteUrl } from "@utils/page.utils";
 import { formatTokenExchangeRate } from "@utils/stake-position-utils";
 import { isEndTickBy, tickToPrice, tickToPriceStr } from "@utils/swap-utils";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
+import { isClaimableReward } from "@utils/reward-utils";
 
 import { DailyEarningTooltipContent, PositionAPRInfo } from "../stat-tooltip-contents/DailyEarningTooltipContent";
 import { BalanceTooltipContent, PositionBalanceInfo } from "./BalanceTooltipContent";
@@ -338,16 +339,23 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
     return formatOtherPrice(usdValue, { isKMB: false });
   }, [isDisplay, position.rewards]);
 
+  const positionWithClaimableRewards = useMemo(() => {
+    return {
+      ...position,
+      rewards: position.rewards.filter(isClaimableReward),
+    };
+  }, [position]);
+
   const isClaimable = useMemo(() => {
-    if (position.rewards.length === 0) {
+    if (positionWithClaimableRewards.rewards.length === 0) {
       return false;
     }
 
-    return position.rewards.some(reward => {
+    return positionWithClaimableRewards.rewards.some(reward => {
       const amount = parseFloat(reward.claimableAmount || "0");
       return amount > 0;
     });
-  }, [position.rewards]);
+  }, [positionWithClaimableRewards.rewards]);
 
   const totalDailyEarning = useMemo(() => {
     const isEmpty = !totalRewardInfo || position.rewards.length === 0;
@@ -901,7 +909,7 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
             >
               <span className={cx("content-text", { claimable: isClaimable })}>{totalRewardUSD}</span>
             </Tooltip>
-            {isClaimable && <ClaimButton text={"Claim"} onClick={() => claim(position)} />}
+            {isClaimable && <ClaimButton text={"Claim"} onClick={() => claim(positionWithClaimableRewards)} />}
           </div>
         ) : (
           !loading && <span className="content-text disabled">{totalRewardUSD}</span>

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
@@ -37,13 +37,12 @@ import { makeRouteUrl } from "@utils/page.utils";
 import { formatTokenExchangeRate } from "@utils/stake-position-utils";
 import { isEndTickBy, tickToPrice, tickToPriceStr } from "@utils/swap-utils";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
-import { isClaimableReward } from "@utils/reward-utils";
+import { isClaimableReward, mapToDisplayRewardType } from "@utils/reward-utils";
 
 import { DailyEarningTooltipContent, PositionAPRInfo } from "../stat-tooltip-contents/DailyEarningTooltipContent";
 import { BalanceTooltipContent, PositionBalanceInfo } from "./BalanceTooltipContent";
 import ManageButton from "./manage-button/ManageButton";
 import PositionHistory from "./PositionHistory";
-import { mapToDisplayRewardType } from "@utils/reward-utils";
 import { DEFAULT_TOKEN_PRICE_RATIO } from "@common/values";
 
 import {
@@ -347,14 +346,7 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
   }, [position]);
 
   const isClaimable = useMemo(() => {
-    if (positionWithClaimableRewards.rewards.length === 0) {
-      return false;
-    }
-
-    return positionWithClaimableRewards.rewards.some(reward => {
-      const amount = parseFloat(reward.claimableAmount || "0");
-      return amount > 0;
-    });
+    return positionWithClaimableRewards.rewards.length > 0;
   }, [positionWithClaimableRewards.rewards]);
 
   const totalDailyEarning = useMemo(() => {

--- a/packages/web/src/utils/reward-utils.ts
+++ b/packages/web/src/utils/reward-utils.ts
@@ -1,3 +1,6 @@
+import BigNumber from "bignumber.js";
+
+import { RewardModel } from "@models/position/reward-model";
 import { RewardType, DisplayRewardType } from "@constants/option.constant";
 
 /**
@@ -36,4 +39,15 @@ export const isInternalRewardType = (rewardType: RewardType): boolean => {
  */
 export const hasRewardInfo = <T>(data: Record<DisplayRewardType, T[]>): boolean => {
   return data.SWAP_FEE.length > 0 || data.INTERNAL_REWARD.length > 0 || data.EXTERNAL_REWARD.length > 0;
+};
+
+/**
+ * Functions to check reward claimability
+ * Returns true if the reward's claimable amount is greater than 0, otherwise false
+ * @param reward
+ * @returns boolean
+ */
+export const isClaimableReward = (reward: RewardModel): boolean => {
+  const claimableAmount = BigNumber(reward.claimableAmount || 0);
+  return !claimableAmount.isNaN() && claimableAmount.isGreaterThan(0);
 };

--- a/packages/web/src/utils/reward-utils.ts
+++ b/packages/web/src/utils/reward-utils.ts
@@ -48,6 +48,6 @@ export const hasRewardInfo = <T>(data: Record<DisplayRewardType, T[]>): boolean 
  * @returns boolean
  */
 export const isClaimableReward = (reward: RewardModel): boolean => {
-  const claimableAmount = BigNumber(reward.claimableAmount || 0);
-  return !claimableAmount.isNaN() && claimableAmount.isGreaterThan(0);
+  const claimableAmount = BigNumber(reward.claimableAmount ?? 0);
+  return claimableAmount.isGreaterThan(0);
 };


### PR DESCRIPTION
## Description
This PR implements a filtering mechanism for position rewards, ensuring that only rewards with claimable amounts greater than zero are included in the position data structure.

## Changes
- Add `isClaimableReward` utility function to validate if a reward has a positive claimable amount
- Use BigNumber library for more accurate numerical comparisons
- Replace manual filtering logic with the reusable utility function
- Update position objects to contain only rewards that are actually claimable