### PR TITLE
[GSW-2272] PositionGraph black-bar logic

### DIFF
--- a/packages/web/src/components/common/pool-graph/PoolGraph.tsx
+++ b/packages/web/src/components/common/pool-graph/PoolGraph.tsx
@@ -44,6 +44,7 @@ export interface PoolGraphProps {
   shiftIndex?: number;
   displayBinCount?: number;
   zoomLevel?: number;
+  disableBlackBars?: boolean;
 }
 
 const PoolGraph: React.FC<PoolGraphProps> = ({
@@ -74,6 +75,7 @@ const PoolGraph: React.FC<PoolGraphProps> = ({
   displayBinCount = 40,
   shiftIndex = 0,
   zoomLevel = 0,
+  disableBlackBars = false,
 }) => {
   const graphIdRef = useRef(uuid.v4());
   const graphId = graphIdRef.current.toString();
@@ -452,6 +454,7 @@ const PoolGraph: React.FC<PoolGraphProps> = ({
           onMouseMove={onMouseMoveChartBin}
           onMouseOut={onMouseOutChartBin}
           shiftIndex={shiftIndex}
+          disableBlackBars={disableBlackBars}
         />
       </FloatingTooltip>
     </PoolGraphWrapper>

--- a/packages/web/src/components/common/pool-graph/pool-graph-svg/PoolGraphSVG.tsx
+++ b/packages/web/src/components/common/pool-graph/pool-graph-svg/PoolGraphSVG.tsx
@@ -36,6 +36,7 @@ interface PoolGraphSVGProps {
   zoomLevel: number;
   currentTickRelative: number | null;
   shiftIndex: number;
+  disableBlackBars?: boolean;
   onMouseEnter?: (event: React.MouseEvent | React.TouchEvent) => void;
   onMouseLeave?: (event: React.MouseEvent) => void;
   onTouchStart?: (event: React.TouchEvent) => void;
@@ -74,6 +75,7 @@ const PoolGraphSVG = forwardRef<SVGSVGElement, PoolGraphSVGProps>(
       onMouseOut,
       zoomLevel,
       shiftIndex,
+      disableBlackBars,
     },
     forwardedRef,
   ) => {
@@ -107,16 +109,26 @@ const PoolGraphSVG = forwardRef<SVGSVGElement, PoolGraphSVGProps>(
     function updateChart() {
       // Retrieves the colour of the chart bar at the current tick.
       function fillByBin(bin: ReservedBin) {
+        if (disableBlackBars) {
+          if (hasCurrentTick && currentTickRelative !== null) {
+            if (bin.minTick < currentTickRelative) {
+              return `url(#gradient-bar-green-${graphId})`;
+            }
+            return `url(#gradient-bar-red-${graphId})`;
+          }
+          return `url(#gradient-bar-red-${graphId})`;
+        }
+
         let isBlackBar = !!(
-          maxTickPosition &&
-          minTickPosition &&
+          maxTickPosition !== null &&
+          minTickPosition !== null &&
           (scaleX(bin.minTick) < minTickPosition - binSpacing || scaleX(bin.minTick) > maxTickPosition)
         );
 
         if (isReversed) {
           isBlackBar = !!(
-            maxTickPosition &&
-            minTickPosition &&
+            maxTickPosition !== null &&
+            minTickPosition !== null &&
             (scaleX(bin.minTick) < scaleX(maxX) - maxTickPosition - binSpacing ||
               scaleX(bin.minTick) > scaleX(maxX) - minTickPosition)
           );
@@ -253,6 +265,7 @@ const PoolGraphSVG = forwardRef<SVGSVGElement, PoolGraphSVGProps>(
       scaleY,
       shiftIndex,
       currentTickPosition,
+      disableBlackBars,
     ]);
 
     return (

--- a/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-content/PoolPairInfoContent.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-content/PoolPairInfoContent.tsx
@@ -538,6 +538,7 @@ const PoolPairInfoContent: React.FC<PoolPairInfoContentProps> = ({
               shiftIndex={shiftIndex}
               displayBinCount={displayBinCount}
               zoomLevel={zoomLevel}
+              disableBlackBars={true}
             />
           )}
           {loadingBins && (


### PR DESCRIPTION
## Description
This PR fixes the issue where colors are incorrectly applied outside the user-defined range in the liquidity pool chart. As shown in GSW-2272, colors should only appear within the range set by the user.

## Details
- Enhanced validation for maxTickPosition and minTickPosition values
- Added disableBlackBar flag to properly manage bar coloring
- Modified chart rendering logic to only display colors within the user-defined range