### PR TITLE
fix(token): handle price precision and current price lines

### DIFF
--- a/packages/web/src/components/common/line-graph/LineGraph.tsx
+++ b/packages/web/src/components/common/line-graph/LineGraph.tsx
@@ -1,14 +1,14 @@
-import BigNumber from "bignumber.js";
-import React, { useCallback, useEffect, useState, useMemo } from "react";
-import { LineGraphTooltipWrapper, LineGraphWrapper } from "./LineGraph.styles";
-import FloatingTooltip from "../tooltip/FloatingTooltip";
 import { Global, css, useTheme } from "@emotion/react";
-import { subscriptFormat } from "@utils/number-utils";
-import { getLocalizeTime } from "@utils/chart";
-import { convertToKMB } from "@utils/stake-position-utils";
-import { formatPrice } from "@utils/new-number-utils";
-import dayjs from "dayjs";
 import { FloatingPosition } from "@hooks/common/use-floating-tooltip";
+import { getLocalizeTime } from "@utils/chart";
+import { formatPrice } from "@utils/new-number-utils";
+import { subscriptFormat } from "@utils/number-utils";
+import { convertToKMB } from "@utils/stake-position-utils";
+import BigNumber from "bignumber.js";
+import dayjs from "dayjs";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import FloatingTooltip from "../tooltip/FloatingTooltip";
+import { LineGraphTooltipWrapper, LineGraphWrapper } from "./LineGraph.styles";
 
 interface DataItem {
   value: number;
@@ -105,6 +105,7 @@ export interface LineGraphProps {
   displayLastDayAsNow?: boolean;
   popupYValueFormatter?: (value: string) => string;
   hasNoLabel?: boolean;
+  referenceTimeForFirstLine?: string;
 }
 
 export interface LineGraphRef {
@@ -172,6 +173,7 @@ const LineGraph: React.FC<LineGraphProps> = ({
   displayLastDayAsNow = false,
   popupYValueFormatter,
   hasNoLabel = false,
+  referenceTimeForFirstLine,
 }: LineGraphProps) => {
   const COMPONENT_ID = (Math.random() * 100000).toString();
   const [activated, setActivated] = useState(false);
@@ -519,6 +521,19 @@ const LineGraph: React.FC<LineGraphProps> = ({
     return points[0];
   }, [points]);
 
+  const firstLineY = useMemo(() => {
+    if (!referenceTimeForFirstLine) {
+      return firstPoint.y;
+    }
+
+    const referenceIndex = datas.findIndex(item => item.time === referenceTimeForFirstLine);
+    if (referenceIndex < 0 || !points[referenceIndex]) {
+      return firstPoint.y;
+    }
+
+    return points[referenceIndex].y;
+  }, [datas, firstPoint.y, points, referenceTimeForFirstLine]);
+
   const locationTooltipPosition = useMemo(() => {
     if (forcedPosition) return forcedPosition;
 
@@ -715,9 +730,9 @@ const LineGraph: React.FC<LineGraphProps> = ({
                   stroke={firstPointColor ? firstPointColor : color}
                   strokeWidth={1}
                   x1={0}
-                  y1={firstPoint.y}
+                  y1={firstLineY}
                   x2={width}
-                  y2={firstPoint.y}
+                  y2={firstLineY}
                   strokeDasharray={3}
                   className="first-line"
                 />

--- a/packages/web/src/layouts/token-detail/components/token-chart/token-chart-graph/TokenChartGraph.tsx
+++ b/packages/web/src/layouts/token-detail/components/token-chart/token-chart-graph/TokenChartGraph.tsx
@@ -201,6 +201,7 @@ const TokenChartGraph: React.FC<TokenChartGraphProps> = ({
           strokeWidth={1}
           datas={chartData}
           firstPointColor={theme.color.border05}
+          referenceTimeForFirstLine={datas[0]?.time}
           customData={customData}
           forcedPosition={"top"}
           displayLastDayAsNow

--- a/packages/web/src/layouts/token-detail/containers/token-chart-container/TokenChartContainer.tsx
+++ b/packages/web/src/layouts/token-detail/containers/token-chart-container/TokenChartContainer.tsx
@@ -3,6 +3,7 @@ import dayjs from "dayjs";
 import { useAtom } from "jotai";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
+import { RefetchInterval } from "@common/values";
 import { MATH_NEGATIVE_TYPE } from "@constants/option.constant";
 import { useClearModal } from "@hooks/common/use-clear-modal";
 import useComponentSize from "@hooks/common/use-component-size";
@@ -18,12 +19,11 @@ import { DEVICE_TYPE } from "@styles/media";
 import { getLabelChartV2, getLocalizeTime, getNumberOfAxis } from "@utils/chart";
 import { checkPositivePrice, generateDateSequence } from "@utils/common";
 import { formatPrice } from "@utils/new-number-utils";
-import { RefetchInterval } from "@common/values";
 
 import TokenChart, { ChartInfo, TokenInfo } from "../../components/token-chart/TokenChart";
 
 const TokenChartGraphPeriods: Readonly<string[]> = ["1D", "7D", "1M", "1Y", "All"] as const;
-export type TokenChartGraphPeriodType = (typeof TokenChartGraphPeriods)[number];
+export type TokenChartGraphPeriodType = typeof TokenChartGraphPeriods[number];
 
 const DEFAULT_PADDING = 12;
 const DEFAULT_X_LABEL_WIDTH = 82;
@@ -253,24 +253,17 @@ const TokenChartContainer: React.FC = () => {
       spaceBetweenLeftYAxisWithFirstLabel,
     );
 
-    const datas = [
-      {
-        amount: {
-          value: (pricesBefore.latestPrice || 0).toString(),
-          denom: "",
-        },
-        time: getLocalizeTime(new Date()),
-      },
-      ...chartData.map((item: IPriceResponse) => ({
+    const datas = chartData
+      .map((item: IPriceResponse) => ({
         amount: {
           value: `${item.price}`,
           denom: "",
         },
         time: getLocalizeTime(item.time),
-      })),
-    ].reverse();
+      }))
+      .reverse();
 
-    const yAxisLabels = getYAxisLabels(datas.map(item => BigNumber(item.amount.value).toFormat(6)));
+    const yAxisLabels = getYAxisLabels(datas.map(item => item.amount.value));
     const chartInfo: ChartInfo = {
       xAxisLabels,
       yAxisLabels,
@@ -288,43 +281,52 @@ const TokenChartContainer: React.FC = () => {
 
     const minPoint = minValue.minus(originalGap.multipliedBy(0.05));
     const maxPoint = maxValue.plus(originalGap.multipliedBy(0.05));
+    const dynamicPrecision = Math.min(6, Math.max(4, (maxPoint.minus(minPoint).decimalPlaces() ?? 0) + 2));
+    const formatYAxisValue = (value: BigNumber, precision = dynamicPrecision) =>
+      formatPrice(value, {
+        usd: false,
+        isKMB: false,
+        lessThan1Significant: precision,
+        greaterThan1Decimals: precision,
+      });
 
     if (datas.every(item => item === datas[0])) {
       return [
-        formatPrice(minValue.multipliedBy(0.95), {
-          usd: false,
-        }),
-        formatPrice(minValue, {
-          usd: false,
-        }),
-        formatPrice(minValue.multipliedBy(1.05), {
-          usd: false,
-        }),
+        formatYAxisValue(minValue.multipliedBy(0.95)),
+        formatYAxisValue(minValue),
+        formatYAxisValue(minValue.multipliedBy(1.05)),
       ];
     }
 
     const gap = maxPoint.minus(minPoint);
     const space = gap.dividedBy(5);
-    const temp = [
-      formatPrice(minPoint, {
-        usd: false,
-      }),
-    ];
+    const temp = [formatYAxisValue(minPoint)];
     for (let i = minPoint.plus(space); i.isLessThan(maxPoint); i = i.plus(space)) {
-      temp.push(
-        `${formatPrice(i, {
-          usd: false,
-        })}`,
-      );
+      temp.push(formatYAxisValue(i));
     }
-    temp.push(
-      formatPrice(maxPoint, {
-        usd: false,
-      }),
-    );
+    temp.push(formatYAxisValue(maxPoint));
 
     const uniqueLabel = [...new Set(temp)];
-    if (uniqueLabel.length === 1) uniqueLabel.unshift("0");
+    if (uniqueLabel.length === 1) {
+      const fallbackPrecision = Math.min(6, dynamicPrecision + 2);
+      const fallbackLabels = [
+        formatYAxisValue(minPoint, fallbackPrecision),
+        formatYAxisValue(minPoint.plus(maxPoint).dividedBy(2), fallbackPrecision),
+        formatYAxisValue(maxPoint, fallbackPrecision),
+      ];
+
+      const uniqueFallbackLabels = [...new Set(fallbackLabels)];
+      if (uniqueFallbackLabels.length > 1) {
+        return uniqueFallbackLabels;
+      }
+
+      return [
+        formatYAxisValue(minValue.multipliedBy(0.99), fallbackPrecision),
+        formatYAxisValue(minValue, fallbackPrecision),
+        formatYAxisValue(minValue.multipliedBy(1.01), fallbackPrecision),
+      ];
+    }
+
     return uniqueLabel;
   };
 


### PR DESCRIPTION
## Summary
- Improved y-axis label generation in the token detail chart to avoid labels collapsing into the same value.
- Added dynamic precision for y-axis labels with a hard cap of 6 decimal places.
- Replaced the previous fallback that injected `0` when labels were duplicated with a midpoint-based fallback label strategy.
- Added `referenceTimeForFirstLine` to `LineGraph` so the current price dashed line can align with the intended reference datapoint.

## Changes
- `packages/web/src/layouts/token-detail/containers/token-chart-container/TokenChartContainer.tsx`
  - Refined chart data construction (removed implicit latestPrice injection, rely on API-based series)
  - Reworked y-axis label formatting (dynamic precision + robust fallback, max 6 decimals)
- `packages/web/src/components/common/line-graph/LineGraph.tsx`
  - Added `referenceTimeForFirstLine?: string` prop
  - Updated dashed-line y-position logic to resolve from the reference timestamp
- `packages/web/src/layouts/token-detail/components/token-chart/token-chart-graph/TokenChartGraph.tsx`
  - Passed `referenceTimeForFirstLine={datas[0]?.time}` to `LineGraph`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional reference time anchoring for the first horizontal line on charts, enabling alignment to specific data points.

* **Bug Fixes**
  * Improved y-axis label display in edge cases where values collapse to a single point.

* **Improvements**
  * Enhanced y-axis formatting with dynamic precision calculation for better readability.
  * Strengthened fallback labeling logic to generate meaningful labels when distinct values are limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->