### PR TITLE
[GSW-2281] Disable browser notification(Adena Action)

### DIFF
--- a/packages/web/src/common/clients/wallet-client/adena/adena-client.ts
+++ b/packages/web/src/common/clients/wallet-client/adena/adena-client.ts
@@ -92,7 +92,7 @@ export class AdenaClient implements WalletClient {
     };
     return createTimeout<WalletResponse<SendTransactionResponse<T | null>>>(
       this.getAdena()
-        .DoContract(request)
+        .DoContract(request, false)
         .then(response => {
           console.log("Injection Response", response);
           return parseTransactionResponse(response) as WalletResponse<SendTransactionResponse<T | null>>;

--- a/packages/web/src/common/clients/wallet-client/adena/adena.ts
+++ b/packages/web/src/common/clients/wallet-client/adena/adena.ts
@@ -1,7 +1,10 @@
 export interface Adena {
   AddEstablish: (name: string) => Promise<Response>;
   GetAccount: () => Promise<Response<AccountInfo>>;
-  DoContract: (mesasage: SendTransactionRequestParam) => Promise<Response<AdenaSendTransactionResponse>>;
+  DoContract: (
+    mesasage: SendTransactionRequestParam,
+    withNotification: boolean,
+  ) => Promise<Response<AdenaSendTransactionResponse>>;
   Sign: (mesasage: SendTransactionRequestParam) => Promise<Response>;
   AddNetwork: (chain: AdenaAddNetworkRequestParam) => Promise<Response<AdenaAddNetworkResponse>>;
   SwitchNetwork: (chainId: string) => Promise<Response<AdenaSwitchNetworkResponse>>;


### PR DESCRIPTION
## Background
Adena wallet currently supports Chrome notifications by default (https://github.com/onbloc/adena-wallet/pull/734). However, some dApps like Gnoswap have their own notification systems, which can create a poor user experience when both notifications are active simultaneously.

## Changes
- Add boolean configuration option to enable/disable Chrome notifications
- Allow dApps to control notification behavior based on their own notification flow
- Prevent duplicate notifications that could harm user experience