### PR TITLE
feat(dashboard): add xgnsTotalSupply field to governance overview

### DIFF
--- a/packages/web/src/common/values/default-object/explore-dashboard/governance-overview-info.ts
+++ b/packages/web/src/common/values/default-object/explore-dashboard/governance-overview-info.ts
@@ -6,4 +6,5 @@ export const DEFAULT_GOVERNANCE_OVERVIEW_INFO: GovernanceOverviewResponse = {
   passedCount: 0,
   activeCount: 0,
   communityPool: 0,
+  xgnsTotalSupply: 0,
 };

--- a/packages/web/src/layouts/dashboard/containers/dashboard-info-container/DashboardInfoContainer.tsx
+++ b/packages/web/src/layouts/dashboard/containers/dashboard-info-container/DashboardInfoContainer.tsx
@@ -107,7 +107,7 @@ const DashboardInfoContainer: React.FC = () => {
     }
 
     return {
-      totalDelegated: `${numberToFormat(convertedGovernanceOverview.totalDelegated)} ${XGNS_TOKEN.symbol}`,
+      totalDelegated: `${numberToFormat(convertedGovernanceOverview.xgnsTotalSupply)} ${XGNS_TOKEN.symbol}`,
       holders: `${numberToFormat(convertedGovernanceOverview.holders)}`,
       passedCount: `${numberToFormat(convertedGovernanceOverview.passedCount)}`,
       activeCount: `${numberToFormat(convertedGovernanceOverview.activeCount)} `,

--- a/packages/web/src/repositories/dashboard/response/governance-overview-response.ts
+++ b/packages/web/src/repositories/dashboard/response/governance-overview-response.ts
@@ -4,4 +4,5 @@ export interface GovernanceOverviewResponse {
   passedCount: number;
   activeCount: number;
   communityPool: number;
+  xgnsTotalSupply: number;
 }

--- a/packages/web/src/services/converters/explore-dashboard/explore-dashboard.converter.ts
+++ b/packages/web/src/services/converters/explore-dashboard/explore-dashboard.converter.ts
@@ -47,6 +47,7 @@ export class ExploreDashboardConverter {
     return {
       ...data,
       totalDelegated: this.safeConvertToNumber(AmountConverter.convertSingle(XGNS_TOKEN, data.totalDelegated)),
+      xgnsTotalSupply: this.safeConvertToNumber(AmountConverter.convertSingle(XGNS_TOKEN, data.xgnsTotalSupply)),
     };
   }
 


### PR DESCRIPTION
## Summary

- Add `xgnsTotalSupply` to the `GovernanceOverviewResponse` type to consume the new API field
- Use `xgnsTotalSupply` (xGNS total supply = governance delegation + launchpad deposits) for the **Total xGNS Issued** display in the Governance Overview widget, replacing `totalDelegated` which only counted governance delegation
- Add `xgnsTotalSupply` conversion in `ExploreDashboardConverter.convertGovernanceOverview`

## Root Cause

The previous implementation used `totalDelegated` (governance delegation only) for the "Total xGNS Issued" label. Launchpad deposits mint xGNS via a separate path and were not reflected in `totalDelegated`, causing the displayed value to be lower than the actual total.

## Changes

| File | Change |
|------|--------|
| `governance-overview-response.ts` | Add `xgnsTotalSupply: number` to response type |
| `governance-overview-info.ts` | Add `xgnsTotalSupply: 0` to default object |
| `explore-dashboard.converter.ts` | Convert `xgnsTotalSupply` with `AmountConverter` |
| `DashboardInfoContainer.tsx` | Map `xgnsTotalSupply` → Total xGNS Issued display |

## Related

Closes GSW-2476  
Depends on gnoswap-labs/gnoswap-api-service#338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added total XGNS supply metric to the governance overview dashboard, providing users with visibility into the complete supply of the XGNS token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->