### PR TITLE
[GSW-2275] SendAmount

### DIFF
--- a/packages/web/src/repositories/position/position.message.ts
+++ b/packages/web/src/repositories/position/position.message.ts
@@ -20,6 +20,7 @@ import { TokenModel } from "@models/token/token-model";
 import { checkGnotPath, isGNOTPath, wrapNativeTokenPath } from "@utils/common";
 import { MAX_INT64 } from "@utils/math.utils";
 import { makeRawTokenAmount } from "@utils/token-utils";
+import { getSendAmount } from "@utils/transaction-utils";
 import BigNumber from "bignumber.js";
 
 enum TransactionMessageFunctionType {
@@ -308,8 +309,7 @@ export function makeIncreaseLiquidityMessagesWithApproves(
   const tokenAAmountRaw = makeRawTokenAmount(tokenA, tokenAAmount) || "0";
   const tokenBAmountRaw = makeRawTokenAmount(tokenB, tokenBAmount) || "0";
 
-  const sendAmount =
-    tokenAWrappedPath === WRAPPED_GNOT_PATH ? tokenAAmountRaw : tokenBWrappedPath ? tokenBAmountRaw : null;
+  const sendAmount = getSendAmount(tokenAWrappedPath, tokenBWrappedPath, tokenAAmountRaw, tokenBAmountRaw);
 
   // Make Approve messages that can be managed by a Pool package of tokens.
   const approveMessageInfos: TokenApproveMessageInfo[] = [
@@ -470,8 +470,7 @@ export function makeRepositionLiquidityMessagesWithApproves(
     },
   ];
 
-  const sendAmount =
-    tokenAWrappedPath === WRAPPED_GNOT_PATH ? tokenAAmountRaw : tokenBWrappedPath ? tokenBAmountRaw : null;
+  const sendAmount = getSendAmount(tokenAWrappedPath, tokenBWrappedPath, tokenAAmountRaw, tokenBAmountRaw);
   const send = makeGNOTSendAmount(sendAmount);
 
   const slippageRatio = (100 - slippage) / 100;

--- a/packages/web/src/utils/transaction-utils.ts
+++ b/packages/web/src/utils/transaction-utils.ts
@@ -7,7 +7,7 @@ import {
   TransactionMessage,
   WalletResponse,
 } from "@common/clients/wallet-client/protocols";
-import { DEFAULT_CHAIN_ID } from "@constants/environment.constant";
+import { DEFAULT_CHAIN_ID, WRAPPED_GNOT_PATH } from "@constants/environment.constant";
 import { DEFAULT_GAS_WANTED } from "@common/values";
 import { Document } from "src/types/transaction-messages.types";
 
@@ -199,4 +199,32 @@ export const generateSendTransactionParams = (params: SendTransactionRequestPara
     ...(gasWanted && { gasWanted }),
     ...(memo && { memo }),
   };
+};
+
+/**
+ * Checks if the given token path corresponds to the wrapped GNOT token path
+ *
+ * @param path - The token path to check
+ * @returns True if the path matches wrapped GNOT path, false otherwise
+ */
+export const isWrappedGnotPath = (path: string) => path === WRAPPED_GNOT_PATH;
+
+/**
+ * Determines the appropriate send amount when trading with wrapped GNOT
+
+ * @param {string} tokenAWrappedPath - The wrapped path of token A
+ * @param {string} tokenBWrappedPath - The wrapped path of token B
+ * @param {string} tokenAAmountRaw - The raw amount of token A
+ * @param {string} tokenBAmountRaw - The raw amount of token B
+ * @returns {string|null} The raw token amount to send if one of the tokens is wrapped GNOT, null otherwise
+ */
+export const getSendAmount = (
+  tokenAWrappedPath: string,
+  tokenBWrappedPath: string,
+  tokenAAmountRaw: string,
+  tokenBAmountRaw: string,
+) => {
+  if (isWrappedGnotPath(tokenAWrappedPath)) return tokenAAmountRaw;
+  if (isWrappedGnotPath(tokenBWrappedPath)) return tokenBAmountRaw;
+  return null;
 };


### PR DESCRIPTION
## Description
- This PR fixes a bug that causes the sendAmount to be set incorrectly when executing an IncreaseLiquidity transaction.

## Details
- Creating the `getSendAmount` Utility Function
- Common to sendAmount logic