### PR TITLE
fix(dashboard): rename gnsTotalSupply to gnsMaxSupply

### DIFF
--- a/packages/web/src/common/values/default-object/explore-dashboard/dashboard-token-info.ts
+++ b/packages/web/src/common/values/default-object/explore-dashboard/dashboard-token-info.ts
@@ -7,5 +7,5 @@ export const DEFAULT_DASHBOARD_TOKEN_INFO: DashboardTokenResponse = {
   gnsDailyBlockEmissions: "0",
   gnsPrice: "0",
   gnsTotalStaked: "0",
-  gnsTotalSupply: "0",
+  gnsMaxSupply: "0",
 };

--- a/packages/web/src/layouts/dashboard/containers/dashboard-info-container/DashboardInfoContainer.tsx
+++ b/packages/web/src/layouts/dashboard/containers/dashboard-info-container/DashboardInfoContainer.tsx
@@ -45,7 +45,7 @@ const DashboardInfoContainer: React.FC = () => {
   const progressBar = useMemo(() => {
     if (!convertedDashboardTokenData) return "0%";
     const circSupply = Number(convertedDashboardTokenData?.gnsCirculatingSupply);
-    const totalSupply = Number(convertedDashboardTokenData?.gnsTotalSupply);
+    const totalSupply = Number(convertedDashboardTokenData?.gnsMaxSupply);
     if (totalSupply === 0) return "0%";
     const percent = Math.min((circSupply / totalSupply) * 100, 100);
     return `${percent}%`;
@@ -69,7 +69,7 @@ const DashboardInfoContainer: React.FC = () => {
     };
 
     const circulatingSupply = convertedDashboardTokenData.gnsCirculatingSupply;
-    const totalSupply = convertedDashboardTokenData.gnsTotalSupply;
+    const totalSupply = convertedDashboardTokenData.gnsMaxSupply;
     const totalStaked = Number(convertedDashboardTokenData.gnsTotalStaked);
     const dailyBlockEmissions = Number(convertedDashboardTokenData.gnsDailyBlockEmissions);
 

--- a/packages/web/src/repositories/dashboard/response/token-response.ts
+++ b/packages/web/src/repositories/dashboard/response/token-response.ts
@@ -1,7 +1,7 @@
 export interface DashboardTokenResponse {
   gnsPrice: string;
   gnotPrice: string;
-  gnsTotalSupply: string;
+  gnsMaxSupply: string;
   gnsCirculatingSupply: string;
   gnsDailyBlockEmissions: string;
   gnsTotalStaked: string;

--- a/packages/web/src/services/converters/explore-dashboard/explore-dashboard.converter.ts
+++ b/packages/web/src/services/converters/explore-dashboard/explore-dashboard.converter.ts
@@ -27,7 +27,7 @@ export class ExploreDashboardConverter {
       ...data,
       gnsCirculatingSupply: AmountConverter.convertSingle(GNS_TOKEN, data.gnsCirculatingSupply),
       gnsDailyBlockEmissions: AmountConverter.convertSingle(GNS_TOKEN, data.gnsDailyBlockEmissions),
-      gnsTotalSupply: AmountConverter.convertSingle(GNS_TOKEN, data.gnsTotalSupply),
+      gnsMaxSupply: AmountConverter.convertSingle(GNS_TOKEN, data.gnsMaxSupply),
       gnsTotalStaked: AmountConverter.convertSingle(GNS_TOKEN, data.gnsTotalStaked),
     };
   }


### PR DESCRIPTION
## Summary

Rename `gnsTotalSupply` to `gnsMaxSupply` in the dashboard response type and its consumers to match the updated API response field name.

## Changes

- `repositories/dashboard/response/token-response.ts`: rename field in `TokenResponse` interface
- `common/values/default-object/explore-dashboard/dashboard-token-info.ts`: rename in default object
- `services/converters/explore-dashboard/explore-dashboard.converter.ts`: rename in converter
- `layouts/dashboard/containers/dashboard-info-container/DashboardInfoContainer.tsx`: update all references


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Block emission metric now available in dashboard token information

* **Updates**
  * Dashboard supply calculation adjusted to use maximum supply data instead of total supply

<!-- end of auto-generated comment: release notes by coderabbit.ai -->