### PR TITLE
[GSW-2323] Add onSuccess callback for confirmation-driven refetch in Tx events

### DIFF
--- a/packages/web/src/hooks/common/use-invalidate-queries.ts
+++ b/packages/web/src/hooks/common/use-invalidate-queries.ts
@@ -1,0 +1,29 @@
+import React from "react";
+import { useQueryClient, QueryKey } from "@tanstack/react-query";
+
+/**
+ * Hook to invalidate the React Query cache to automatically trigger refetching.
+ */
+export function useInvalidateQueries() {
+  const queryClient = useQueryClient();
+
+  /**
+   * Triggers React Query to automatically fetch data again in the background by invalidating the given query keys.
+   */
+  const invalidateQueryKey = React.useCallback(
+    async (context: string, queryKeys: QueryKey[]) => {
+      const results = await Promise.allSettled(queryKeys.map(queryKey => queryClient.invalidateQueries(queryKey)));
+
+      const failures = results
+        .map((r, i) => (r.status === "rejected" ? { idx: i, err: r.reason } : null))
+        .filter((x): x is { idx: number; err: unknown } => x !== null);
+
+      failures.forEach(({ idx, err }) =>
+        console.warn(`${context}: invalidateQueries failed for key[${idx}]:`, queryKeys[idx], err),
+      );
+    },
+    [queryClient],
+  );
+
+  return { invalidateQueryKey };
+}

--- a/packages/web/src/hooks/common/use-transaction-event-store.ts
+++ b/packages/web/src/hooks/common/use-transaction-event-store.ts
@@ -36,6 +36,7 @@ export const useTransactionEventStore = () => {
     formatData = () => ({}),
     onUpdate = async () => {},
     onEmit,
+    onSuccess,
   }: {
     txHash?: string;
     action: DexEventType;
@@ -49,6 +50,7 @@ export const useTransactionEventStore = () => {
     };
     onUpdate?: () => Promise<void>;
     onEmit?: () => Promise<void>;
+    onSuccess?: () => Promise<void>;
   }) {
     if (!txHash) {
       return;
@@ -71,6 +73,10 @@ export const useTransactionEventStore = () => {
         if (visibleEmitResult && event.status === "SUCCESS") {
           wait<boolean>(async () => true, TX_RESULT_SNACKBAR_TIMEOUT).then(() => {
             enqueue({ txHash: message.txHash }, updatingSnackbarConfig);
+
+            if (onSuccess !== undefined) {
+              onSuccess();
+            }
 
             if (alreadyEmitted) {
               change(updatingSnackbarConfig.id, "updating-done");

--- a/packages/web/src/hooks/pool/ui/use-decrease-position-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-decrease-position-modal.tsx
@@ -13,12 +13,14 @@ import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 import { useMessage } from "@hooks/common/use-message";
 import { useTransactionEventStore } from "@hooks/common/use-transaction-event-store";
 import { TokenModel } from "@models/token/token-model";
-import { useGetPoolList, useRefetchGetPoolDetailByPath } from "@query/pools";
 import { DexEvent } from "@repositories/common";
 import { DecreaseLiquiditySuccessResponse } from "@repositories/position/response";
 import { CommonState } from "@states/index";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
+import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
+import { QUERY_KEY } from "@query/query-keys";
+import { wait } from "@utils/common";
 
 import DecreasePositionModalContainer from "../../../layouts/pool/pool-decrease-liquidity/containers/decrease-position-modal-container/DecreasePositionModalContainer";
 import { IPooledTokenInfo } from "../data/use-decrease-handle";
@@ -63,15 +65,15 @@ export const useDecreasePositionModal = ({
   calculatedLiquidity,
   pooledTokenInfos,
   isGetWGNOT,
-  refetchPositions,
 }: DecreasePositionModal): Props => {
-  const { walletClient } = useWallet();
+  const { walletClient, currentChainId } = useWallet();
   const router = useRouter();
   const { address } = useAddress();
   const clearModal = useClearModal();
 
   const { positionRepository, transactionService } = useGnoswapContext();
   const { estimateNetworkFee } = useNetworkFee(null);
+  const { invalidateQueryKey } = useInvalidateQueries();
 
   const onSuccessClose = useCallback(() => {
     clearModal();
@@ -81,13 +83,21 @@ export const useDecreasePositionModal = ({
   const { broadcastRejected, broadcastSuccess, broadcastLoading, broadcastError } = useBroadcastHandler();
   const { enqueueEvent } = useTransactionEventStore();
 
+  const poolPath = makePoolPath(tokenA, tokenB, swapFeeTier);
+
   // Refetch functions
   const { updateBalances } = useTokenData();
-  const { refetch: refetchPools } = useGetPoolList();
-  const { refetch: refetchPoolDetails } = useRefetchGetPoolDetailByPath(makePoolPath(tokenA, tokenB, swapFeeTier));
 
   const [, setOpenedModal] = useAtom(CommonState.openedModal);
   const [, setModalContent] = useAtom(CommonState.modalContent);
+
+  const handleRefreshData = useCallback(async () => {
+    invalidateQueryKey("DecreasePosition", [
+      [QUERY_KEY.pools],
+      [QUERY_KEY.positions, currentChainId, address],
+      [QUERY_KEY.poolDetail, poolPath],
+    ]);
+  }, [invalidateQueryKey, poolPath, currentChainId, address]);
 
   const { getMessage } = useMessage();
 
@@ -256,14 +266,14 @@ export const useDecreasePositionModal = ({
                 ),
               };
             },
-            onEmit: async () => {
-              refetchPools();
-              refetchPositions();
-              refetchPoolDetails();
-            },
             onUpdate: async () => {
               updateBalances();
             },
+            onEmit: async () => {
+              await wait(async () => true, 5000);
+              handleRefreshData();
+            },
+            onSuccess: handleRefreshData,
           });
         }
 

--- a/packages/web/src/hooks/pool/ui/use-decrease-position-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-decrease-position-modal.tsx
@@ -20,7 +20,7 @@ import { makeDisplayTokenAmount } from "@utils/token-utils";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
 import { QUERY_KEY } from "@query/query-keys";
-import { wait } from "@utils/common";
+import { delay } from "@utils/common";
 
 import DecreasePositionModalContainer from "../../../layouts/pool/pool-decrease-liquidity/containers/decrease-position-modal-container/DecreasePositionModalContainer";
 import { IPooledTokenInfo } from "../data/use-decrease-handle";
@@ -270,7 +270,7 @@ export const useDecreasePositionModal = ({
               updateBalances();
             },
             onEmit: async () => {
-              await wait(async () => true, 5000);
+              await delay(5000);
               handleRefreshData();
             },
             onSuccess: handleRefreshData,

--- a/packages/web/src/hooks/pool/ui/use-increase-position-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-increase-position-modal.tsx
@@ -14,10 +14,10 @@ import { PoolPositionModel } from "@models/position/pool-position-model";
 import { TokenModel } from "@models/token/token-model";
 import { DexEvent } from "@repositories/common";
 import { CommonState } from "@states/index";
+import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
 
 import IncreasePositionModalContainer from "../../../layouts/pool/pool-increase-liquidity/containers/increase-position-modal-container/IncreasePositionModalContainer";
 import { useTransactionEventStore } from "@hooks/common/use-transaction-event-store";
-import { useGetPoolList, useRefetchGetPoolDetailByPath } from "@query/pools";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
 import { useTokenData } from "@hooks/token/data/use-token-data";
 import { BROADCAST_ERROR_VALUE } from "@common/errors/broadcast/broadcast-error";
@@ -28,6 +28,8 @@ import { fetchAllowance } from "@common/clients/wallet-client/transaction-messag
 import { makeIncreaseLiquidityMessagesWithApproves } from "@repositories/position/position.message";
 import { useNetworkFee } from "@hooks/common/use-network-fee";
 import { CommonError } from "@common/errors";
+import { QUERY_KEY } from "@query/query-keys";
+import { wait } from "@utils/common";
 
 export interface Props {
   openModal: () => void;
@@ -62,12 +64,12 @@ export const useIncreasePositionModal = ({
   rangeStatus,
   isDepositTokenA,
   isDepositTokenB,
-  refetchPositions,
 }: IncreasePositionModal): Props => {
-  const { walletClient } = useWallet();
+  const { walletClient, currentChainId } = useWallet();
   const { broadcastRejected, broadcastSuccess, broadcastLoading, broadcastError } = useBroadcastHandler();
   const { enqueueEvent } = useTransactionEventStore();
   const { estimateNetworkFee } = useNetworkFee(null);
+  const { invalidateQueryKey } = useInvalidateQueries();
 
   const router = useRouter();
   const { positionRepository, transactionService } = useGnoswapContext();
@@ -75,10 +77,18 @@ export const useIncreasePositionModal = ({
   const [, setOpenedModal] = useAtom(CommonState.openedModal);
   const [, setModalContent] = useAtom(CommonState.modalContent);
 
+  const poolPath = selectedPosition?.poolPath || "";
+
   // Refetch functions
   const { updateBalances } = useTokenData();
-  const { refetch: refetchPools } = useGetPoolList();
-  const { refetch: refetchPoolDetails } = useRefetchGetPoolDetailByPath(selectedPosition?.poolPath);
+
+  const handleRefreshData = useCallback(async () => {
+    invalidateQueryKey("IncreasePosition", [
+      [QUERY_KEY.pools],
+      [QUERY_KEY.positions, currentChainId, address],
+      [QUERY_KEY.poolDetail, poolPath],
+    ]);
+  }, [invalidateQueryKey, poolPath, currentChainId, address]);
 
   const onCloseConfirmTransactionModal = useCallback(() => {
     router.back();
@@ -199,14 +209,14 @@ export const useIncreasePositionModal = ({
               }),
             };
           },
-          onEmit: async () => {
-            refetchPools();
-            refetchPositions();
-            refetchPoolDetails();
-          },
           onUpdate: async () => {
             updateBalances();
           },
+          onEmit: async () => {
+            await wait(async () => true, 5000);
+            handleRefreshData();
+          },
+          onSuccess: handleRefreshData,
         });
       }
 

--- a/packages/web/src/hooks/pool/ui/use-increase-position-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-increase-position-modal.tsx
@@ -29,7 +29,7 @@ import { makeIncreaseLiquidityMessagesWithApproves } from "@repositories/positio
 import { useNetworkFee } from "@hooks/common/use-network-fee";
 import { CommonError } from "@common/errors";
 import { QUERY_KEY } from "@query/query-keys";
-import { wait } from "@utils/common";
+import { delay } from "@utils/common";
 
 export interface Props {
   openModal: () => void;
@@ -213,7 +213,7 @@ export const useIncreasePositionModal = ({
             updateBalances();
           },
           onEmit: async () => {
-            await wait(async () => true, 5000);
+            await delay(5000);
             handleRefreshData();
           },
           onSuccess: handleRefreshData,

--- a/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
@@ -40,7 +40,7 @@ import PoolAddConfirmModal from "@layouts/pool/pool-add/components/pool-add-conf
 import { BROADCAST_ERROR_VALUE } from "@common/errors/broadcast/broadcast-error";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 import { GnoProvider } from "@common/clients/gno-provider/gno-provider";
-import { wait } from "@utils/common";
+import { delay } from "@utils/common";
 
 export interface EarnAddLiquidityConfirmModalProps {
   tokenA: TokenModel | null;
@@ -385,7 +385,7 @@ export const usePoolAddLiquidityConfirmModal = ({
                 updateBalances();
               },
               onEmit: async () => {
-                await wait(async () => true, 5000);
+                await delay(5000);
                 handleRefreshData();
               },
               onSuccess: handleRefreshData,

--- a/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
@@ -2,7 +2,9 @@ import BigNumber from "bignumber.js";
 import { useAtom } from "jotai";
 import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { useQueryClient } from "@tanstack/react-query";
 
+import { QUERY_KEY } from "@query/query-keys";
 import { WalletResponse } from "@common/clients/wallet-client/protocols";
 import { ERROR_VALUE } from "@common/errors/adena";
 import { GNS_TOKEN } from "@common/values/token-constant";
@@ -16,7 +18,7 @@ import { SelectPool } from "@hooks/pool/data/use-select-pool";
 import { TokenAmountInputModel } from "@hooks/token/data/use-token-amount-input";
 import { useTokenData } from "@hooks/token/data/use-token-data";
 import { TokenModel } from "@models/token/token-model";
-import { useGetPoolCreationFee, useGetPoolList, useRefetchGetPoolDetailByPath } from "@query/pools";
+import { useGetPoolCreationFee } from "@query/pools";
 import { DexEvent } from "@repositories/common";
 import {
   AddLiquidityFailedResponse,
@@ -29,15 +31,16 @@ import { formatTokenExchangeRate } from "@utils/stake-position-utils";
 import { priceToNearTick } from "@utils/swap-utils";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
 import { useReferral } from "@hooks/common/use-referral";
+import { useWallet } from "@hooks/wallet/data/use-wallet";
 
 import { useAddress } from "@hooks/common/use-address";
 import { useTransactionEventStore } from "@hooks/common/use-transaction-event-store";
-import { useGetPositionsByAddress } from "@query/positions";
 import OneClickStakingModal from "@layouts/pool/pool-add/components/one-click-staking-modal/OneClickStakingModal";
 import PoolAddConfirmModal from "@layouts/pool/pool-add/components/pool-add-confirm-modal/PoolAddConfirmModal";
 import { BROADCAST_ERROR_VALUE } from "@common/errors/broadcast/broadcast-error";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 import { GnoProvider } from "@common/clients/gno-provider/gno-provider";
+import { wait } from "@utils/common";
 
 export interface EarnAddLiquidityConfirmModalProps {
   tokenA: TokenModel | null;
@@ -95,9 +98,11 @@ export const usePoolAddLiquidityConfirmModal = ({
 }: EarnAddLiquidityConfirmModalProps): SelectTokenModalModel => {
   const { t } = useTranslation();
   const { rpcProvider } = useGnoswapContext();
+  const queryClient = useQueryClient();
   const { broadcastLoading, broadcastRejected, broadcastSuccess, broadcastError } = useBroadcastHandler();
   const { enqueueEvent } = useTransactionEventStore();
   const { removeReferrerFromLocalStorage } = useReferral();
+  const { currentChainId } = useWallet();
 
   const { getMessage } = useMessage();
 
@@ -108,16 +113,25 @@ export const usePoolAddLiquidityConfirmModal = ({
   // Refetch functions
   const { address } = useAddress();
   const { updateBalances } = useTokenData();
-  const { refetch: refetchAccountPositions } = useGetPositionsByAddress({
-    address,
-  });
-  const { refetch: refetchPoolPositions } = useGetPositionsByAddress({
-    poolPath: selectPool.poolPath,
-  });
-  const { refetch: refetchPools } = useGetPoolList();
-  const { refetch: refetchPoolDetails } = useRefetchGetPoolDetailByPath(selectPool.poolPath);
+
   const [openedModal, setOpenedModal] = useAtom(CommonState.openedModal);
   const [, setModalContent] = useAtom(CommonState.modalContent);
+
+  const invalidateAndRefreshPoolPositionData = useCallback(async () => {
+    const poolPath = selectPool.poolPath || "";
+
+    const results = await Promise.allSettled([
+      queryClient.invalidateQueries([QUERY_KEY.positions, currentChainId, address]),
+      queryClient.invalidateQueries([QUERY_KEY.pools]),
+      queryClient.invalidateQueries([QUERY_KEY.poolDetail, poolPath]),
+    ]);
+
+    const errors = results
+      .map(result => (result.status === "rejected" ? result.reason : null))
+      .filter(error => error !== null);
+
+    errors.forEach((e, idx) => console.warn(`invalidateAndRefreshPoolData [${idx}]`, e.reason));
+  }, [queryClient, selectPool.poolPath, currentChainId, address]);
 
   const tokenAAmount = useMemo(() => {
     const depositRatio = selectPool.depositRatio;
@@ -373,15 +387,14 @@ export const usePoolAddLiquidityConfirmModal = ({
                   }),
                 };
               },
-              onEmit: async () => {
-                refetchPools();
-                refetchAccountPositions();
-                refetchPoolPositions();
-                refetchPoolDetails();
-              },
               onUpdate: async () => {
                 updateBalances();
               },
+              onEmit: async () => {
+                await wait(async () => true, 5000);
+                invalidateAndRefreshPoolPositionData();
+              },
+              onSuccess: invalidateAndRefreshPoolPositionData,
             });
           }
 

--- a/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
@@ -2,7 +2,6 @@ import BigNumber from "bignumber.js";
 import { useAtom } from "jotai";
 import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { useQueryClient } from "@tanstack/react-query";
 
 import { QUERY_KEY } from "@query/query-keys";
 import { WalletResponse } from "@common/clients/wallet-client/protocols";
@@ -32,6 +31,7 @@ import { priceToNearTick } from "@utils/swap-utils";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
 import { useReferral } from "@hooks/common/use-referral";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
+import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
 
 import { useAddress } from "@hooks/common/use-address";
 import { useTransactionEventStore } from "@hooks/common/use-transaction-event-store";
@@ -98,7 +98,6 @@ export const usePoolAddLiquidityConfirmModal = ({
 }: EarnAddLiquidityConfirmModalProps): SelectTokenModalModel => {
   const { t } = useTranslation();
   const { rpcProvider } = useGnoswapContext();
-  const queryClient = useQueryClient();
   const { broadcastLoading, broadcastRejected, broadcastSuccess, broadcastError } = useBroadcastHandler();
   const { enqueueEvent } = useTransactionEventStore();
   const { removeReferrerFromLocalStorage } = useReferral();
@@ -116,22 +115,17 @@ export const usePoolAddLiquidityConfirmModal = ({
 
   const [openedModal, setOpenedModal] = useAtom(CommonState.openedModal);
   const [, setModalContent] = useAtom(CommonState.modalContent);
+  const { invalidateQueryKey } = useInvalidateQueries();
 
-  const invalidateAndRefreshPoolPositionData = useCallback(async () => {
+  const handleRefreshData = useCallback(async () => {
     const poolPath = selectPool.poolPath || "";
 
-    const results = await Promise.allSettled([
-      queryClient.invalidateQueries([QUERY_KEY.positions, currentChainId, address]),
-      queryClient.invalidateQueries([QUERY_KEY.pools]),
-      queryClient.invalidateQueries([QUERY_KEY.poolDetail, poolPath]),
+    invalidateQueryKey("AddLiquidity", [
+      [QUERY_KEY.positions, currentChainId, address],
+      [QUERY_KEY.pools],
+      [QUERY_KEY.poolDetail, poolPath],
     ]);
-
-    const errors = results
-      .map(result => (result.status === "rejected" ? result.reason : null))
-      .filter(error => error !== null);
-
-    errors.forEach((e, idx) => console.warn(`invalidateAndRefreshPoolData [${idx}]`, e.reason));
-  }, [queryClient, selectPool.poolPath, currentChainId, address]);
+  }, [invalidateQueryKey, selectPool.poolPath, currentChainId, address]);
 
   const tokenAAmount = useMemo(() => {
     const depositRatio = selectPool.depositRatio;
@@ -392,9 +386,9 @@ export const usePoolAddLiquidityConfirmModal = ({
               },
               onEmit: async () => {
                 await wait(async () => true, 5000);
-                invalidateAndRefreshPoolPositionData();
+                handleRefreshData();
               },
-              onSuccess: invalidateAndRefreshPoolPositionData,
+              onSuccess: handleRefreshData,
             });
           }
 

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -15,7 +15,7 @@ import { DexEvent } from "@repositories/common";
 import { formatOtherPrice } from "@utils/new-number-utils";
 import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
 import { QUERY_KEY } from "@query/query-keys";
-import { wait } from "@utils/common";
+import { delay } from "@utils/common";
 
 import { useTransactionEventStore } from "@hooks/common/use-transaction-event-store";
 import { PoolPositionModel } from "@models/position/pool-position-model";
@@ -151,7 +151,7 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ address = "
                 updateBalances();
               },
               onEmit: async () => {
-                await wait(async () => true, 5000);
+                await delay(5000);
                 handleRefreshData();
               },
               onSuccess: handleRefreshData,
@@ -205,7 +205,7 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ address = "
               await updateBalances();
             },
             onEmit: async () => {
-              await wait(async () => true, 5000);
+              await delay(5000);
               handleRefreshData();
             },
             onSuccess: handleRefreshData,

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -13,6 +13,9 @@ import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { useGetUsernameByAddress } from "@query/address";
 import { DexEvent } from "@repositories/common";
 import { formatOtherPrice } from "@utils/new-number-utils";
+import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
+import { QUERY_KEY } from "@query/query-keys";
+import { wait } from "@utils/common";
 
 import { useTransactionEventStore } from "@hooks/common/use-transaction-event-store";
 import { PoolPositionModel } from "@models/position/pool-position-model";
@@ -26,13 +29,13 @@ interface MyLiquidityContainerProps {
   isStakable: boolean;
 }
 
-const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ address, isStakable }) => {
+const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ address = "", isStakable }) => {
   const { rpcProvider } = useGnoswapContext();
 
   const router = useRouter();
   const divRef = useRef<HTMLDivElement | null>(null);
   const { breakpoint } = useWindowSize();
-  const { connected: connectedWallet, isSwitchNetwork, account } = useWallet();
+  const { connected: connectedWallet, isSwitchNetwork, account, currentChainId } = useWallet();
   const [currentIndex, setCurrentIndex] = useState(1);
   const poolPath = router.getPoolPath();
   const {
@@ -46,6 +49,15 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ address, is
       enabled: !!poolPath,
     },
   });
+
+  const { invalidateQueryKey } = useInvalidateQueries();
+
+  const handleRefreshData = useCallback(async () => {
+    invalidateQueryKey("MyLiquidity, Claim", [
+      [QUERY_KEY.tokenBalancesByAddress, address],
+      [QUERY_KEY.positions, currentChainId, address],
+    ]);
+  }, [invalidateQueryKey, currentChainId, address]);
 
   const { claimAll, claim } = usePosition(positions.filter(item => !item.closed));
   const [loadingTransactionClaim, setLoadingTransactionClaim] = useState(false);
@@ -136,13 +148,13 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ address, is
                 return messageData;
               },
               onUpdate: async () => {
-                await refetchGrc20Balances();
-                await updateBalances();
+                updateBalances();
               },
               onEmit: async () => {
-                await refetchGrc20Balances();
-                await refetchPositions();
+                await wait(async () => true, 5000);
+                handleRefreshData();
               },
+              onSuccess: handleRefreshData,
             });
           }
 
@@ -193,9 +205,10 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ address, is
               await updateBalances();
             },
             onEmit: async () => {
-              await refetchGrc20Balances();
-              await refetchPositions();
+              await wait(async () => true, 5000);
+              handleRefreshData();
             },
+            onSuccess: handleRefreshData,
           });
         }
 

--- a/packages/web/src/layouts/pool/pool-remove/containers/remove-position-modal-container/RemovePositionModalContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-remove/containers/remove-position-modal-container/RemovePositionModalContainer.tsx
@@ -23,6 +23,10 @@ import { useNetworkFee } from "@hooks/common/use-network-fee";
 import { fetchAllowance } from "@common/clients/wallet-client/transaction-messages";
 import { CommonError } from "@common/errors";
 import { makeRemoveLiquidityMessagesWithApproves } from "@repositories/position/position.message";
+import { useAddress } from "@hooks/common/use-address";
+import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
+import { QUERY_KEY } from "@query/query-keys";
+import { wait } from "@utils/common";
 
 import { usePositionsRewards } from "@hooks/pool/data/use-positions-rewards";
 import RemovePositionModal from "../../components/remove-position-modal/RemovePositionModal";
@@ -44,14 +48,18 @@ const RemovePositionModalContainer = ({
   positionLiquidities,
   refetchPositions,
 }: RemovePositionModalContainerProps) => {
-  const { account, walletClient } = useWallet();
+  const { account, walletClient, currentChainId } = useWallet();
+  const { address } = useAddress();
   const { transactionService, positionRepository } = useGnoswapContext();
   const { estimateNetworkFee } = useNetworkFee(null);
+  const { invalidateQueryKey } = useInvalidateQueries();
 
   const router = useRouter();
   const clearModal = useClearModal();
   const { broadcastRejected, broadcastSuccess, broadcastLoading, broadcastError } = useBroadcastHandler();
   const { enqueueEvent } = useTransactionEventStore();
+
+  const poolPath = selectedPositions?.[0]?.poolPath || "";
 
   // Refetch functions
   const { updateBalances } = useTokenData();
@@ -60,6 +68,14 @@ const RemovePositionModalContainer = ({
   const { pooledTokenInfos, unclaimedFees } = usePositionsRewards({
     positions: selectedPositions,
   });
+
+  const handleRefreshData = useCallback(async () => {
+    invalidateQueryKey("RemovePosition", [
+      [QUERY_KEY.pools],
+      [QUERY_KEY.positions, currentChainId, address],
+      [QUERY_KEY.poolDetail, poolPath],
+    ]);
+  }, [invalidateQueryKey, poolPath, currentChainId, address]);
 
   const onCloseConfirmTransactionModal = useCallback(() => {
     clearModal();
@@ -194,14 +210,14 @@ const RemovePositionModalContainer = ({
                 }
                 return broadcastMessageData;
               },
-              onEmit: async () => {
-                refetchPools();
-                refetchPositions();
-                refetchPoolDetails();
-              },
               onUpdate: async () => {
                 updateBalances();
               },
+              onEmit: async () => {
+                await wait(async () => true, 5000);
+                handleRefreshData();
+              },
+              onSuccess: handleRefreshData,
             });
           }
           if (result.code === 0) {

--- a/packages/web/src/layouts/pool/pool-remove/containers/remove-position-modal-container/RemovePositionModalContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-remove/containers/remove-position-modal-container/RemovePositionModalContainer.tsx
@@ -16,7 +16,7 @@ import { PoolPositionModel } from "@models/position/pool-position-model";
 import { TokenModel } from "@models/token/token-model";
 import { useGetPoolList, useRefetchGetPoolDetailByPath } from "@query/pools";
 import { DexEvent } from "@repositories/common";
-import { checkGnotPath } from "@utils/common";
+import { checkGnotPath, delay } from "@utils/common";
 import { formatPoolPairAmount } from "@utils/new-number-utils";
 import { RemoveLiquidityRequest } from "@repositories/position/request";
 import { useNetworkFee } from "@hooks/common/use-network-fee";
@@ -26,7 +26,6 @@ import { makeRemoveLiquidityMessagesWithApproves } from "@repositories/position/
 import { useAddress } from "@hooks/common/use-address";
 import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
 import { QUERY_KEY } from "@query/query-keys";
-import { wait } from "@utils/common";
 
 import { usePositionsRewards } from "@hooks/pool/data/use-positions-rewards";
 import RemovePositionModal from "../../components/remove-position-modal/RemovePositionModal";
@@ -214,7 +213,7 @@ const RemovePositionModalContainer = ({
                 updateBalances();
               },
               onEmit: async () => {
-                await wait(async () => true, 5000);
+                await delay(5000);
                 handleRefreshData();
               },
               onSuccess: handleRefreshData,

--- a/packages/web/src/layouts/pool/pool-stake/containers/stake-position-modal-container/StakePositionModalContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-stake/containers/stake-position-modal-container/StakePositionModalContainer.tsx
@@ -22,7 +22,7 @@ import { useNetworkFee } from "@hooks/common/use-network-fee";
 import { useAddress } from "@hooks/common/use-address";
 import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
 import { QUERY_KEY } from "@query/query-keys";
-import { wait } from "@utils/common";
+import { delay } from "@utils/common";
 
 import StakePositionModal from "../../components/stake-position-modal/StakePositionModal";
 
@@ -184,7 +184,7 @@ const StakePositionModalContainer = ({ positions, refetchPositions }: StakePosit
               updateBalances();
             },
             onEmit: async () => {
-              await wait(async () => true, 5000);
+              await delay(5000);
               handleRefreshData();
             },
             onSuccess: handleRefreshData,

--- a/packages/web/src/layouts/pool/pool-stake/containers/stake-position-modal-container/StakePositionModalContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-stake/containers/stake-position-modal-container/StakePositionModalContainer.tsx
@@ -19,6 +19,10 @@ import { useReferral } from "@hooks/common/use-referral";
 import { StakePositionsRequest } from "@repositories/position/request";
 import { makeStakePositionsMessagesWithApproves } from "@repositories/position/position.message";
 import { useNetworkFee } from "@hooks/common/use-network-fee";
+import { useAddress } from "@hooks/common/use-address";
+import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
+import { QUERY_KEY } from "@query/query-keys";
+import { wait } from "@utils/common";
 
 import StakePositionModal from "../../components/stake-position-modal/StakePositionModal";
 
@@ -28,26 +32,38 @@ interface StakePositionModalContainerProps {
 }
 
 const StakePositionModalContainer = ({ positions, refetchPositions }: StakePositionModalContainerProps) => {
-  const { account, walletClient } = useWallet();
+  const router = useCustomRouter();
+  const { account, walletClient, currentChainId } = useWallet();
+  const { address } = useAddress();
   const { broadcastRejected, broadcastSuccess, broadcastLoading, broadcastError } = useBroadcastHandler();
   const { enqueueEvent } = useTransactionEventStore();
 
+  const poolPath = router.getPoolPath();
+
   // Refetch functions
+  const { invalidateQueryKey } = useInvalidateQueries();
   const { refetch: refetchPools } = useGetPoolList();
-  const { refetch: refetchPoolDetails } = useRefetchGetPoolDetailByPath(positions?.[0]?.poolPath);
+  const { refetch: refetchPoolDetails } = useRefetchGetPoolDetailByPath(poolPath);
 
   const { transactionService, positionRepository } = useGnoswapContext();
   const { estimateNetworkFee } = useNetworkFee(null);
-  const router = useCustomRouter();
+
   const { getCurrentReferralAddress, removeReferrerFromLocalStorage } = useReferral();
   const clearModal = useClearModal();
   const { updateBalances, tokenPrices } = useTokenData();
-  const poolPath = router.getPoolPath();
   const { data: pool } = useGetPoolDetailByPath(poolPath, {
     enabled: !!poolPath,
   });
 
   const { getMessage } = useMessage();
+
+  const handleRefreshData = useCallback(async () => {
+    invalidateQueryKey("StakePosition", [
+      [QUERY_KEY.pools],
+      [QUERY_KEY.positions, currentChainId, address],
+      [QUERY_KEY.poolDetail, poolPath],
+    ]);
+  }, [invalidateQueryKey, poolPath, currentChainId, address]);
 
   const onCloseConfirmTransactionModal = useCallback(() => {
     clearModal();
@@ -164,14 +180,14 @@ const StakePositionModalContainer = ({ positions, refetchPositions }: StakePosit
                 isKMB: false,
               }),
             }),
-            onEmit: async () => {
-              refetchPools();
-              refetchPositions();
-              refetchPoolDetails();
-            },
             onUpdate: async () => {
               updateBalances();
             },
+            onEmit: async () => {
+              await wait(async () => true, 5000);
+              handleRefreshData();
+            },
+            onSuccess: handleRefreshData,
           });
         }
         if (result.code === 0) {

--- a/packages/web/src/layouts/portfolio/containers/wallet-balance-container/WalletBalanceContainer.tsx
+++ b/packages/web/src/layouts/portfolio/containers/wallet-balance-container/WalletBalanceContainer.tsx
@@ -24,6 +24,10 @@ import { toUnitFormat } from "@utils/number-utils";
 import { isEmptyObject } from "@utils/validation-utils";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { PositionConverter } from "@services/converters/position";
+import { useAddress } from "@hooks/common/use-address";
+import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
+import { QUERY_KEY } from "@query/query-keys";
+import { wait } from "@utils/common";
 
 import AssetSendModal from "../../components/asset-send-modal/AssetSendModal";
 import WalletBalance from "../../components/wallet-balance/WalletBalance";
@@ -33,7 +37,8 @@ import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 
 const WalletBalanceContainer: React.FC = () => {
   const { rpcProvider } = useGnoswapContext();
-  const { connected, isSwitchNetwork, loadingConnect, account, walletType } = useWallet();
+  const { connected, isSwitchNetwork, loadingConnect, account, walletType, currentChainId } = useWallet();
+  const { address: userAddress = "" } = useAddress();
   const [address] = useState("");
   const { breakpoint } = useWindowSize();
   const [isShowDepositModal, setIsShowDepositModal] = useState(false);
@@ -44,9 +49,18 @@ const WalletBalanceContainer: React.FC = () => {
   const [sendAssetAmount, setSendAssetAmount] = useState("");
 
   const { data: blockTimeData } = useGetAvgBlockTime();
-  const { balances: balancesPrice, loadingBalance, updateBalances, refetchGrc20Balances } = useTokenData();
+  const { balances: balancesPrice, loadingBalance, updateBalances } = useTokenData();
 
-  const { positions, loading: loadingPositions, refetch: refetchPositions } = usePositionData();
+  const { positions, loading: loadingPositions } = usePositionData();
+
+  const { invalidateQueryKey } = useInvalidateQueries();
+
+  const handleRefreshData = useCallback(async () => {
+    invalidateQueryKey("WalletBalance, ClaimAll", [
+      [QUERY_KEY.tokenBalancesByAddress, userAddress],
+      [QUERY_KEY.positions, currentChainId, userAddress],
+    ]);
+  }, [invalidateQueryKey, currentChainId, userAddress]);
 
   const isClaimablePosition = (position: PoolPositionModel) => position.liquidity > 0 && !position.closed;
 
@@ -110,13 +124,13 @@ const WalletBalanceContainer: React.FC = () => {
             action: DexEvent.CLAIM_FEE,
             formatData: () => messageData,
             onUpdate: async () => {
-              await refetchGrc20Balances();
-              await updateBalances();
+              updateBalances();
             },
             onEmit: async () => {
-              await refetchGrc20Balances();
-              await refetchPositions();
+              await wait(async () => true, 5000);
+              handleRefreshData();
             },
+            onSuccess: handleRefreshData,
           });
         }
         if (response?.code === 0) {

--- a/packages/web/src/layouts/portfolio/containers/wallet-balance-container/WalletBalanceContainer.tsx
+++ b/packages/web/src/layouts/portfolio/containers/wallet-balance-container/WalletBalanceContainer.tsx
@@ -27,7 +27,7 @@ import { PositionConverter } from "@services/converters/position";
 import { useAddress } from "@hooks/common/use-address";
 import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
 import { QUERY_KEY } from "@query/query-keys";
-import { wait } from "@utils/common";
+import { delay } from "@utils/common";
 
 import AssetSendModal from "../../components/asset-send-modal/AssetSendModal";
 import WalletBalance from "../../components/wallet-balance/WalletBalance";
@@ -127,7 +127,7 @@ const WalletBalanceContainer: React.FC = () => {
               updateBalances();
             },
             onEmit: async () => {
-              await wait(async () => true, 5000);
+              await delay(5000);
               handleRefreshData();
             },
             onSuccess: handleRefreshData,

--- a/packages/web/src/react-query/positions/use-get-positions-by-address.ts
+++ b/packages/web/src/react-query/positions/use-get-positions-by-address.ts
@@ -7,7 +7,7 @@ import { PositionModel } from "@models/position/position-model";
 
 import { QUERY_KEY } from "../query-keys";
 
-const REFETCH_INTERVAL = 60_000;
+const REFETCH_INTERVAL = 5_000;
 
 interface UseGetPositionsByAddressProps {
   address?: string;

--- a/packages/web/src/react-query/positions/use-get-positions-by-address.ts
+++ b/packages/web/src/react-query/positions/use-get-positions-by-address.ts
@@ -7,7 +7,7 @@ import { PositionModel } from "@models/position/position-model";
 
 import { QUERY_KEY } from "../query-keys";
 
-const REFETCH_INTERVAL = 5_000;
+const REFETCH_INTERVAL = 60_000;
 
 interface UseGetPositionsByAddressProps {
   address?: string;

--- a/packages/web/src/utils/common.ts
+++ b/packages/web/src/utils/common.ts
@@ -31,7 +31,6 @@ export function wait<T>(runner: () => Promise<T>, waitTime = 1000, finishTime = 
   });
 }
 
-// common.ts
 export function delay<T = void>(ms: number, returnValue?: T): Promise<T> {
   return new Promise(resolve => setTimeout(() => resolve(returnValue as T), ms));
 }

--- a/packages/web/src/utils/common.ts
+++ b/packages/web/src/utils/common.ts
@@ -31,6 +31,11 @@ export function wait<T>(runner: () => Promise<T>, waitTime = 1000, finishTime = 
   });
 }
 
+// common.ts
+export function delay<T = void>(ms: number, returnValue?: T): Promise<T> {
+  return new Promise(resolve => setTimeout(() => resolve(returnValue as T), ms));
+}
+
 export function makeId(value: string) {
   return encodeURIComponent(value);
 }


### PR DESCRIPTION
## Description
This PR enhances the transaction event handling by introducing an explicit onSuccess callback that runs after the blockchain transaction is confirmed, decoupling it from the initial “emit” phase

## Details
- Executes only once the transaction status is SUCCESS, ensuring UI updates and data refetches occur after on-chain confirmation rather than immediately on emit.
- Reliable refetch with React Query invalidation

