### PR TITLE
fix: resolve event listener and timer cleanup leaks causing memory growth

### DIFF
--- a/packages/web/src/components/common/header/sub-menu-button/SubMenuButton.tsx
+++ b/packages/web/src/components/common/header/sub-menu-button/SubMenuButton.tsx
@@ -52,7 +52,7 @@ const SubMenuButton: React.FC<SubMenuButtonProps> = ({
     if (element) document.addEventListener("mousemove", mouseEventHandler);
 
     return () => {
-      if (element) document.removeEventListener("mouseover", mouseEventHandler);
+      if (element) document.removeEventListener("mousemove", mouseEventHandler);
     };
   }, []);
 

--- a/packages/web/src/hooks/common/use-auto-disconnect.tsx
+++ b/packages/web/src/hooks/common/use-auto-disconnect.tsx
@@ -117,7 +117,7 @@ export const useAutoDisconnect = () => {
         clearTimeout(inactivityTimerRef.current);
       }
       if (backgroundCheckIntervalRef.current) {
-        clearTimeout(backgroundCheckIntervalRef.current);
+        clearInterval(backgroundCheckIntervalRef.current);
       }
     };
   }, [updateLastActiveTimestamp, checkBackgroundInactivity, walletClient, account]);

--- a/packages/web/src/hooks/common/use-modal-close-event.tsx
+++ b/packages/web/src/hooks/common/use-modal-close-event.tsx
@@ -1,21 +1,27 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 
 function useModalCloseEvent(modal: React.RefObject<HTMLElement | null>, callback: () => void) {
-  const handleEsc = (event: KeyboardEvent) => {
-    if (event.key === "Escape") {
-      callback();
-    }
-  };
+  const handleEsc = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        callback();
+      }
+    },
+    [callback],
+  );
 
-  function onClickOutbound(event: MouseEvent) {
-    if (!modal.current) {
-      return;
-    }
-    if (modal.current.contains(event.target as Node)) {
-      return;
-    }
-    callback();
-  }
+  const onClickOutbound = useCallback(
+    (event: MouseEvent) => {
+      if (!modal.current) {
+        return;
+      }
+      if (modal.current.contains(event.target as Node)) {
+        return;
+      }
+      callback();
+    },
+    [modal, callback],
+  );
 
   useEffect(() => {
     window.addEventListener("click", onClickOutbound, true);
@@ -23,9 +29,9 @@ function useModalCloseEvent(modal: React.RefObject<HTMLElement | null>, callback
 
     return () => {
       window.removeEventListener("click", onClickOutbound, true);
-      window.addEventListener("keydown", handleEsc);
+      window.removeEventListener("keydown", handleEsc);
     };
-  }, []);
+  }, [handleEsc, onClickOutbound]);
 }
 
 export default useModalCloseEvent;


### PR DESCRIPTION
## Summary

- **`useModalCloseEvent`**: Cleanup called `addEventListener` instead of `removeEventListener`, accumulating `keydown` listeners on every unmount
- **`SubMenuButton`**: Cleanup removed `mouseover` instead of `mousemove`, leaving dangling listeners on `document` across all pages
- **`useAutoDisconnect`**: Cleanup called `clearTimeout` on a `setInterval` ID, preventing the 10s background check internal from ever being cleared

## Changes

### `useModalCloseEvent`

| Before | After |
|--------|-------|
| `window.addEventListener("keydown", handleEsc)` in cleanup | `window.removeEventListener("keydown", handleEsc)` |
| Handler functions recreated every render (stale closure) | Wrapped in `useCallback` with proper deps |
| `useEffect` deps: `[]` | `useEffect` deps: `[handleEsc, onClickOutbound]` |

### `SubMenuButton`

| Before | After |
|--------|-------|
| `removeEventListener("mouseover", ...)` | `removeEventListener("mousemove", ...)` |

### `useAutoDisconnect`

| Before | After |
|--------|-------|
| `clearTimeout(backgroundCheckIntervalRef.current)` | `clearInterval(backgroundCheckIntervalRef.current)` |

## Performance Measurements

Tested by opening/closing a SelectBox dropdown **10 times** and recording Chrome DevTools Performance for ~15 seconds.

### Before (tested on beta.gnoswap.io)
<img width="1586" height="907" alt="수정 전" src="https://github.com/user-attachments/assets/801dc8c8-3ee4-4946-853f-0f6c47511bd3" />

### After (tested on Vercel preview)

<img width="1373" height="910" alt="수정 후" src="https://github.com/user-attachments/assets/d76eaef6-64e8-4256-98c0-1aa4063ea1e2" />

### Results

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| **Listeners** | Staircase increase on every open/close | Stable after initial mount | Accumulation eliminated |
| **JS Heap range** | 54.1 → 68.8 MB (+14.7 MB) | 48.8 → 59.7 MB (+10.9 MB) | **~26% less growth** |
| **Profiling overhead** | 85.6% of self time | 46.9% of self time | Reduced listener dispatch overhead |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected event listener cleanup in sub-menu interactions to properly remove registered listeners
  * Fixed timer cleanup to use the correct cancellation method
  * Improved modal close event handler stability and cleanup to prevent memory leaks and ensure proper event removal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->