### PR TITLE
refactor: remove derived-state `useEffect`/`useMemo` patterns

### DIFF
--- a/packages/web/src/components/common/line-graph/LineGraph.tsx
+++ b/packages/web/src/components/common/line-graph/LineGraph.tsx
@@ -184,7 +184,7 @@ const LineGraph: React.FC<LineGraphProps> = ({
   const [baseLineYAxis, setBaseLineYAxis] = useState<string[]>([]);
   const [baseLineNumberWidth, setBaseLineNumberWidth] = useState<number>(0);
   const { height: customHeight = 0, locationTooltip } = customData;
-  const baseLineCount = useMemo(() => 4, []);
+  const baseLineCount = 4;
   const theme = useTheme();
 
   const isFocus = useCallback(() => {

--- a/packages/web/src/hooks/common/use-referral.spec.tsx
+++ b/packages/web/src/hooks/common/use-referral.spec.tsx
@@ -1,0 +1,74 @@
+import { renderHook } from "@testing-library/react";
+
+let mockLeaderboardMyInfo: { referralPoint?: string; referrerAddress?: string } | undefined = undefined;
+
+jest.mock("@query/leaderboard", () => ({
+  useGetLeaderboardByAddress: () => ({
+    data: mockLeaderboardMyInfo,
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@hooks/wallet/data/use-wallet", () => ({
+  useWallet: () => ({
+    account: { address: "g1testaddress" },
+  }),
+}));
+
+jest.mock("./use-custom-router", () => () => ({
+  getReferrerParameter: () => null,
+  pathname: "/",
+  query: {},
+  replace: jest.fn(),
+  push: jest.fn(),
+}));
+
+jest.mock("@utils/validation-utils", () => ({
+  isValidAddress: (addr: string) => addr.startsWith("g1"),
+}));
+
+jest.mock("@states/common", () => ({
+  GNOSWAP_REFERRAL_CODE: "GNOSWAP_REFERRAL",
+}));
+
+jest.mock("@constants/page.constant", () => ({
+  QUERY_PARAMETER: { REFERRER: "referrer" },
+}));
+
+import { useReferral } from "./use-referral";
+
+describe("useReferral — referralEarnedPoints derivation", () => {
+  beforeEach(() => {
+    mockLeaderboardMyInfo = undefined;
+  });
+
+  it("returns 0 when leaderboardMyInfo is undefined", () => {
+    mockLeaderboardMyInfo = undefined;
+    const { result } = renderHook(() => useReferral());
+    expect(result.current.referralEarnedPoints).toBe(0);
+  });
+
+  it("returns 0 when referralPoint is undefined", () => {
+    mockLeaderboardMyInfo = {};
+    const { result } = renderHook(() => useReferral());
+    expect(result.current.referralEarnedPoints).toBe(0);
+  });
+
+  it("returns parsed integer for valid numeric string", () => {
+    mockLeaderboardMyInfo = { referralPoint: "42" };
+    const { result } = renderHook(() => useReferral());
+    expect(result.current.referralEarnedPoints).toBe(42);
+  });
+
+  it("returns 0 for non-numeric string", () => {
+    mockLeaderboardMyInfo = { referralPoint: "abc" };
+    const { result } = renderHook(() => useReferral());
+    expect(result.current.referralEarnedPoints).toBe(0);
+  });
+
+  it("returns parsed integer ignoring decimals", () => {
+    mockLeaderboardMyInfo = { referralPoint: "123.456" };
+    const { result } = renderHook(() => useReferral());
+    expect(result.current.referralEarnedPoints).toBe(123);
+  });
+});

--- a/packages/web/src/hooks/common/use-referral.tsx
+++ b/packages/web/src/hooks/common/use-referral.tsx
@@ -35,10 +35,9 @@ export const useReferral = () => {
   const [storedReferralAddress, setStoredReferralAddress] = React.useState<string | null>(null);
   const apiReferrerAddress = leaderboardMyInfo?.referrerAddress || "";
 
-  const referralEarnedPoints = React.useMemo(() => {
-    if (!leaderboardMyInfo?.referralPoint) return 0;
-    return parseInt(leaderboardMyInfo.referralPoint) || 0;
-  }, [leaderboardMyInfo?.referralPoint]);
+  const referralEarnedPoints = leaderboardMyInfo?.referralPoint
+    ? parseInt(leaderboardMyInfo.referralPoint) || 0
+    : 0;
 
   const generateReferralLink = React.useCallback((): string => {
     if (typeof window === "undefined" || !account?.address) return "";

--- a/packages/web/src/hooks/pool/data/use-decrease-handle.spec.tsx
+++ b/packages/web/src/hooks/pool/data/use-decrease-handle.spec.tsx
@@ -1,4 +1,14 @@
 import { renderHook } from "@testing-library/react";
+import { Provider as JotaiProvider } from "jotai";
+import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <JotaiProvider>
+    <GnoswapThemeProvider>
+      {children}
+    </GnoswapThemeProvider>
+  </JotaiProvider>
+);
 
 const mockPositions: unknown[] = [];
 let mockSelectedPosition: unknown = null;
@@ -113,13 +123,13 @@ describe("useDecreaseHandle — derived values", () => {
   describe("loading", () => {
     it("returns true when selectedPosition is null", () => {
       mockSelectedPosition = null;
-      const { result } = renderHook(() => useDecreaseHandle());
+      const { result } = renderHook(() => useDecreaseHandle(), { wrapper });
       expect(result.current.loading).toBe(true);
     });
 
     it("returns false when selectedPosition exists", () => {
       mockSelectedPosition = makePosition(100, 50, 150);
-      const { result } = renderHook(() => useDecreaseHandle());
+      const { result } = renderHook(() => useDecreaseHandle(), { wrapper });
       expect(result.current.loading).toBe(false);
     });
   });

--- a/packages/web/src/hooks/pool/data/use-decrease-handle.spec.tsx
+++ b/packages/web/src/hooks/pool/data/use-decrease-handle.spec.tsx
@@ -1,0 +1,126 @@
+import { renderHook } from "@testing-library/react";
+
+const mockPositions: unknown[] = [];
+let mockSelectedPosition: unknown = null;
+
+jest.mock("jotai", () => {
+  const actual = jest.requireActual("jotai");
+  return {
+    ...actual,
+    useAtom: () => [mockSelectedPosition, jest.fn()],
+  };
+});
+
+jest.mock("@hooks/common/use-custom-router", () => () => ({
+  getPoolPath: () => "tokenA:tokenB:3000",
+  getPositionId: () => "1",
+  push: jest.fn(),
+  movePageWithPoolPath: jest.fn(),
+}));
+
+jest.mock("@hooks/pool/data/use-position-data", () => ({
+  usePositionData: () => ({
+    positions: mockPositions,
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@hooks/token/data/use-gnot-wugnot", () => ({
+  useGnotToGnot: () => ({
+    getGnotPath: (token: { name: string; symbol: string; logoURI: string }) => token,
+  }),
+}));
+
+jest.mock("@hooks/token/data/use-token-amount-input", () => ({
+  useTokenAmountInput: () => ({
+    amount: "0",
+    balance: "0",
+    changeAmount: jest.fn(),
+  }),
+}));
+
+jest.mock("@hooks/token/data/use-token-data", () => ({
+  useTokenData: () => ({
+    tokenPrices: {},
+  }),
+}));
+
+jest.mock("@hooks/wallet/data/use-wallet", () => ({
+  useWallet: () => ({
+    connected: true,
+    account: { address: "g1test" },
+    loadingConnect: "done",
+  }),
+}));
+
+jest.mock("@utils/swap-utils", () => ({
+  tickToPrice: (tick: number) => tick,
+  tickToPriceStr: (tick: number) => `${tick}`,
+  isEndTickBy: () => false,
+  getDepositAmountsByLiquidity: () => ({ amountA: "0", amountB: "0" }),
+}));
+
+jest.mock("@utils/token-utils", () => ({
+  makeDisplayTokenAmount: () => 0,
+}));
+
+jest.mock("@utils/common", () => ({
+  checkGnotPath: (path: string) => path,
+}));
+
+jest.mock("@utils/new-number-utils", () => ({
+  formatOtherPrice: (val: number) => `$${val}`,
+}));
+
+jest.mock("@hooks/pool/data/use-select-pool", () => ({
+  useSelectPool: () => ({
+    depositRatio: null,
+    feeBoost: null,
+    compareToken: null,
+    selectedFullRange: false,
+  }),
+}));
+
+import { useDecreaseHandle } from "./use-decrease-handle";
+
+function makePosition(currentTick: number, tickLower: number, tickUpper: number, closed = false) {
+  return {
+    lpTokenId: 1,
+    tickLower,
+    tickUpper,
+    closed,
+    liquidity: "1000",
+    tokenABalance: "100",
+    tokenBBalance: "200",
+    unclaimedFeeAAmount: "0",
+    unclaimedFeeBAmount: "0",
+    rewards: [],
+    pool: {
+      currentTick,
+      fee: "3000",
+      tokenA: { path: "tokenA", name: "TokenA", symbol: "TA", logoURI: "", decimals: 6, priceID: "tokenA" },
+      tokenB: { path: "tokenB", name: "TokenB", symbol: "TB", logoURI: "", decimals: 6, priceID: "tokenB" },
+    },
+  };
+}
+
+describe("useDecreaseHandle — derived values", () => {
+  afterEach(() => {
+    mockSelectedPosition = null;
+    mockPositions.length = 0;
+  });
+
+  describe("loading", () => {
+    it("returns true when selectedPosition is null", () => {
+      mockSelectedPosition = null;
+      const { result } = renderHook(() => useDecreaseHandle());
+      expect(result.current.loading).toBe(true);
+    });
+
+    it("returns false when selectedPosition exists", () => {
+      mockSelectedPosition = makePosition(100, 50, 150);
+      const { result } = renderHook(() => useDecreaseHandle());
+      expect(result.current.loading).toBe(false);
+    });
+  });
+});

--- a/packages/web/src/hooks/pool/data/use-decrease-handle.tsx
+++ b/packages/web/src/hooks/pool/data/use-decrease-handle.tsx
@@ -64,9 +64,7 @@ export const useDecreaseHandle = () => {
     },
   });
 
-  const loading = useMemo(() => {
-    return !selectedPosition;
-  }, [selectedPosition]);
+  const loading = !selectedPosition;
 
   useEffect(() => {
     if (!selectedPosition && positions.length > 0 && positionId) {
@@ -79,7 +77,7 @@ export const useDecreaseHandle = () => {
 
       setSelectedPosition(position);
     }
-  }, [selectedPosition, positions, positionId, poolPath, selectedPosition]);
+  }, [selectedPosition, positions, positionId, poolPath]);
 
   const { connected, account, loadingConnect } = useWallet();
   const minPriceStr = useMemo(() => {
@@ -125,15 +123,10 @@ export const useDecreaseHandle = () => {
     };
   }, [selectedPosition?.pool]);
 
-  const inRange = useMemo(() => {
-    if (!selectedPosition) return false;
-    const { tickLower, tickUpper, pool } = selectedPosition;
-    const currentTick = pool.currentTick;
-    if (currentTick < tickLower || currentTick > tickUpper) {
-      return false;
-    }
-    return true;
-  }, [selectedPosition]);
+  const inRange = !selectedPosition
+    ? false
+    : selectedPosition.pool.currentTick >= selectedPosition.tickLower &&
+      selectedPosition.pool.currentTick <= selectedPosition.tickUpper;
 
   const rangeStatus = useMemo(() => {
     return selectedPosition?.closed

--- a/packages/web/src/hooks/pool/data/use-increase-handle.spec.tsx
+++ b/packages/web/src/hooks/pool/data/use-increase-handle.spec.tsx
@@ -1,0 +1,128 @@
+import { renderHook } from "@testing-library/react";
+
+let mockSelectedPosition: unknown = null;
+
+jest.mock("jotai", () => {
+  const actual = jest.requireActual("jotai");
+  return {
+    ...actual,
+    useAtom: () => [mockSelectedPosition, jest.fn()],
+  };
+});
+
+jest.mock("@hooks/common/use-custom-router", () => () => ({
+  getPoolPath: () => "tokenA:tokenB:3000",
+  getPositionId: () => "1",
+  push: jest.fn(),
+  movePageWithPoolPath: jest.fn(),
+}));
+
+jest.mock("@hooks/pool/data/use-position-data", () => ({
+  usePositionData: () => ({
+    positions: [],
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@hooks/common/use-slippage", () => ({
+  useSlippage: () => ({
+    slippage: 0.5,
+    changeSlippage: jest.fn(),
+  }),
+}));
+
+jest.mock("@hooks/token/data/use-gnot-wugnot", () => ({
+  useGnotToGnot: () => ({
+    getGnotPath: (token: { name: string; symbol: string; logoURI: string }) => token,
+  }),
+}));
+
+jest.mock("@hooks/token/data/use-token-amount-input", () => ({
+  useTokenAmountInput: () => ({
+    amount: "0",
+    balance: "0",
+    changeAmount: jest.fn(),
+  }),
+}));
+
+jest.mock("@hooks/wallet/data/use-wallet", () => ({
+  useWallet: () => ({
+    connected: true,
+    account: { address: "g1test" },
+    loadingConnect: "done",
+  }),
+}));
+
+jest.mock("@hooks/pool/data/use-select-pool", () => ({
+  useSelectPool: () => ({
+    depositRatio: null,
+    feeBoost: null,
+    compareToken: null,
+    selectedFullRange: false,
+    currentPrice: null,
+    minPrice: null,
+    maxPrice: null,
+    sqrtPriceX96: null,
+    setCompareToken: jest.fn(),
+    selectFullRange: jest.fn(),
+    setMinPosition: jest.fn(),
+    setMaxPosition: jest.fn(),
+  }),
+}));
+
+import { useIncreaseHandle } from "./use-increase-handle";
+
+function makePosition(currentTick: number, tickLower: number, tickUpper: number, closed = false) {
+  return {
+    lpTokenId: 1,
+    tickLower,
+    tickUpper,
+    closed,
+    liquidity: "1000",
+    rewards: [],
+    pool: {
+      currentTick,
+      fee: "3000",
+      tokenA: { path: "tokenA", name: "TokenA", symbol: "TA", logoURI: "", decimals: 6, priceID: "tokenA" },
+      tokenB: { path: "tokenB", name: "TokenB", symbol: "TB", logoURI: "", decimals: 6, priceID: "tokenB" },
+    },
+  };
+}
+
+describe("useIncreaseHandle — inRange derivation", () => {
+  afterEach(() => {
+    mockSelectedPosition = null;
+  });
+
+  it("returns false when selectedPosition is null", () => {
+    mockSelectedPosition = null;
+    const { result } = renderHook(() => useIncreaseHandle());
+    // inRange is not directly returned but affects rangeStatus
+    // rangeStatus is OUT when inRange is false and not closed
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("rangeStatus is IN when currentTick is within range", () => {
+    mockSelectedPosition = makePosition(100, 50, 150);
+    const { result } = renderHook(() => useIncreaseHandle());
+    expect(result.current.rangeStatus).toBe("IN");
+  });
+
+  it("rangeStatus is OUT when currentTick is below tickLower", () => {
+    mockSelectedPosition = makePosition(10, 50, 150);
+    const { result } = renderHook(() => useIncreaseHandle());
+    expect(result.current.rangeStatus).toBe("OUT");
+  });
+
+  it("rangeStatus is OUT when currentTick is above tickUpper", () => {
+    mockSelectedPosition = makePosition(200, 50, 150);
+    const { result } = renderHook(() => useIncreaseHandle());
+    expect(result.current.rangeStatus).toBe("OUT");
+  });
+
+  it("rangeStatus is NONE when position is closed", () => {
+    mockSelectedPosition = makePosition(100, 50, 150, true);
+    const { result } = renderHook(() => useIncreaseHandle());
+    expect(result.current.rangeStatus).toBe("NONE");
+  });
+});

--- a/packages/web/src/hooks/pool/data/use-increase-handle.tsx
+++ b/packages/web/src/hooks/pool/data/use-increase-handle.tsx
@@ -108,15 +108,10 @@ export const useIncreaseHandle = () => {
     };
   }, [selectedPosition?.pool]);
 
-  const inRange = useMemo(() => {
-    if (!selectedPosition) return false;
-    const { tickLower, tickUpper, pool } = selectedPosition;
-    const currentTick = pool.currentTick;
-    if (currentTick < tickLower || currentTick > tickUpper) {
-      return false;
-    }
-    return true;
-  }, [selectedPosition]);
+  const inRange = !selectedPosition
+    ? false
+    : selectedPosition.pool.currentTick >= selectedPosition.tickLower &&
+      selectedPosition.pool.currentTick <= selectedPosition.tickUpper;
 
   const rangeStatus = useMemo(() => {
     return selectedPosition?.closed

--- a/packages/web/src/hooks/pool/data/use-select-pool.tsx
+++ b/packages/web/src/hooks/pool/data/use-select-pool.tsx
@@ -216,10 +216,6 @@ export const useSelectPool = ({
     return [[0, 0], ...result];
   }, [ticks]);
 
-  const poolPath = useMemo(() => {
-    return latestPoolPath;
-  }, [latestPoolPath]);
-
   const renderState = useCallback(
     (isIgnoreDefaultLoading = false) => {
       if (!tokenA || !tokenB || !feeTier) return "NONE";
@@ -506,7 +502,7 @@ export const useSelectPool = ({
   return {
     startPrice,
     bins: isCreate ? initializeBins : bins,
-    poolPath,
+    poolPath: latestPoolPath,
     renderState,
     feeTier,
     tickSpacing: tickSpacing ?? 1,

--- a/packages/web/src/hooks/token/data/use-token-amount-input.spec.tsx
+++ b/packages/web/src/hooks/token/data/use-token-amount-input.spec.tsx
@@ -1,0 +1,81 @@
+import { renderHook, act } from "@testing-library/react";
+import { useTokenAmountInput } from "./use-token-amount-input";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("@hooks/wallet/data/use-wallet", () => ({
+  useWallet: () => ({
+    connected: true,
+    isSwitchNetwork: false,
+  }),
+}));
+
+const mockDisplayBalanceMap: Record<string, string> = {};
+const mockTokenPrices: Record<string, { usd: number }> = {};
+
+jest.mock("./use-token-data", () => ({
+  useTokenData: () => ({
+    displayBalanceMap: mockDisplayBalanceMap,
+    tokenPrices: mockTokenPrices,
+  }),
+}));
+
+function makeToken(path: string, decimals = 6) {
+  return {
+    path,
+    name: "TestToken",
+    symbol: "TT",
+    decimals,
+    logoURI: "",
+    priceID: path,
+    chainId: "test",
+    createdAt: "",
+    address: "",
+    wrappedPath: path,
+    type: 0,
+    isGnot: false,
+  } as never;
+}
+
+describe("useTokenAmountInput — balance derivation", () => {
+  beforeEach(() => {
+    Object.keys(mockDisplayBalanceMap).forEach(k => delete mockDisplayBalanceMap[k]);
+    Object.keys(mockTokenPrices).forEach(k => delete mockTokenPrices[k]);
+  });
+
+  it("returns '0' when token is null", () => {
+    const { result } = renderHook(() => useTokenAmountInput(null));
+    expect(result.current.balance).toBe("0");
+  });
+
+  it("returns '0' when token.path is not in displayBalanceMap", () => {
+    const token = makeToken("gno.land/r/demo/foo");
+    const { result } = renderHook(() => useTokenAmountInput(token));
+    expect(result.current.balance).toBe("0");
+  });
+
+  it("returns formatted balance when token.path exists in displayBalanceMap", () => {
+    const token = makeToken("gno.land/r/demo/foo");
+    mockDisplayBalanceMap["gno.land/r/demo/foo"] = "123456.789";
+
+    const { result } = renderHook(() => useTokenAmountInput(token));
+    expect(result.current.balance).toBe("123,456.789");
+  });
+
+  it("returns '0' for amount initially and allows changing", () => {
+    const token = makeToken("gno.land/r/demo/foo");
+    const { result } = renderHook(() => useTokenAmountInput(token));
+
+    expect(result.current.amount).toBe("0");
+
+    act(() => {
+      result.current.changeAmount("100");
+    });
+
+    expect(result.current.amount).toBe("100");
+  });
+});

--- a/packages/web/src/hooks/token/data/use-token-amount-input.spec.tsx
+++ b/packages/web/src/hooks/token/data/use-token-amount-input.spec.tsx
@@ -1,5 +1,15 @@
 import { renderHook, act } from "@testing-library/react";
+import { Provider as JotaiProvider } from "jotai";
+import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
 import { useTokenAmountInput } from "./use-token-amount-input";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <JotaiProvider>
+    <GnoswapThemeProvider>
+      {children}
+    </GnoswapThemeProvider>
+  </JotaiProvider>
+);
 
 jest.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -43,18 +53,22 @@ function makeToken(path: string, decimals = 6) {
 
 describe("useTokenAmountInput — balance derivation", () => {
   beforeEach(() => {
-    Object.keys(mockDisplayBalanceMap).forEach(k => delete mockDisplayBalanceMap[k]);
-    Object.keys(mockTokenPrices).forEach(k => delete mockTokenPrices[k]);
+    for (const k of Object.keys(mockDisplayBalanceMap)) {
+      delete mockDisplayBalanceMap[k];
+    }
+    for (const k of Object.keys(mockTokenPrices)) {
+      delete mockTokenPrices[k];
+    }
   });
 
   it("returns '0' when token is null", () => {
-    const { result } = renderHook(() => useTokenAmountInput(null));
+    const { result } = renderHook(() => useTokenAmountInput(null), { wrapper });
     expect(result.current.balance).toBe("0");
   });
 
   it("returns '0' when token.path is not in displayBalanceMap", () => {
     const token = makeToken("gno.land/r/demo/foo");
-    const { result } = renderHook(() => useTokenAmountInput(token));
+    const { result } = renderHook(() => useTokenAmountInput(token), { wrapper });
     expect(result.current.balance).toBe("0");
   });
 
@@ -62,13 +76,13 @@ describe("useTokenAmountInput — balance derivation", () => {
     const token = makeToken("gno.land/r/demo/foo");
     mockDisplayBalanceMap["gno.land/r/demo/foo"] = "123456.789";
 
-    const { result } = renderHook(() => useTokenAmountInput(token));
+    const { result } = renderHook(() => useTokenAmountInput(token), { wrapper });
     expect(result.current.balance).toBe("123,456.789");
   });
 
   it("returns '0' for amount initially and allows changing", () => {
     const token = makeToken("gno.land/r/demo/foo");
-    const { result } = renderHook(() => useTokenAmountInput(token));
+    const { result } = renderHook(() => useTokenAmountInput(token), { wrapper });
 
     expect(result.current.amount).toBe("0");
 

--- a/packages/web/src/hooks/token/data/use-token-amount-input.tsx
+++ b/packages/web/src/hooks/token/data/use-token-amount-input.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import BigNumber from "bignumber.js";
 
 import { TokenModel } from "@models/token/token-model";
@@ -64,16 +64,13 @@ export const useTokenAmountInput = (token: TokenModel | null): TokenAmountInputM
   const { connected: isConnectedWallet, isSwitchNetwork } = useWallet();
 
   const [amount, setAmount] = useState<string>("0");
-  const [balance, setBalance] = useState<string>("0");
   const { displayBalanceMap, tokenPrices } = useTokenData();
 
-  useEffect(() => {
+  const balance = useMemo(() => {
     if (token && displayBalanceMap[token.path]) {
-      const balance = displayBalanceMap[token.path];
-      setBalance(BigNumber(balance ?? 0).toFormat());
-    } else {
-      setBalance("0");
+      return BigNumber(displayBalanceMap[token.path] ?? 0).toFormat();
     }
+    return "0";
   }, [displayBalanceMap, token]);
 
   const usdValue = useMemo(() => {

--- a/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/staking-content-card/StakingContentCard.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/staking-content-card/StakingContentCard.tsx
@@ -109,9 +109,7 @@ const StakingContentCard: React.FC<StakingContentCardProps> = ({
   const { tokenPrices } = useTokenData();
   const hasPosition = positions.length > 0;
 
-  const checkedStep = useMemo(() => {
-    return checkPoints.includes(period);
-  }, [checkPoints, period]);
+  const checkedStep = checkPoints.includes(period);
 
   const periodInfo = useMemo(() => {
     return STAKING_PERIOD_INFO[period];
@@ -288,9 +286,7 @@ export const SummuryApr: React.FC<SummuryAprProps> = ({ period, checkPoints, pos
 
   const hasPosition = positions.length > 0;
 
-  const checkedStep = useMemo(() => {
-    return checkPoints.includes(period);
-  }, [checkPoints, period]);
+  const checkedStep = checkPoints.includes(period);
 
   const periodInfo = useMemo(() => {
     return STAKING_PERIOD_INFO[period];


### PR DESCRIPTION
## Description

When a value is purely derived from props or other state, synchronizing it through `useState` + `useEffect` causes two render cycles per change.

### Changes

- `useDecreaseHandle` where `selectedPosition` was duplicated in the useEffect deps, which could mask stale closure issues
- Replace `useState` + `useEffect` sync pattern
- Remove trivial `useMemo` wrappers where the computation is a simple property access, boolean check, or constant
- Remove trivial `useMemo` identity wrapper in `useSelectPool` (`poolPath` that just returned `latestPoolPath`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for referral, pool position management, and token input hooks, covering edge cases and expected behaviors.

* **Refactor**
  * Simplified multiple hooks and components by removing redundant memoization and state indirections, preserving behavior while improving readability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->