### PR TITLE
[GSW-2272] properly handle zero values for min/maxTickPosition

### DIFF
--- a/packages/web/src/components/common/bar-area-graph/BarAreaGraph.tsx
+++ b/packages/web/src/components/common/bar-area-graph/BarAreaGraph.tsx
@@ -32,6 +32,7 @@ export interface BarAreaGraphProps {
   pool: PoolModel;
   positionBins: PoolBinModel[];
   poolBins: PoolBinModel[];
+  disableBlackBars: boolean;
 }
 
 const VIEWPORT_DEFAULT_WIDTH = 400;
@@ -50,6 +51,7 @@ const BarAreaGraph: React.FC<BarAreaGraphProps> = ({
   themeKey,
   pool,
   poolBins,
+  disableBlackBars,
 }) => {
   const isHideBar = useMemo(() => {
     const isAllReserveZeroBin40 = poolBins.every(
@@ -81,6 +83,7 @@ const BarAreaGraph: React.FC<BarAreaGraphProps> = ({
         isPosition
         binsMyAmount={positionBins}
         disabled={isHideBar}
+        disableBlackBars={disableBlackBars}
       />
     </BarAreaGraphWrapper>
   );

--- a/packages/web/src/components/common/my-position-card-list/my-position-card/MyPositionCard.tsx
+++ b/packages/web/src/components/common/my-position-card-list/my-position-card/MyPositionCard.tsx
@@ -239,7 +239,7 @@ const MyPositionCard: React.FC<MyPositionCardProps> = ({
   };
 
   const getMinTick = useMemo(() => {
-    if (!minTickPosition) {
+    if (minTickPosition == null) {
       return null;
     }
     if (minTickPosition < 0) {
@@ -252,7 +252,7 @@ const MyPositionCard: React.FC<MyPositionCardProps> = ({
   }, [minTickPosition]);
 
   const getMaxTick = useMemo(() => {
-    if (!maxTickPosition) {
+    if (maxTickPosition == null) {
       return null;
     }
     if (maxTickPosition < 0) {
@@ -402,6 +402,7 @@ const MyPositionCard: React.FC<MyPositionCardProps> = ({
                     maxTickRate={maxTickRate}
                     pool={pool}
                     positionBins={positionBins}
+                    disableBlackBars={false}
                   />
                 </div>
                 <div className="min-max-price">

--- a/packages/web/src/components/common/pool-graph/PoolGraph.tsx
+++ b/packages/web/src/components/common/pool-graph/PoolGraph.tsx
@@ -309,14 +309,14 @@ const PoolGraph: React.FC<PoolGraphProps> = ({
       const depositTokenAAmountStr = currentBin?.reserveTokenAMyAmount;
       const depositTokenBAmountStr = currentBin?.reserveTokenBMyAmount;
       let disabledBin = !!(
-        maxTickPosition &&
-        minTickPosition &&
+        maxTickPosition != null &&
+        minTickPosition != null &&
         (scaleX(currentBin.minTick) < minTickPosition - binSpacing || scaleX(currentBin.minTick) > maxTickPosition)
       );
       if (isReversed) {
         disabledBin = !!(
-          maxTickPosition &&
-          minTickPosition &&
+          maxTickPosition != null &&
+          minTickPosition != null &&
           (scaleX(currentBin.minTick) < scaleX(maxX) - maxTickPosition - binSpacing ||
             scaleX(currentBin.minTick) > scaleX(maxX) - minTickPosition)
         );

--- a/packages/web/src/components/common/pool-graph/pool-graph-svg/PoolGraphSVG.tsx
+++ b/packages/web/src/components/common/pool-graph/pool-graph-svg/PoolGraphSVG.tsx
@@ -120,15 +120,15 @@ const PoolGraphSVG = forwardRef<SVGSVGElement, PoolGraphSVGProps>(
         }
 
         let isBlackBar = !!(
-          maxTickPosition !== null &&
-          minTickPosition !== null &&
+          maxTickPosition != null &&
+          minTickPosition != null &&
           (scaleX(bin.minTick) < minTickPosition - binSpacing || scaleX(bin.minTick) > maxTickPosition)
         );
 
         if (isReversed) {
           isBlackBar = !!(
-            maxTickPosition !== null &&
-            minTickPosition !== null &&
+            maxTickPosition != null &&
+            minTickPosition != null &&
             (scaleX(bin.minTick) < scaleX(maxX) - maxTickPosition - binSpacing ||
               scaleX(bin.minTick) > scaleX(maxX) - minTickPosition)
           );


### PR DESCRIPTION
## Description
This PR fixes a bug where tick positions with a value of `0` are treated as invalid values, causing visual bugs in graphs

## Details
- Replace `!minTickPosition` and `!maxTickPosition` checks with explicit `== null` checks
- Standardize null checks using `!= null` instead of `!== null` for consistency
- Add `disableBlackBars` flag to control black bar visibility in graphs
- Apply the same logic to Earn > My Range graphs for consistent behavior