### PR TITLE
[GSW-2289] Pool price chart data

### DIFF
--- a/packages/web/src/layouts/pool/pool-add/components/additional-info/AdditionalInfo.tsx
+++ b/packages/web/src/layouts/pool/pool-add/components/additional-info/AdditionalInfo.tsx
@@ -17,6 +17,7 @@ interface AdditionalInfoProps {
   unstakedPositions: PositionModel[];
   handleClickGotoStaking: (type: PAGE_PATH_TYPE) => void;
   pool: PoolDetailModel;
+  poolPath: string | null;
   biggestPool: PoolDetailModel;
   isLoadingPool: boolean;
   isLoadingGraph: boolean;
@@ -30,6 +31,7 @@ const AdditionalInfo: React.FC<AdditionalInfoProps> = ({
   unstakedPositions,
   handleClickGotoStaking,
   pool,
+  poolPath,
   biggestPool,
   isLoadingPool,
   isLoadingGraph,
@@ -53,6 +55,7 @@ const AdditionalInfo: React.FC<AdditionalInfoProps> = ({
         <ExchangeRateGraph
           breakpoint={breakpoint}
           poolData={biggestPool}
+          poolPath={poolPath}
           isLoading={isLoadingGraph}
           isReversed={isReversed}
         />

--- a/packages/web/src/layouts/pool/pool-add/components/additional-info/exchange-rate-graph/ExchangeRateGraph.tsx
+++ b/packages/web/src/layouts/pool/pool-add/components/additional-info/exchange-rate-graph/ExchangeRateGraph.tsx
@@ -8,6 +8,7 @@ import { CHART_DAY_SCOPE_TYPE } from "@constants/option.constant";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { PoolModel } from "@models/pool/pool-model";
 import { TokenExchangeRateGraphResponse } from "@repositories/token/response/token-exchange-rate-response";
+import { useGetPoolPriceByPath } from "@query/pools/use-get-pool-price-by-path";
 
 import ChartScopeSelectTab from "./chart-scope-select-tab/ChartScopeSelectTab";
 import ExchangeRateGraphContent from "./exchange-rate-graph-content/ExchangeRateGraphContent";
@@ -27,6 +28,7 @@ import { DEVICE_TYPE } from "@styles/media";
 interface ExchangeRateGraphProps {
   breakpoint: DEVICE_TYPE;
   poolData: PoolModel;
+  poolPath: string | null;
   isReversed: boolean;
   data?: TokenExchangeRateGraphResponse;
   isLoading: boolean;
@@ -36,6 +38,7 @@ interface ExchangeRateGraphProps {
 const ExchangeRateGraph: React.FC<ExchangeRateGraphProps> = ({
   breakpoint,
   poolData,
+  poolPath,
   isReversed,
   isLoading,
   defaultScope,
@@ -46,6 +49,10 @@ const ExchangeRateGraph: React.FC<ExchangeRateGraphProps> = ({
   const [currentPoint, setCurrentPoint] = useState<string | null>();
   const [active, setActive] = useState<boolean>(false);
   const [selectedScope, setSelectedScope] = useState<CHART_DAY_SCOPE_TYPE>(defaultScope ?? CHART_DAY_SCOPE_TYPE["7D"]);
+
+  const { data: { prices = [] } = {} } = useGetPoolPriceByPath(poolPath || "", selectedScope, {
+    enabled: !!poolPath,
+  });
 
   const changedPoolInfo = useMemo(() => {
     return isReversed === false
@@ -79,17 +86,17 @@ const ExchangeRateGraph: React.FC<ExchangeRateGraphProps> = ({
   const showChart = () => {
     if (!hasData) return <ExchangeChartNotFound>{t("common:noData")}</ExchangeChartNotFound>;
     return (
-      <ExchangeRateGraphContent
-        poolData={changedPoolInfo}
-        selectedScope={selectedScope}
-        isReversed={isReversed}
-        onMouseMove={data => {
-          setCurrentPoint(data?.value);
-        }}
-        onMouseOut={active => {
-          setActive(active);
-        }}
-      />
+      <>
+        <ExchangeRateGraphContent
+          pricesData={prices}
+          onMouseMove={data => {
+            setCurrentPoint(data?.value);
+          }}
+          onMouseOut={active => {
+            setActive(active);
+          }}
+        />
+      </>
     );
   };
 

--- a/packages/web/src/layouts/pool/pool-add/components/additional-info/exchange-rate-graph/exchange-rate-graph-content/ExchangeRateGraphContent.tsx
+++ b/packages/web/src/layouts/pool/pool-add/components/additional-info/exchange-rate-graph/exchange-rate-graph-content/ExchangeRateGraphContent.tsx
@@ -3,15 +3,14 @@ import { useTranslation } from "react-i18next";
 
 import LineGraph from "@components/common/line-graph/LineGraph";
 import { LANGUAGE_CODE_MAP } from "@constants/common.constant";
-import { CHART_DAY_SCOPE_TYPE } from "@constants/option.constant";
 import { useTheme } from "@emotion/react";
 import useComponentSize from "@hooks/common/use-component-size";
 import { useWindowSize } from "@hooks/common/use-window-size";
-import { PoolDetailModel } from "@models/pool/pool-detail-model";
 import { DEVICE_TYPE } from "@styles/media";
 import { getLocalizeTime, parseDate } from "@utils/chart";
 
 import { ExchangeRateGraphContentWrapper, ExchangeRateGraphXAxisWrapper } from "./ExchangeRateGraphContent.styles";
+import { IPoolPriceRatioItem } from "@models/pool/pool-model";
 
 interface LineGraphData {
   value: string;
@@ -19,91 +18,32 @@ interface LineGraphData {
 }
 
 interface ExchangeRateGraphContentProps {
-  poolData: PoolDetailModel;
-  selectedScope: CHART_DAY_SCOPE_TYPE;
-  isReversed: boolean;
+  pricesData: IPoolPriceRatioItem[];
   onMouseMove?: (data?: LineGraphData) => void;
   onMouseOut?: (active: boolean) => void;
 }
 
-export function ExchangeRateGraphContent({
-  poolData,
-  selectedScope,
-  isReversed,
-  onMouseMove,
-  onMouseOut,
-}: ExchangeRateGraphContentProps) {
+export function ExchangeRateGraphContent({ pricesData, onMouseMove, onMouseOut }: ExchangeRateGraphContentProps) {
   const { i18n } = useTranslation();
   const theme = useTheme();
   const [componentRef, size] = useComponentSize();
   const { breakpoint } = useWindowSize();
 
-  const sortedRawDataByType = useMemo(() => {
-    const data = poolData.priceRatio;
-    let result = [];
-
-    switch (selectedScope) {
-      case "30D":
-        result = data?.["30d"];
-        break;
-      case "ALL":
-        result = data?.all;
-        break;
-      case "7D":
-      default:
-        result = data?.["7d"];
-        break;
-    }
-
-    return (result ?? [])?.sort((a, b) => {
-      return new Date(a.date).getTime() - new Date(b.date).getTime();
-    });
-  }, [poolData.priceRatio, selectedScope]);
-
-  const dataMemo = useMemo(() => {
-    const lastTime =
-      sortedRawDataByType.length >= 1 ? new Date(sortedRawDataByType[sortedRawDataByType.length - 1]?.date) : undefined;
-    const last2Time =
-      sortedRawDataByType.length >= 2 ? new Date(sortedRawDataByType[sortedRawDataByType.length - 2]?.date) : undefined;
-    const latestTimeGap = (() => {
-      if (lastTime && last2Time) return lastTime.getTime() - last2Time.getTime();
-    })();
-
-    const fakeLastTime = (() => {
-      if (lastTime && latestTimeGap) return new Date(lastTime.getTime() + latestTimeGap);
-
-      return new Date();
-    })();
-
-    const dataByType = [
-      ...sortedRawDataByType,
-      {
-        date: fakeLastTime.toString(),
-        ratio: poolData.price,
-      },
-    ];
-
-    return dataByType?.map((item, index) => {
-      const value = (() => {
-        if (!item.ratio || item.ratio === "0") return "0";
-
-        if (index === dataByType.length - 1) return item.ratio.toString();
-
-        return isReversed ? (1 / Number(item.ratio)).toString() : item.ratio.toString();
-      })();
-
+  const pricesChartData = useMemo(() => {
+    if (!pricesData) return [];
+    return [...pricesData].reverse().map(item => {
       return {
-        value: value,
+        value: item.ratio,
         time: getLocalizeTime(item.date),
       };
     });
-  }, [isReversed, poolData.price, sortedRawDataByType]);
+  }, [pricesData]);
 
   const xAxisLabels = useMemo(() => {
-    return sortedRawDataByType?.map(item => parseDate(item.date, LANGUAGE_CODE_MAP[i18n.language]));
-  }, [sortedRawDataByType, i18n.language]);
+    return pricesChartData?.map(item => parseDate(item.time, LANGUAGE_CODE_MAP[i18n.language]));
+  }, [pricesChartData, i18n.language]);
 
-  const hasSingleData = useMemo(() => dataMemo?.length === 1, [dataMemo]);
+  const hasSingleData = useMemo(() => pricesChartData?.length === 1, [pricesChartData]);
 
   const countXAxis = useMemo(() => {
     if (hasSingleData) return 1;
@@ -149,7 +89,7 @@ export function ExchangeRateGraphContent({
             height={size.height - 36}
             color={theme.color.background04Hover}
             strokeWidth={1}
-            datas={dataMemo ?? []}
+            datas={pricesChartData ?? []}
             typeOfChart="exchange-rate"
             customData={{
               height: 36,
@@ -157,7 +97,7 @@ export function ExchangeRateGraphContent({
             }}
             showBaseLine
             showBaseLineLabels
-            isShowTooltip={false}
+            isShowTooltip={true}
             renderBottom={renderXAxis}
             onMouseOut={onMouseOut}
           />

--- a/packages/web/src/layouts/pool/pool-add/containers/additional-info-container/AdditionalInfoContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-add/containers/additional-info-container/AdditionalInfoContainer.tsx
@@ -127,6 +127,7 @@ const AdditionalInfoContainer: React.FC = () => {
       unstakedPositions={unstakedPositions}
       handleClickGotoStaking={handleClickGotoStaking}
       pool={data}
+      poolPath={poolPath}
       biggestPool={biggestPool}
       isLoadingPool={isLoadingRPCPoolInfo || isFetchingFeetierOfLiquidityMap || isLoadingPoolInfo || isLoadingPosition}
       isLoadingGraph={isLoadingBiggestPoolInfo}

--- a/packages/web/src/react-query/pools/use-get-pool-price-by-path.ts
+++ b/packages/web/src/react-query/pools/use-get-pool-price-by-path.ts
@@ -17,6 +17,8 @@ export const useGetPoolPriceByPath = (
     queryFn: async () => {
       return poolRepository.getPoolPriceByPoolPath(path, period);
     },
+    cacheTime: 1 * 60 * 1000,
+    staleTime: 1 * 60 * 1000,
     refetchOnMount: true,
     refetchOnReconnect: true,
     ...options,

--- a/packages/web/src/react-query/pools/use-get-pool-price-by-path.ts
+++ b/packages/web/src/react-query/pools/use-get-pool-price-by-path.ts
@@ -1,0 +1,24 @@
+import { UseQueryOptions, useQuery } from "@tanstack/react-query";
+
+import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
+
+import { QUERY_KEY } from "@query/query-keys";
+import { CHART_DAY_SCOPE_TYPE } from "@constants/option.constant";
+import { PoolPricesResponse } from "@repositories/pool";
+
+export const useGetPoolPriceByPath = (
+  path: string,
+  period?: CHART_DAY_SCOPE_TYPE,
+  options?: UseQueryOptions<PoolPricesResponse, Error>,
+) => {
+  const { poolRepository } = useGnoswapContext();
+  return useQuery<PoolPricesResponse, Error>({
+    queryKey: [QUERY_KEY.prices, path, period],
+    queryFn: async () => {
+      return poolRepository.getPoolPriceByPoolPath(path, period);
+    },
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+    ...options,
+  });
+};

--- a/packages/web/src/react-query/query-keys.ts
+++ b/packages/web/src/react-query/query-keys.ts
@@ -31,6 +31,7 @@ export enum QUERY_KEY {
   poolCreationFee = "poolCreationFee",
   poolDetail = "pool_details",
   bins = "bins",
+  prices = "prices",
   lazyBins = "lazyBins",
   initializeBins = "initializeBins",
   incentivizePools = "incentivizePools",

--- a/packages/web/src/repositories/pool/pool-repository-impl.ts
+++ b/packages/web/src/repositories/pool/pool-repository-impl.ts
@@ -12,6 +12,7 @@ import { PoolError } from "@common/errors/pool";
 import { DEFAULT_GAS_FEE } from "@common/values";
 import { PACKAGE_POOL_PATH, PACKAGE_STAKER_PATH } from "@constants/environment.constant";
 import { GnoProvider } from "@gnolang/gno-js-client";
+import { CHART_DAY_SCOPE_TYPE } from "@constants/option.constant";
 import { PoolMapper } from "@models/pool/mapper/pool-mapper";
 import { PoolRPCMapper } from "@models/pool/mapper/pool-rpc-mapper";
 import { PoolStakingMapper } from "@models/pool/mapper/pool-staking-mapper";
@@ -22,7 +23,7 @@ import { IncentivizePoolModel, PoolModel } from "@models/pool/pool-model";
 import { PoolStakingModel } from "@models/pool/pool-staking";
 import { evaluateExpressionToNumber, evaluateExpressionToObject, makeABCIParams } from "@utils/rpc-utils";
 import { withTransactionGuard, generateSendTransactionParams } from "@utils/transaction-utils";
-import { PoolListResponse, PoolRepository, PoolResponse } from ".";
+import { PoolListResponse, PoolPricesResponse, PoolRepository, PoolResponse } from ".";
 import {
   makeCreateExternalIncentiveMessageWithApproves,
   makeCreatePoolMessageWithApproves,
@@ -196,6 +197,18 @@ export class PoolRepositoryImpl implements PoolRepository {
     return this.networkClient
       .get<{ data: PoolBinModel[] }>({
         url: `/pools/${encodeURIComponent(poolPath)}/bins?binSize=${count || 40}`,
+      })
+      .then(response => response.data.data);
+  };
+
+  getPoolPriceByPoolPath = async (poolPath: string, period?: CHART_DAY_SCOPE_TYPE): Promise<PoolPricesResponse> => {
+    if (!this.networkClient) {
+      throw new CommonError("FAILED_INITIALIZE_PROVIDER");
+    }
+
+    return this.networkClient
+      .get<{ data: PoolPricesResponse }>({
+        url: `/pools/${encodeURIComponent(poolPath)}/prices?period=${period || CHART_DAY_SCOPE_TYPE["7D"]}`,
       })
       .then(response => response.data.data);
   };

--- a/packages/web/src/repositories/pool/pool-repository-mock.ts
+++ b/packages/web/src/repositories/pool/pool-repository-mock.ts
@@ -1,4 +1,4 @@
-import { PoolRepository } from ".";
+import { PoolPricesResponse, PoolRepository } from ".";
 
 import { SendTransactionResponse, WalletResponse } from "@common/clients/wallet-client/protocols";
 import { PoolError } from "@common/errors/pool";
@@ -12,6 +12,7 @@ import { PoolStakingModel } from "@models/pool/pool-staking";
 import PoolDetailDataByPath from "./mock/pool-detai-by-path.json";
 import PoolDetailData from "./mock/pool-detail.json";
 import rpcPools from "./mock/rpc-pools.json";
+import { CHART_DAY_SCOPE_TYPE } from "@constants/option.constant";
 export class PoolRepositoryMock implements PoolRepository {
   getWithdrawalFee = async (): Promise<number> => {
     return 0;
@@ -70,6 +71,12 @@ export class PoolRepositoryMock implements PoolRepository {
     console.log(poolPath);
 
     return PoolDetailDataByPath as IPoolDetailResponse;
+  };
+
+  getPoolPriceByPoolPath = async (poolPath: string, period?: CHART_DAY_SCOPE_TYPE): Promise<PoolPricesResponse> => {
+    console.log(poolPath, period);
+
+    return { prices: [] };
   };
 
   createExternalIncentive = async (): Promise<WalletResponse<SendTransactionResponse<string[] | null>> | null> => {

--- a/packages/web/src/repositories/pool/pool-repository.ts
+++ b/packages/web/src/repositories/pool/pool-repository.ts
@@ -10,6 +10,8 @@ import { CreatePoolFailedResponse, CreatePoolSuccessResponse } from "./response/
 import { SendTransactionResponse, WalletResponse } from "@common/clients/wallet-client/protocols";
 import { PoolBinModel } from "@models/pool/pool-bin-model";
 import { PoolStakingModel } from "@models/pool/pool-staking";
+import { PoolPricesResponse } from "./response";
+import { CHART_DAY_SCOPE_TYPE } from "@constants/option.constant";
 
 export interface PoolRepository {
   getPools: () => Promise<PoolModel[]>;
@@ -27,6 +29,8 @@ export interface PoolRepository {
   getPoolDetailByPoolPath: (poolPath: string) => Promise<PoolDetailModel>;
 
   getBinsOfPoolByPath: (poolPath: string, count?: number) => Promise<PoolBinModel[]>;
+
+  getPoolPriceByPoolPath: (poolPath: string, period?: CHART_DAY_SCOPE_TYPE) => Promise<PoolPricesResponse>;
 
   createPool: (
     request: CreatePoolRequest,

--- a/packages/web/src/repositories/pool/response/index.ts
+++ b/packages/web/src/repositories/pool/response/index.ts
@@ -1,2 +1,3 @@
 export * from "./pool-list-response";
 export * from "./pool-detail-response";
+export * from "./pool-prices-response";

--- a/packages/web/src/repositories/pool/response/pool-prices-response.ts
+++ b/packages/web/src/repositories/pool/response/pool-prices-response.ts
@@ -1,6 +1,5 @@
+import { IPoolPriceRatioItem } from "@models/pool/pool-model";
+
 export interface PoolPricesResponse {
-  prices: {
-    date: string;
-    ratio: string;
-  }[];
+  prices: IPoolPriceRatioItem[];
 }

--- a/packages/web/src/repositories/pool/response/pool-prices-response.ts
+++ b/packages/web/src/repositories/pool/response/pool-prices-response.ts
@@ -1,0 +1,6 @@
+export interface PoolPricesResponse {
+  prices: {
+    date: string;
+    ratio: string;
+  }[];
+}


### PR DESCRIPTION
## Description
This PR implements a new API endpoint for retrieving pool price data and modifies the response format to integrate with the chart component.

## Details
- Add new endpoint `/pools/{poolPath}/prices` (GET)
- Implement `getPoolPriceByPoolPath` method in PoolRepository interface
- Set up HTTP GET request via network client
- Define PoolPriceResponse type
- Modify data format from:
  ```typescript
  // as-is
  {
    ratio: string;
    date: string;
  }

  // to-be
  {
    value: string;
    time: string;
  }