### PR TITLE
[GSW-2325] Earn Page UI issue

### DIFF
--- a/packages/web/src/components/common/calendar/Calendar.tsx
+++ b/packages/web/src/components/common/calendar/Calendar.tsx
@@ -55,7 +55,7 @@ const Calendar: React.FC<CalendarProps> = ({
     const currentDateWithoutTime = new Date(today.getFullYear(), today.getMonth(), today.getDate());
     const checkDateWithoutTime = new Date(checkDate.getFullYear(), checkDate.getMonth(), checkDate.getDate());
 
-    return currentDateWithoutTime <= checkDateWithoutTime;
+    return currentDateWithoutTime < checkDateWithoutTime;
   }
 
   const getCurrent = useCallback(() => {

--- a/packages/web/src/components/common/calendar/Calendar.tsx
+++ b/packages/web/src/components/common/calendar/Calendar.tsx
@@ -49,9 +49,13 @@ const Calendar: React.FC<CalendarProps> = ({
   }
 
   function verifyDate(date: number) {
-    const crDate = new Date();
-    const checkDate = new Date(`${currentDate.year}-${currentDate.month}-${date}`);
-    return crDate <= checkDate;
+    const today = new Date();
+    const checkDate = new Date(currentDate.year, currentDate.month - 1, date);
+
+    const currentDateWithoutTime = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    const checkDateWithoutTime = new Date(checkDate.getFullYear(), checkDate.getMonth(), checkDate.getDate());
+
+    return currentDateWithoutTime <= checkDateWithoutTime;
   }
 
   const getCurrent = useCallback(() => {

--- a/packages/web/src/components/common/pool-graph/PoolGraph.tsx
+++ b/packages/web/src/components/common/pool-graph/PoolGraph.tsx
@@ -90,7 +90,6 @@ const PoolGraph: React.FC<PoolGraphProps> = ({
 
   // D3 - Dimension Definition
   const defaultMinX = React.useMemo(() => Math.min(...bins.map(bin => bin.minTick)), [bins]);
-
   const reservedBins: ReservedBin[] = useMemo(() => {
     const length = bins.length / 2;
     const fullLength = length * 2;
@@ -324,13 +323,13 @@ const PoolGraph: React.FC<PoolGraphProps> = ({
 
       const tokenAAmount = tokenAAmountStr
         ? formatTokenExchangeRate(tokenAAmountStr.toString(), {
-            maxSignificantDigits: 6,
+            maxSignificantDigits: tokenA.decimals + 1,
             minLimit: 0.000001,
           })
         : "-";
       const tokenBAmount = tokenBAmountStr
         ? formatTokenExchangeRate(tokenBAmountStr.toString(), {
-            maxSignificantDigits: 6,
+            maxSignificantDigits: tokenB.decimals + 1,
             minLimit: 0.000001,
           })
         : "-";
@@ -340,7 +339,7 @@ const PoolGraph: React.FC<PoolGraphProps> = ({
           : index > 19 && `${currentBin.reserveTokenAMyAmount}` === "0"
           ? "<0.000001"
           : formatTokenExchangeRate(depositTokenAAmountStr.toString(), {
-              maxSignificantDigits: 6,
+              maxSignificantDigits: tokenA.decimals + 1,
               minLimit: 0.000001,
             }) || "-";
       const depositTokenBAmount =
@@ -349,7 +348,7 @@ const PoolGraph: React.FC<PoolGraphProps> = ({
           : index < 20 && `${currentBin.reserveTokenBMyAmount}` === "0"
           ? "<0.000001"
           : formatTokenExchangeRate(depositTokenBAmountStr.toString(), {
-              maxSignificantDigits: 6,
+              maxSignificantDigits: tokenB.decimals + 1,
               minLimit: 0.000001,
             }) || "-";
 
@@ -394,7 +393,7 @@ const PoolGraph: React.FC<PoolGraphProps> = ({
               });
 
               acc[current] = formatTokenExchangeRate(priceStr, {
-                maxSignificantDigits: 6,
+                maxSignificantDigits: 7,
                 minLimit: 0.000001,
                 isInfinite: priceStr === "∞",
               });

--- a/packages/web/src/components/common/pool-graph/pool-graph-svg/PoolGraphSVG.tsx
+++ b/packages/web/src/components/common/pool-graph/pool-graph-svg/PoolGraphSVG.tsx
@@ -148,20 +148,6 @@ const PoolGraphSVG = forwardRef<SVGSVGElement, PoolGraphSVGProps>(
       const rects = d3.select(chartRef.current);
       rects.attr("clip-path", "url(#clip)");
 
-      // D3 - Draw Current tick (middle line)
-      rects.select("line").remove();
-      if (hasCurrentTick && rects.select("line").empty()) {
-        rects
-          .append("line")
-          .attr("x1", currentTickPosition)
-          .attr("x2", currentTickPosition)
-          .attr("y1", 0)
-          .attr("y2", boundsHeight)
-          .attr("stroke-dasharray", 3)
-          .attr("stroke", `${themeKey === "dark" ? "#E0E8F4" : "#596782"}`)
-          .attr("stroke-width", 1);
-      }
-
       // D3 - Draw reservedBins as bars
       rects.selectAll("g").remove();
       if (!disabled && rects.selectAll("g").size() === 0 && reservedBins.length > 0) {
@@ -217,6 +203,20 @@ const PoolGraphSVG = forwardRef<SVGSVGElement, PoolGraphSVGProps>(
                 );
               });
           });
+      }
+
+      // D3 - Draw Current tick (middle line)
+      rects.select("line").remove();
+      if (hasCurrentTick && rects.select("line").empty()) {
+        rects
+          .append("line")
+          .attr("x1", currentTickPosition)
+          .attr("x2", currentTickPosition)
+          .attr("y1", 0)
+          .attr("y2", boundsHeight)
+          .attr("stroke-dasharray", 3)
+          .attr("stroke", `${themeKey === "dark" ? "#E0E8F4" : "#596782"}`)
+          .attr("stroke-width", 1);
       }
     }
 

--- a/packages/web/src/components/common/pool-selection-graph/PoolSelectionGraph.tsx
+++ b/packages/web/src/components/common/pool-selection-graph/PoolSelectionGraph.tsx
@@ -657,7 +657,7 @@ const PoolSelectionGraph: React.FC<PoolSelectionGraphProps> = ({
     if (!!width && !!height && !!scaleX && !!scaleY) {
       updateChart();
     }
-  }, [width, height, svgRef?.current, chartRef?.current, resolvedDisplayBins, hoverBarIndex]);
+  }, [minPrice, maxPrice, width, height, svgRef?.current, chartRef?.current, resolvedDisplayBins, hoverBarIndex]);
 
   // Brush settings, on currentPrice change, zoom, move ...
   useEffect(() => {

--- a/packages/web/src/layouts/earn/components/pool-list/pool-list-table/pool-info/PoolInfo.tsx
+++ b/packages/web/src/layouts/earn/components/pool-list/pool-list-table/pool-info/PoolInfo.tsx
@@ -8,7 +8,7 @@ import { POOL_INFO, POOL_INFO_MOBILE, POOL_INFO_SMALL_TABLET, POOL_INFO_TABLET }
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { PoolListInfo } from "@models/pool/info/pool-list-info";
 import { DEVICE_TYPE } from "@styles/media";
-import { formatRate } from "@utils/new-number-utils";
+import { formatOtherPrice, formatRate } from "@utils/new-number-utils";
 import { getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
 
 import PoolInfoLazyChart from "./pool-info-lazy-chart/PoolInfoLazyChart";
@@ -19,6 +19,9 @@ import { useGetPoolStakingListByPoolPath } from "@query/pools";
 import { useTokenPriceInfo } from "@hooks/token/data/use-token-price-info";
 import { cx } from "@emotion/css";
 import PriceWarning from "@components/common/price-warning/PriceWarning";
+import { TokenModel } from "@models/token/token-model";
+import { checkGnotPath } from "@utils/common";
+import { useTokenData } from "@hooks/token/data/use-token-data";
 
 interface PoolInfoProps {
   pool: PoolListInfo;
@@ -28,6 +31,8 @@ interface PoolInfoProps {
 }
 
 const PoolInfo: React.FC<PoolInfoProps> = ({ pool, routeItem, breakpoint }) => {
+  const { tokenPrices } = useTokenData();
+
   const {
     poolId,
     tokenA,
@@ -96,6 +101,43 @@ const PoolInfo: React.FC<PoolInfoProps> = ({ pool, routeItem, breakpoint }) => {
       ? POOL_INFO_TABLET
       : POOL_INFO;
 
+  /**
+   * Checks if either token has missing price information
+   */
+  const anyEmptyPrice = React.useCallback(
+    (tokenA: TokenModel, tokenB: TokenModel) =>
+      !tokenPrices?.[checkGnotPath(tokenA.priceID)]?.usd || !tokenPrices?.[checkGnotPath(tokenB.priceID)]?.usd,
+    [tokenPrices],
+  );
+
+  /**
+   * Format pool value with proper formatting or fallback to "-" when price data is missing
+   */
+  const formatPoolValue = React.useCallback(
+    (value: string | number | undefined, tokenA: TokenModel, tokenB: TokenModel, decimals?: number) => {
+      if (anyEmptyPrice(tokenA, tokenB)) return "-";
+
+      return formatOtherPrice(value || 0, {
+        isKMB: false,
+        decimals: decimals ?? 0,
+      });
+    },
+    [anyEmptyPrice],
+  );
+
+  const tvlDisplay = useMemo(() => {
+    const decimals = Number(tvl) < 0.01 ? 2 : 0;
+    return formatPoolValue(tvl, tokenA, tokenB, decimals);
+  }, [tvl, tokenA, tokenB]);
+
+  const volume24hDisplay = useMemo(() => {
+    return formatPoolValue(volume24h, tokenA, tokenB);
+  }, [volume24h, tokenA, tokenB]);
+
+  const fees24hDisplay = useMemo(() => {
+    return formatPoolValue(fees24h, tokenA, tokenB);
+  }, [fees24h, tokenA, tokenB]);
+
   const aprDisplay = useMemo(() => {
     if (tvl === "<$0.01" && apr) return "0%";
     return (
@@ -121,16 +163,16 @@ const PoolInfo: React.FC<PoolInfoProps> = ({ pool, routeItem, breakpoint }) => {
       </TableColumn>
       {/* TVL */}
       <TableColumn tdWidth={cellWidths.list[1].width} className={columnClassName}>
-        <span className="liquidity">{tvl}</span>
+        <span className="liquidity">{tvlDisplay}</span>
         {shouldShowPriceWarning && hasPriceInformational && <PriceWarning type="TVL" />}
       </TableColumn>
       {/* Volume (24h) */}
       <TableColumn tdWidth={cellWidths.list[2].width} className={columnClassName}>
-        <span className="volume">{volume24h}</span>
+        <span className="volume">{volume24hDisplay}</span>
       </TableColumn>
       {/* Fee (24h) */}
       <TableColumn tdWidth={cellWidths.list[3].width} className={columnClassName}>
-        <span className="fees">{fees24h}</span>
+        <span className="fees">{fees24hDisplay}</span>
       </TableColumn>
       {/* APR */}
       <TableColumn tdWidth={cellWidths.list[4].width} className={columnClassName}>

--- a/packages/web/src/layouts/earn/containers/pool-list-container/PoolListContainer.tsx
+++ b/packages/web/src/layouts/earn/containers/pool-list-container/PoolListContainer.tsx
@@ -11,7 +11,6 @@ import { PoolListInfo } from "@models/pool/info/pool-list-info";
 import { TokenModel } from "@models/token/token-model";
 import { CommonState, ThemeState } from "@states/index";
 import { checkGnotPath } from "@utils/common";
-import { formatOtherPrice } from "@utils/new-number-utils";
 import { TOKEN_PRICE_GRADE_TYPE } from "@models/token/token-price-grade";
 
 import PoolList from "../../components/pool-list/PoolList";
@@ -66,21 +65,6 @@ const PoolListContainer: React.FC = () => {
   useEffect(() => {
     setPage(0);
   }, [keyword, poolType]);
-
-  /**
-   * Format pool value with proper formatting or fallback to "-" when price data is missing
-   */
-  const formatPoolValue = useCallback(
-    (value: string | number | undefined, tokenA: TokenModel, tokenB: TokenModel) => {
-      if (anyEmptyPrice(tokenA, tokenB)) return "-";
-
-      return formatOtherPrice(value || 0, {
-        isKMB: false,
-        decimals: 0,
-      });
-    },
-    [anyEmptyPrice],
-  );
 
   /**
    * Check if pool info matches the search keyword
@@ -162,16 +146,12 @@ const PoolListContainer: React.FC = () => {
 
         return {
           ...item,
-          liquidity: formatPoolValue(item.liquidity, item.tokenA, item.tokenB),
-          volume24h: formatPoolValue(item.volume24h, item.tokenA, item.tokenB),
-          fees24h: formatPoolValue(item.fees24h, item.tokenA, item.tokenB),
-          tvl: formatPoolValue(item.tvl, item.tokenA, item.tokenB),
           apr: anyEmptyPrice(item.tokenA, item.tokenB) ? "" : item.apr,
           tokenAPriceGrade,
           tokenBPriceGrade,
         };
       });
-  }, [poolListInfos, keyword, poolType, anyEmptyPrice, matchesKeyword, filteredPoolType, formatPoolValue]);
+  }, [poolListInfos, keyword, poolType, anyEmptyPrice, matchesKeyword, filteredPoolType]);
 
   /**
    * Sort filtered pools based on current sort option

--- a/packages/web/src/layouts/pool/pool-detail/PoolDetail.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/PoolDetail.tsx
@@ -23,16 +23,26 @@ const PoolDetail: React.FC = () => {
 
   const { initializedData, hash } = useUrlParam<{ addr: string | undefined }>({ addr: undefined });
 
-  const address = useMemo(() => {
-    const address = initializedData?.addr;
-    if (!address || !isValidAddress(address)) {
-      return account?.address;
-    }
-    return address;
-  }, [initializedData, account]);
+  const urlAddress = useMemo(() => {
+    if (!initializedData?.addr) return "";
+
+    return isValidAddress(initializedData.addr) ? initializedData.addr : "";
+  }, [initializedData?.addr]);
+
+  const connectAddress = useMemo(() => {
+    return account?.address || "";
+  }, [account?.address]);
+
+  const addressContext = useMemo(() => {
+    return {
+      urlAddress,
+      connectAddress,
+      isOwner: urlAddress ? urlAddress === connectAddress : true,
+    };
+  }, [urlAddress, connectAddress]);
 
   const { isFetchedPosition, loading, positions } = usePositionData({
-    address,
+    address: urlAddress ?? connectAddress,
     poolPath,
     queryOption: {
       enabled: !!poolPath,
@@ -107,7 +117,7 @@ const PoolDetail: React.FC = () => {
     <PoolLayout
       header={<HeaderContainer />}
       poolPairInformation={<PoolPairInformationContainer />}
-      liquidity={<MyLiquidityContainer address={address} isStakable={isStakable} />}
+      liquidity={<MyLiquidityContainer addressContext={addressContext} isStakable={isStakable} />}
       staking={isStakable ? <StakingContainer hasPoolStaking={hasPoolStaking} /> : null}
       footer={<Footer />}
       isStaking={isStakable}

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.tsx
@@ -12,6 +12,7 @@ import { MyLiquidityWrapper, MyLiquidityWrapperAnchor, PoolDivider } from "./MyL
 
 interface MyLiquidityProps {
   address: string | null;
+  isOwnerAddress: boolean;
   addressName: string;
   isOtherPosition: boolean;
   openedPosition: PoolPositionModel[];
@@ -40,6 +41,7 @@ interface MyLiquidityProps {
 const MyLiquidity: React.FC<MyLiquidityProps> = ({
   isOtherPosition,
   address,
+  isOwnerAddress,
   addressName,
   openedPosition,
   breakpoint,
@@ -119,6 +121,7 @@ const MyLiquidity: React.FC<MyLiquidityProps> = ({
                 isHiddenAddPosition={isHiddenAddPosition}
                 connected={connected}
                 tokenPrices={tokenPrices}
+                isOwnerAddress={isOwnerAddress}
                 claim={claim}
               />
             ))}
@@ -138,6 +141,7 @@ const MyLiquidity: React.FC<MyLiquidityProps> = ({
                     isHiddenAddPosition={isHiddenAddPosition}
                     connected={connected}
                     tokenPrices={tokenPrices}
+                    isOwnerAddress={isOwnerAddress}
                     claim={claim}
                   />
                 ))}

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
@@ -70,6 +70,7 @@ interface MyDetailedPositionCardProps {
   isHiddenAddPosition: boolean;
   connected: boolean;
   tokenPrices: Record<string, TokenPriceModel>;
+  isOwnerAddress: boolean;
 
   claim: (position: PoolPositionModel) => void;
 }
@@ -83,6 +84,7 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
   isHiddenAddPosition,
   connected,
   tokenPrices,
+  isOwnerAddress,
   claim,
 }) => {
   const router = useRouter();
@@ -354,8 +356,8 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
   }, [position]);
 
   const isClaimable = useMemo(() => {
-    return positionWithClaimableRewards.rewards.length > 0;
-  }, [positionWithClaimableRewards.rewards]);
+    return isOwnerAddress && positionWithClaimableRewards.rewards.length > 0;
+  }, [isOwnerAddress, positionWithClaimableRewards.rewards]);
 
   const totalDailyEarning = useMemo(() => {
     const isEmpty = !totalRewardInfo || position.rewards.length === 0;

--- a/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/StakingContent.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/StakingContent.tsx
@@ -57,6 +57,7 @@ const StakingContent: React.FC<StakingContentProps> = ({
   const { t } = useTranslation();
 
   const { ref, entry } = useIntersectionObserver();
+  const isTargetElementVisible = entry?.isIntersecting === true;
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   const debounce = (func: Function, delay: number) => {
@@ -153,7 +154,9 @@ const StakingContent: React.FC<StakingContentProps> = ({
             <AprStakingHeader $isMobile={mobile}>
               <Tooltip
                 FloatingContent={<IncentivizeTokenDetailTooltipContent poolStakings={poolStakings} />}
-                forcedClose={!pool?.incentivized || pool.rewardTokens.length === 0 || !hasPoolStaking}
+                forcedClose={
+                  !pool?.incentivized || pool.rewardTokens.length === 0 || !hasPoolStaking || !isTargetElementVisible
+                }
                 placement="top"
                 className="apr-text"
                 scroll
@@ -167,7 +170,7 @@ const StakingContent: React.FC<StakingContentProps> = ({
                     isVisible &&
                     forcedShowAprGuide
                   }
-                  forcedClose={!forcedShowAprGuide || !hasPoolStaking}
+                  forcedClose={!forcedShowAprGuide || !hasPoolStaking || !isTargetElementVisible}
                   placement="top"
                   FloatingContent={
                     <span style={{ fontSize: breakpoint === "mobile" ? 14 : 16 }}>

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -25,12 +25,21 @@ import { PositionConverter } from "@services/converters/position";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 
 interface MyLiquidityContainerProps {
-  address?: string | undefined;
+  addressContext: {
+    urlAddress: string;
+    connectAddress: string;
+    isOwner: boolean;
+  };
   isStakable: boolean;
 }
 
-const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ address = "", isStakable }) => {
+const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable, addressContext }) => {
   const { rpcProvider } = useGnoswapContext();
+  const { urlAddress, connectAddress } = addressContext;
+
+  const address = useMemo(() => {
+    return urlAddress || connectAddress;
+  }, [urlAddress, connectAddress]);
 
   const router = useRouter();
   const divRef = useRef<HTMLDivElement | null>(null);
@@ -262,7 +271,8 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ address = "
 
   return (
     <MyLiquidity
-      address={address || account?.address || null}
+      address={address}
+      isOwnerAddress={addressContext.isOwner}
       addressName={addressName}
       isOtherPosition={isOtherPosition}
       openedPosition={visiblePositions ? openedPosition : []}


### PR DESCRIPTION
## Description
This PR fixes UI issues on the Earn page.

## Details
- Issue where dotted area is hidden when liquidity bars are in negative range 
- "Hover to view details" tooltip following cursor issue needs fixing
- (Mobile) Date selection not working in Earn > Incentive
- Claim button visible and active when accessing other accounts' position pages -> Claim button should only be visible and active when wallet is connected and position Owner matches the connected wallet address
- When small amounts remain in pool causing TVL to display as <$0.01, process as <$0.01 in Earn > Pool table as well (to apply Informational TVL Grade effect)
- Fix incorrect fee name displayed as "Router Fee"
- Add Position > Liquidity chart
- Current price needs to be fixed at center
- When TVL exists but supplementary data like APR, Trading Volume, Fees have no values, display as $0 for consistency (currently some show as "-" as shown in image)
- Token quantities should not be rounded, but quantities shown on hover in charts are currently being rounded (*see attached image). Please verify.