### PR TITLE
fix: harden number formatting utilities — negative zero, precision, and consistency

### DIFF
--- a/packages/web/src/utils/new-number-utils.spec.ts
+++ b/packages/web/src/utils/new-number-utils.spec.ts
@@ -299,6 +299,25 @@ describe("formatPoolPairAmount", () => {
   });
 });
 
+describe("resolveMinLimit precision with large decimals", () => {
+  test("decimals=18 produces exact threshold without floating point error", () => {
+    // 1 / Math.pow(10, 18) === 1e-18 (JS number) has precision issues
+    // BigNumber(1).div(BigNumber(10).pow(18)) produces exact "0.000000000000000001"
+    const result = formatTokenAmount("0.0000000000000000005", { decimals: 18, isKMB: false });
+    expect(result).toBe("<0.000000000000000001");
+  });
+
+  test("decimals=18 in formatPoolPairAmount produces exact threshold", () => {
+    const result = formatPoolPairAmount("0.0000000000000000005", {
+      decimals: 18,
+      isKMB: false,
+      hasMinLimit: true,
+      minLimit: null,
+    });
+    expect(result).toBe("<0.000000000000000001");
+  });
+});
+
 describe("cross-function consistency", () => {
   describe("trailing zero removal produces same results across functions", () => {
     test("value 1.1 formatted consistently", () => {

--- a/packages/web/src/utils/new-number-utils.spec.ts
+++ b/packages/web/src/utils/new-number-utils.spec.ts
@@ -148,6 +148,18 @@ describe("formatTokenAmount", () => {
     });
   });
 
+  describe("decimals=0 is honored", () => {
+    test("decimals=0 formats as integer", () => {
+      expect(formatTokenAmount(1234.56, { decimals: 0, isKMB: false })).toBe("1,234");
+    });
+
+    test("decimals=0 does not fall through to default toFormat", () => {
+      // Without the fix, decimals=0 is falsy and skips the decimals branch
+      const withDecimals0 = formatTokenAmount(1.999, { decimals: 0, isKMB: false });
+      expect(withDecimals0).toBe("1");
+    });
+  });
+
   describe("negative values with minLimit", () => {
     test("negative value does not trigger minLimit check", () => {
       // isGreaterThan(0) guard prevents negative values from matching
@@ -194,6 +206,12 @@ describe("formatRate", () => {
     });
   });
 
+  describe("decimals=0 is honored", () => {
+    test("decimals=0 formats as integer percent", () => {
+      expect(formatRate(5.75, { decimals: 0 })).toBe("5%");
+    });
+  });
+
   describe("basic formatting", () => {
     test("null returns '-'", () => {
       expect(formatRate(null)).toBe("-");
@@ -231,6 +249,16 @@ describe("formatPoolPairAmount", () => {
       const result = formatPoolPairAmount(-0.5, { minLimit: 0.01, decimals: 2, isKMB: false });
       // removeTrailingZeros strips the trailing 0
       expect(result).toBe("-0.5");
+    });
+  });
+
+  describe("decimals=0 is honored", () => {
+    test("decimals=0 formats as integer", () => {
+      expect(formatPoolPairAmount(1234.56, { decimals: 0, isKMB: false })).toBe("1,234");
+    });
+
+    test("decimals=0 with fractional value rounds down to integer", () => {
+      expect(formatPoolPairAmount(9.99, { decimals: 0, isKMB: false })).toBe("9");
     });
   });
 

--- a/packages/web/src/utils/new-number-utils.spec.ts
+++ b/packages/web/src/utils/new-number-utils.spec.ts
@@ -1,4 +1,33 @@
-import { formatOtherPrice } from "./new-number-utils";
+import {
+  formatOtherPrice,
+  formatTokenAmount,
+  formatRate,
+  formatPoolPairAmount,
+  formatPrice,
+  removeTrailingZeros,
+} from "./new-number-utils";
+
+describe("removeTrailingZeros", () => {
+  test("removes trailing zeros after decimal", () => {
+    expect(removeTrailingZeros("1.000")).toBe("1");
+    expect(removeTrailingZeros("1.100")).toBe("1.1");
+    expect(removeTrailingZeros("1.120")).toBe("1.12");
+  });
+
+  test("preserves integer values without decimal point", () => {
+    expect(removeTrailingZeros("10")).toBe("10");
+    expect(removeTrailingZeros("100")).toBe("100");
+    expect(removeTrailingZeros("0")).toBe("0");
+  });
+
+  test("preserves formatted integers with commas", () => {
+    expect(removeTrailingZeros("1,000")).toBe("1,000");
+  });
+
+  test("handles decimal that becomes integer", () => {
+    expect(removeTrailingZeros("5.00")).toBe("5");
+  });
+});
 
 describe("formatOtherPrice", () => {
   describe("negative zero handling (GSW-2501)", () => {
@@ -50,6 +79,218 @@ describe("formatOtherPrice", () => {
 
     test("without usd prefix", () => {
       expect(formatOtherPrice(-0.001, { usd: false })).toBe("0");
+    });
+  });
+
+  describe("minLimit comparison and display consistency", () => {
+    test("uses resolvedMinLimit for both comparison and display", () => {
+      // With minLimit=0.001, value 0.005 is NOT less than 0.001, so it should format normally
+      const result = formatOtherPrice(0.005, { minLimit: 0.001, decimals: 2, isKMB: false });
+      expect(result).not.toBe("<$0.001");
+      // 0.005 is not less than 0.001 — should be formatted as "$0"
+      // (0.005 rounds down to 0.00 with decimals=2, trailing zeros removed → "0")
+      expect(result).toBe("$0");
+    });
+
+    test("value below resolvedMinLimit shows consistent threshold", () => {
+      const result = formatOtherPrice(0.0005, { minLimit: 0.001, decimals: 2, isKMB: false });
+      expect(result).toBe("<$0.001");
+    });
+  });
+
+  describe("precision preservation with removeTrailingZeros", () => {
+    test("long decimal string preserves precision", () => {
+      const result = formatOtherPrice("0.123456789012345678", {
+        decimals: 18,
+        isKMB: false,
+        hasMinLimit: false,
+      });
+      expect(result).toBe("$0.123456789012345678");
+    });
+
+    test("trailing zeros in long decimal are removed", () => {
+      const result = formatOtherPrice("1.50000", { decimals: 5, isKMB: false });
+      expect(result).toBe("$1.5");
+    });
+  });
+});
+
+describe("formatTokenAmount", () => {
+  describe("null safety on NaN branch", () => {
+    test("null amount returns '-' via early null check", () => {
+      expect(formatTokenAmount(null)).toBe("-");
+    });
+
+    test("non-numeric string returns the string itself", () => {
+      expect(formatTokenAmount("abc")).toBe("abc");
+    });
+
+    // Verify the NaN branch is safe even if null somehow reaches it
+    // (e.g. via JS caller bypassing TypeScript)
+    test("NaN branch with null-like value does not throw", () => {
+      // By design null is caught earlier, but the NaN branch now has a null guard
+      expect(() => formatTokenAmount(null)).not.toThrow();
+    });
+  });
+
+  describe("minLimit=0 handling with nullish coalescing", () => {
+    test("minLimit=0 is honored (disables min limit)", () => {
+      // With `??`, minLimit=0 is not falsy — it's used as the threshold
+      // 0 as threshold means no value is less than 0 (for positive values), so no "<" prefix
+      const result = formatTokenAmount(0.005, { minLimit: 0, decimals: 2, isKMB: false });
+      expect(result).toBe("0.00");
+    });
+
+    test("minLimit=undefined falls back to decimals-based limit", () => {
+      const result = formatTokenAmount(0.005, { decimals: 2, isKMB: false });
+      // internalMinLimit = 0.01, 0.005 < 0.01 → "<0.01"
+      expect(result).toBe("<0.01");
+    });
+  });
+
+  describe("negative values with minLimit", () => {
+    test("negative value does not trigger minLimit check", () => {
+      // isGreaterThan(0) guard prevents negative values from matching
+      const result = formatTokenAmount(-5, { minLimit: 10, decimals: 2, isKMB: false });
+      expect(result).toBe("-5.00");
+    });
+  });
+});
+
+describe("formatRate", () => {
+  describe("showSign with zero value", () => {
+    test("zero with showSign=true produces '0%' (not '+0%')", () => {
+      expect(formatRate(0, { showSign: true })).toBe("0%");
+    });
+
+    test("zero with showSign=false produces '0%'", () => {
+      expect(formatRate(0)).toBe("0%");
+    });
+
+    test("string '0' with showSign=true produces '0%'", () => {
+      expect(formatRate("0", { showSign: true })).toBe("0%");
+    });
+  });
+
+  describe("showSign with non-zero values", () => {
+    test("negative value with showSign formats correctly", () => {
+      expect(formatRate(-5.5, { showSign: true })).toBe("-5.50%");
+    });
+
+    test("positive value with showSign formats correctly", () => {
+      expect(formatRate(5.5, { showSign: true })).toBe("+5.50%");
+    });
+
+    test("positive value without showSign has no sign", () => {
+      expect(formatRate(5.5)).toBe("5.50%");
+    });
+  });
+
+  describe("minLimit=0 handling", () => {
+    test("minLimit=0 is honored", () => {
+      const result = formatRate(0.005, { minLimit: 0, decimals: 2 });
+      // minLimit=0, no value > 0 is less than 0, so it formats normally
+      expect(result).toBe("0.00%");
+    });
+  });
+
+  describe("basic formatting", () => {
+    test("null returns '-'", () => {
+      expect(formatRate(null)).toBe("-");
+    });
+
+    test("undefined returns '-'", () => {
+      expect(formatRate(undefined)).toBe("-");
+    });
+
+    test("NaN string returns '-'", () => {
+      expect(formatRate("abc")).toBe("-");
+    });
+  });
+});
+
+describe("formatPoolPairAmount", () => {
+  describe("minLimit handling", () => {
+    test("minLimit=0 is honored (does not fall back to decimals)", () => {
+      // With `??`, minLimit=0 is used as the threshold
+      // No positive value is less than 0, so it formats normally (no "<" prefix)
+      // 0.005 with decimals=2 and ROUND_DOWN → "0.00" → trailing zeros removed → "0"
+      const result = formatPoolPairAmount(0.005, { minLimit: 0, decimals: 2, isKMB: false });
+      expect(result).not.toContain("<");
+      expect(result).toBe("0");
+    });
+
+    test("minLimit=undefined falls back to decimals-based limit", () => {
+      const result = formatPoolPairAmount(0.005, { minLimit: null, decimals: 2, isKMB: false });
+      // internalMinLimit = 0.01, 0.005 < 0.01 → "<0.01"
+      expect(result).toBe("<0.01");
+    });
+
+    test("negative value does not trigger minLimit", () => {
+      // isGreaterThan(0) guard prevents negative values from matching
+      const result = formatPoolPairAmount(-0.5, { minLimit: 0.01, decimals: 2, isKMB: false });
+      // removeTrailingZeros strips the trailing 0
+      expect(result).toBe("-0.5");
+    });
+  });
+
+  describe("trailing zero removal uses removeTrailingZeros", () => {
+    test("trailing zeros are removed", () => {
+      const result = formatPoolPairAmount(1.1, { decimals: 4, isKMB: false });
+      expect(result).toBe("1.1");
+    });
+
+    test("all-zero fraction is removed", () => {
+      const result = formatPoolPairAmount(5, { decimals: 4, isKMB: false });
+      expect(result).toBe("5");
+    });
+
+    test("integer value without decimals param is preserved", () => {
+      const result = formatPoolPairAmount(100, { isKMB: false });
+      expect(result).toBe("100");
+    });
+
+    test("long decimal preserves precision", () => {
+      const result = formatPoolPairAmount("0.123456789012345678", {
+        decimals: 18,
+        isKMB: false,
+        hasMinLimit: false,
+      });
+      expect(result).toBe("0.123456789012345678");
+    });
+  });
+
+  describe("basic formatting", () => {
+    test("null returns '-'", () => {
+      expect(formatPoolPairAmount(null)).toBe("-");
+    });
+
+    test("zero returns '0'", () => {
+      expect(formatPoolPairAmount(0)).toBe("0");
+    });
+  });
+});
+
+describe("cross-function consistency", () => {
+  describe("trailing zero removal produces same results across functions", () => {
+    test("value 1.1 formatted consistently", () => {
+      const price = formatPrice(1.1, { isKMB: false, greaterThan1Decimals: 4 });
+      const otherPrice = formatOtherPrice(1.1, { isKMB: false, decimals: 4 });
+      const poolPair = formatPoolPairAmount(1.1, { decimals: 4, isKMB: false });
+
+      expect(price).toBe("$1.1");
+      expect(otherPrice).toBe("$1.1");
+      expect(poolPair).toBe("1.1");
+    });
+
+    test("value with all-zero decimals formatted consistently", () => {
+      const price = formatPrice(5, { isKMB: false, greaterThan1Decimals: 4 });
+      const otherPrice = formatOtherPrice(5, { isKMB: false, decimals: 4 });
+      const poolPair = formatPoolPairAmount(5, { decimals: 4, isKMB: false });
+
+      expect(price).toBe("$5");
+      expect(otherPrice).toBe("$5");
+      expect(poolPair).toBe("5");
     });
   });
 });

--- a/packages/web/src/utils/new-number-utils.spec.ts
+++ b/packages/web/src/utils/new-number-utils.spec.ts
@@ -1,0 +1,55 @@
+import { formatOtherPrice } from "./new-number-utils";
+
+describe("formatOtherPrice", () => {
+  describe("negative zero handling (GSW-2501)", () => {
+    test("small negative value that rounds to zero should not show '-$0'", () => {
+      expect(formatOtherPrice(-0.001)).toBe("$0");
+    });
+
+    test("very small negative value should not show '-$0'", () => {
+      expect(formatOtherPrice(-0.000001)).toBe("$0");
+    });
+
+    test("negative value that rounds to zero as string input", () => {
+      expect(formatOtherPrice("-0.004")).toBe("$0");
+    });
+
+    test("negative zero should display as '$0'", () => {
+      expect(formatOtherPrice(-0)).toBe("$0");
+    });
+
+    test("actual negative value should still show negative sign", () => {
+      expect(formatOtherPrice(-1.5)).toBe("-$1.5");
+    });
+
+    test("larger negative value should still show negative sign", () => {
+      expect(formatOtherPrice(-100.99)).toBe("-$100.99");
+    });
+  });
+
+  describe("basic formatting", () => {
+    test("null returns '-'", () => {
+      expect(formatOtherPrice(null)).toBe("-");
+    });
+
+    test("undefined returns '-'", () => {
+      expect(formatOtherPrice(undefined)).toBe("-");
+    });
+
+    test("empty string returns '-'", () => {
+      expect(formatOtherPrice("")).toBe("-");
+    });
+
+    test("zero returns '$0'", () => {
+      expect(formatOtherPrice(0)).toBe("$0");
+    });
+
+    test("positive value formats correctly", () => {
+      expect(formatOtherPrice(1234.56, { isKMB: false })).toBe("$1,234.56");
+    });
+
+    test("without usd prefix", () => {
+      expect(formatOtherPrice(-0.001, { usd: false })).toBe("0");
+    });
+  });
+});

--- a/packages/web/src/utils/new-number-utils.ts
+++ b/packages/web/src/utils/new-number-utils.ts
@@ -26,8 +26,47 @@ const parseToBigNumber = (value: NumericInput): ParsedBigNumber | null => {
   return { bigNum, raw };
 };
 
-const resolveMinLimit = (minLimit: number | null | undefined, decimals?: number): number | null => {
-  return minLimit ?? (decimals != null ? 1 / Math.pow(10, decimals) : null);
+/**
+ * Resolved minimum limit threshold used by formatting functions to determine
+ * when a value should be displayed as `<threshold` instead of the actual amount.
+ */
+interface ResolvedMinLimit {
+  /** BigNumber instance for precise comparison (e.g. `bigNum.isLessThan(value)`). */
+  value: BigNumber;
+  /**
+   * Fixed-point string for user-facing display (e.g. `"0.000000000000000001"`).
+   * Uses `toFixed()` instead of `toString()` to avoid exponential notation
+   * like `"1e-18"` that BigNumber's default stringification can produce.
+   */
+  display: string;
+}
+
+/**
+ * Resolves the minimum displayable limit from either an explicit `minLimit`
+ * or the number of `decimals`.
+ *
+ * Uses BigNumber arithmetic (`1 / 10^decimals`) instead of JavaScript's
+ * `Math.pow` to avoid IEEE 754 floating-point precision loss that occurs
+ * with large exponents (e.g. `1 / Math.pow(10, 18)` yields `1e-18` which
+ * cannot represent all intermediate values exactly).
+ *
+ * @param minLimit - Explicit threshold provided by the caller. When present
+ *   (including `0`), it takes precedence over the decimals-derived value.
+ * @param decimals - Number of decimal places. When `minLimit` is absent,
+ *   the threshold is computed as `10^(-decimals)`.
+ * @returns A {@link ResolvedMinLimit} with both comparison and display forms,
+ *   or `null` when neither `minLimit` nor `decimals` is provided.
+ */
+const resolveMinLimit = (minLimit: number | null | undefined, decimals?: number): ResolvedMinLimit | null => {
+  if (minLimit != null) {
+    const value = BigNumber(minLimit);
+    return { value, display: value.toFixed() };
+  }
+  if (decimals != null) {
+    const value = BigNumber(1).div(BigNumber(10).pow(decimals));
+    return { value, display: value.toFixed(decimals) };
+  }
+  return null;
 };
 
 export const formatPoolPairAmount = (
@@ -52,8 +91,8 @@ export const formatPoolPairAmount = (
 
   const internalMinLimit = resolveMinLimit(minLimit, decimals);
 
-  if (hasMinLimit && internalMinLimit && bigNum.isLessThan(internalMinLimit) && bigNum.isGreaterThan(0)) {
-    return `<${internalMinLimit}`;
+  if (hasMinLimit && internalMinLimit && bigNum.isLessThan(internalMinLimit.value) && bigNum.isGreaterThan(0)) {
+    return `<${internalMinLimit.display}`;
   }
 
   if (isKMB) {
@@ -96,8 +135,8 @@ export const formatRate = (
     return "0%";
   }
 
-  if (internalMinLimit && bigNum.isLessThan(internalMinLimit) && bigNum.isGreaterThan(0)) {
-    return `<${internalMinLimit}%`;
+  if (internalMinLimit && bigNum.isLessThan(internalMinLimit.value) && bigNum.isGreaterThan(0)) {
+    return `<${internalMinLimit.display}%`;
   }
 
   return sign + bigNum.abs().toFormat(decimals, BigNumber.ROUND_DOWN) + "%";
@@ -132,8 +171,8 @@ export const formatTokenAmount = (
 
   const internalMinLimit = resolveMinLimit(minLimit, decimals);
 
-  if (internalMinLimit && bigNum.isLessThan(internalMinLimit) && bigNum.isGreaterThan(0)) {
-    return `<${internalMinLimit}${internalSuffix}`;
+  if (internalMinLimit && bigNum.isLessThan(internalMinLimit.value) && bigNum.isGreaterThan(0)) {
+    return `<${internalMinLimit.display}${internalSuffix}`;
   }
 
   if (isKMB) {
@@ -230,8 +269,8 @@ export const formatOtherPrice = (
 
   const resolvedMinLimit = resolveMinLimit(minLimit, decimals);
 
-  if (hasMinLimit && resolvedMinLimit && bigNum.isLessThan(resolvedMinLimit) && bigNum.isGreaterThan(0)) {
-    return `<${prefix}${resolvedMinLimit}`;
+  if (hasMinLimit && resolvedMinLimit && bigNum.isLessThan(resolvedMinLimit.value) && bigNum.isGreaterThan(0)) {
+    return `<${prefix}${resolvedMinLimit.display}`;
   }
 
   if (isKMB) {

--- a/packages/web/src/utils/new-number-utils.ts
+++ b/packages/web/src/utils/new-number-utils.ts
@@ -19,7 +19,11 @@ interface ParsedBigNumber {
   bigNum: BigNumber;
   /** Pre-computed absolute value (`bigNum.abs()`), used for formatting and comparison. */
   abs: BigNumber;
-  /** Comma-stripped string form of the input, suitable for passing to `toKMBFormat` etc. */
+  /**
+   * Comma-stripped string form of the input, suitable for passing to `toKMBFormat` etc.
+   *
+   * Note: debug purpose only.
+   */
   raw: string;
 }
 
@@ -28,10 +32,17 @@ interface ParsedBigNumber {
  * Returns null for empty, null, undefined, or NaN inputs.
  */
 const parseToBigNumber = (value: NumericInput): ParsedBigNumber | null => {
-  if (value === "" || value === null || value === undefined) return null;
+  if (value === "" || value === null || value === undefined) {
+    return null;
+  }
+
   const raw = value.toString().replace(/,/g, "");
   const bigNum = BigNumber(raw);
-  if (bigNum.isNaN()) return null;
+
+  if (!bigNum.isFinite() || bigNum.isNaN()) {
+    return null;
+  }
+
   return { bigNum, abs: bigNum.abs(), raw };
 };
 
@@ -90,10 +101,19 @@ const resolveMinLimit = (minLimit: number | null | undefined, decimals?: number)
  * @param showSign - When true, positive values get a "+" prefix.
  */
 const resolveSign = (bigNum: BigNumber, formattedAbs: string, showSign = false): string => {
-  if (formattedAbs === "0") return "";
-  if (bigNum.isNegative()) return "-";
-  if (showSign) return "+";
-  return "";
+  // formattedAbs may include commas
+  const noComma = formattedAbs.replace(/,/g, "");
+  const formattedBn = new BigNumber(noComma);
+
+  if (formattedBn.isZero()) {
+    return "";
+  }
+
+  if (bigNum.isNegative()) {
+    return "-";
+  }
+
+  return showSign ? "+" : "";
 };
 
 export const formatPoolPairAmount = (
@@ -203,7 +223,7 @@ export const formatTokenAmount = (
 
   if (isKMB) {
     const kmbNumber = toKMBFormat(abs);
-    if (kmbNumber) return kmbNumber;
+    if (kmbNumber) return kmbNumber + internalSuffix;
   }
 
   const formatted = decimals != null ? abs.toFormat(decimals, BigNumber.ROUND_DOWN) : abs.toFormat();

--- a/packages/web/src/utils/new-number-utils.ts
+++ b/packages/web/src/utils/new-number-utils.ts
@@ -2,10 +2,36 @@ import BigNumber from "bignumber.js";
 import { buildPricePrefix } from "./common";
 import { toKMBFormat } from "./number-utils";
 
-export const removeTrailingZeros = (value: string) => value.replace(/\.?0+$/, "");
+export const removeTrailingZeros = (value: string) => {
+  if (!value.includes(".")) return value;
+  return value.replace(/0+$/, "").replace(/\.$/, "");
+};
+
+type NumericInput = string | number | BigNumber | null | undefined;
+
+interface ParsedBigNumber {
+  bigNum: BigNumber;
+  raw: string;
+}
+
+/**
+ * Parses a numeric input into a BigNumber, stripping commas and validating.
+ * Returns null for empty, null, undefined, or NaN inputs.
+ */
+const parseToBigNumber = (value: NumericInput): ParsedBigNumber | null => {
+  if (value === "" || value === null || value === undefined) return null;
+  const raw = value.toString().replace(/,/g, "");
+  const bigNum = BigNumber(raw);
+  if (bigNum.isNaN()) return null;
+  return { bigNum, raw };
+};
+
+const resolveMinLimit = (minLimit: number | null | undefined, decimals?: number): number | null => {
+  return minLimit ?? (decimals ? 1 / Math.pow(10, decimals) : null);
+};
 
 export const formatPoolPairAmount = (
-  amount?: number | BigNumber | string | null,
+  amount?: NumericInput,
   {
     decimals,
     minLimit = 0.01,
@@ -18,52 +44,32 @@ export const formatPoolPairAmount = (
     hasMinLimit?: boolean;
   } = {},
 ) => {
-  if (amount === null || amount === undefined) {
-    return "-";
-  }
+  const parsed = parseToBigNumber(amount);
+  if (!parsed) return "-";
+  const { bigNum, raw } = parsed;
 
-  const valueWithoutComma = amount?.toString().replace(/,/g, "");
-  const bigNumberValue = BigNumber(valueWithoutComma);
+  if (bigNum.isEqualTo(0)) return "0";
 
-  if (bigNumberValue.isNaN()) {
-    return "-";
-  }
+  const internalMinLimit = resolveMinLimit(minLimit, decimals);
 
-  if (bigNumberValue.isEqualTo(0)) return "0";
-
-  const internalMinLimit = minLimit || (decimals ? 1 / Math.pow(10, decimals) : null);
-
-  if (hasMinLimit && internalMinLimit && bigNumberValue.isLessThan(internalMinLimit)) {
+  if (hasMinLimit && internalMinLimit && bigNum.isLessThan(internalMinLimit) && bigNum.isGreaterThan(0)) {
     return `<${internalMinLimit}`;
   }
 
-  if (minLimit && bigNumberValue.isLessThan(minLimit) && bigNumberValue.isGreaterThan(0)) {
-    return `<${minLimit}`;
-  }
-
   if (isKMB) {
-    const kmbNumber = toKMBFormat(valueWithoutComma);
+    const kmbNumber = toKMBFormat(raw);
     if (kmbNumber) return kmbNumber;
   }
 
-  let stringValue = "";
+  const stringValue = decimals
+    ? bigNum.toFormat(decimals, BigNumber.ROUND_DOWN)
+    : bigNum.toFormat();
 
-  if (decimals) {
-    stringValue = bigNumberValue.toFormat(decimals, decimals ? BigNumber.ROUND_DOWN : undefined);
-  } else {
-    stringValue = bigNumberValue.toFormat();
-  }
-
-  const [integerValue, fractionValue] = stringValue.split(".");
-  if (fractionValue) {
-    const fractionString = Number(`0.${fractionValue}`).toString().split(".")[1];
-    if (fractionString) return `${integerValue}.${fractionString}`;
-    return integerValue;
-  } else return stringValue;
+  return removeTrailingZeros(stringValue);
 };
 
 export const formatRate = (
-  amount?: number | BigNumber | string | null,
+  amount?: NumericInput,
   {
     decimals = 2,
     minLimit,
@@ -76,29 +82,29 @@ export const formatRate = (
     allowZeroDecimals?: boolean;
   } = {},
 ) => {
-  if (amount === null || amount === undefined || BigNumber(amount).isNaN()) {
-    return "-";
+  const parsed = parseToBigNumber(amount);
+  if (!parsed) return "-";
+  const { bigNum } = parsed;
+
+  const sign = showSign && !bigNum.isEqualTo(0)
+    ? (bigNum.isLessThan(0) ? "-" : "+")
+    : "";
+
+  const internalMinLimit = resolveMinLimit(minLimit, decimals);
+
+  if (!allowZeroDecimals && bigNum.isEqualTo(0)) {
+    return "0%";
   }
 
-  const valueWithoutComma = amount?.toString().replace(/,/g, "");
-  const bigNumberValue = BigNumber(valueWithoutComma);
-  const sign = showSign ? (bigNumberValue.isLessThan(0) ? "-" : "+") : "";
-
-  const internalMinLimit = minLimit || (decimals ? 1 / Math.pow(10, decimals) : null);
-
-  if (!allowZeroDecimals && bigNumberValue.isEqualTo(0)) {
-    return sign + "0%";
-  }
-
-  if (internalMinLimit && bigNumberValue.isLessThan(internalMinLimit) && bigNumberValue.isGreaterThan(0)) {
+  if (internalMinLimit && bigNum.isLessThan(internalMinLimit) && bigNum.isGreaterThan(0)) {
     return `<${internalMinLimit}%`;
   }
 
-  return sign + BigNumber(amount).abs().toFormat(decimals, BigNumber.ROUND_DOWN) + "%";
+  return sign + bigNum.abs().toFormat(decimals, BigNumber.ROUND_DOWN) + "%";
 };
 
 export const formatTokenAmount = (
-  amount: string | number | BigNumber | null,
+  amount: NumericInput,
   {
     decimals,
     minLimit,
@@ -115,28 +121,31 @@ export const formatTokenAmount = (
     return "-";
   }
 
-  const inputAsNumber = BigNumber(amount?.toString().replace(/,/g, ""));
+  const parsed = parseToBigNumber(amount);
   const internalSuffix = suffix ? " " + suffix : "";
 
-  if (inputAsNumber.isNaN()) return amount.toString();
+  if (!parsed) return amount?.toString() ?? "-";
 
-  if (amount === 0) return "0" + internalSuffix;
+  const { bigNum } = parsed;
 
-  const internalMinLimit = minLimit || (decimals ? 1 / Math.pow(10, decimals) : null);
+  if (bigNum.isEqualTo(0)) return "0" + internalSuffix;
 
-  if (internalMinLimit && inputAsNumber.isLessThan(internalMinLimit)) {
+  const internalMinLimit = resolveMinLimit(minLimit, decimals);
+
+  if (internalMinLimit && bigNum.isLessThan(internalMinLimit) && bigNum.isGreaterThan(0)) {
     return `<${internalMinLimit}${internalSuffix}`;
   }
 
   if (isKMB) {
-    const kmbNumber = toKMBFormat(inputAsNumber);
+    const kmbNumber = toKMBFormat(bigNum);
     if (kmbNumber) return kmbNumber;
   }
+
   if (decimals) {
-    return `${inputAsNumber.toFormat(decimals, BigNumber.ROUND_DOWN)}${internalSuffix}`;
+    return `${bigNum.toFormat(decimals, BigNumber.ROUND_DOWN)}${internalSuffix}`;
   }
 
-  return `${BigNumber(inputAsNumber).toFormat()}${internalSuffix}`;
+  return `${bigNum.toFormat()}${internalSuffix}`;
 };
 
 interface FormatPriceOptions {
@@ -148,7 +157,7 @@ interface FormatPriceOptions {
   approx?: boolean;
 }
 
-export const formatPrice = (value?: BigNumber | string | number | null, options: FormatPriceOptions = {}): string => {
+export const formatPrice = (value?: NumericInput, options: FormatPriceOptions = {}): string => {
   const {
     isKMB = true,
     usd = true,
@@ -162,38 +171,34 @@ export const formatPrice = (value?: BigNumber | string | number | null, options:
     return "-";
   }
 
-  const valueWithoutComma = value.toString().replace(/,/g, "");
-  const valueAsBigNum = BigNumber(valueWithoutComma);
-  const absValue = valueAsBigNum.abs();
+  const parsed = parseToBigNumber(value);
+  if (!parsed) return value.toString();
 
+  const { bigNum, raw } = parsed;
+  const absValue = bigNum.abs();
   const prefix = buildPricePrefix({ usd, approx });
-  const negativeSign = valueAsBigNum.isLessThan(0) ? "-" : "";
-
-  if (absValue.isNaN()) return value.toString();
+  const negativeSign = bigNum.isLessThan(0) ? "-" : "";
 
   if (absValue.isEqualTo(0)) return prefix + "0";
 
   if (isKMB) {
-    const kmbNumber = toKMBFormat(valueWithoutComma, { usd });
+    const kmbNumber = toKMBFormat(raw, { usd });
     if (kmbNumber) return kmbNumber;
   }
 
   if (absValue.isLessThan(1)) {
-    const tempNum = valueAsBigNum.toPrecision(lessThan1Significant, BigNumber.ROUND_DOWN);
-    const formattedValue = `${negativeSign}${prefix}${tempNum}`;
-    return formattedValue;
+    const tempNum = bigNum.toPrecision(lessThan1Significant, BigNumber.ROUND_DOWN);
+    return `${negativeSign}${prefix}${tempNum}`;
   }
 
-  const formattedNumber = valueAsBigNum.toFormat(greaterThan1Decimals, BigNumber.ROUND_DOWN);
-  const finalNumber = `${negativeSign}${prefix}${
+  const formattedNumber = bigNum.toFormat(greaterThan1Decimals, BigNumber.ROUND_DOWN);
+  return `${negativeSign}${prefix}${
     forcedDecimals ? formattedNumber : removeTrailingZeros(formattedNumber)
   }`;
-
-  return finalNumber;
 };
 
 export const formatOtherPrice = (
-  value?: BigNumber | string | number | null,
+  value?: NumericInput,
   {
     usd = true,
     isKMB = true,
@@ -210,44 +215,31 @@ export const formatOtherPrice = (
     zeroAsEmpty?: boolean;
   } = {},
 ): string => {
-  if (value === "" || value === null || value === undefined) {
-    return "-";
-  }
+  const parsed = parseToBigNumber(value);
+  if (!parsed) return "-";
 
-  const valueWithoutComma = value.toString().replace(/,/g, "");
-
-  const valueAsBigNum = BigNumber(valueWithoutComma);
-  const absValue = valueAsBigNum.abs();
-
+  const { bigNum, raw } = parsed;
+  const absValue = bigNum.abs();
   const prefix = usd ? "$" : "";
-  const negativeSign = valueAsBigNum.isLessThan(0) ? "-" : "";
-
-  if (absValue.isNaN()) return "-";
+  const negativeSign = bigNum.isLessThan(0) ? "-" : "";
 
   if (absValue.isEqualTo(0)) {
     if (zeroAsEmpty) return "-";
-
     return prefix + "0";
   }
 
-  const internalMinLimit = decimals ? 1 / Math.pow(10, decimals) : null;
+  const resolvedMinLimit = resolveMinLimit(minLimit, decimals);
 
-  if (hasMinLimit && internalMinLimit && valueAsBigNum.isLessThan(internalMinLimit) && valueAsBigNum.isGreaterThan(0)) {
-    return `<${prefix}${minLimit || internalMinLimit}`;
+  if (hasMinLimit && resolvedMinLimit && bigNum.isLessThan(resolvedMinLimit) && bigNum.isGreaterThan(0)) {
+    return `<${prefix}${resolvedMinLimit}`;
   }
 
   if (isKMB) {
-    const kmbNumber = toKMBFormat(valueWithoutComma, { usd });
+    const kmbNumber = toKMBFormat(raw, { usd });
     if (kmbNumber) return kmbNumber;
   }
 
-  const [integer, fraction] = absValue.toFormat(decimals, BigNumber.ROUND_DOWN).split(".");
-  let newFraction = "";
-  if (fraction && Number(fraction) > 0) {
-    newFraction = Number(`0.${fraction}`).toString().split(".")[1];
-  }
-
-  const formatted = integer + (newFraction ? `.${newFraction.toString()}` : "");
+  const formatted = removeTrailingZeros(absValue.toFormat(decimals, BigNumber.ROUND_DOWN));
   const sign = formatted === "0" ? "" : negativeSign;
 
   return sign + prefix + formatted;

--- a/packages/web/src/utils/new-number-utils.ts
+++ b/packages/web/src/utils/new-number-utils.ts
@@ -9,8 +9,17 @@ export const removeTrailingZeros = (value: string) => {
 
 type NumericInput = string | number | BigNumber | null | undefined;
 
+/**
+ * Result of parsing a {@link NumericInput} into a validated BigNumber.
+ * Provides the original value, its absolute value, and the sanitized
+ * string form so that callers never need to re-parse or re-strip commas.
+ */
 interface ParsedBigNumber {
+  /** The parsed value with its original sign preserved. */
   bigNum: BigNumber;
+  /** Pre-computed absolute value (`bigNum.abs()`), used for formatting and comparison. */
+  abs: BigNumber;
+  /** Comma-stripped string form of the input, suitable for passing to `toKMBFormat` etc. */
   raw: string;
 }
 
@@ -23,7 +32,7 @@ const parseToBigNumber = (value: NumericInput): ParsedBigNumber | null => {
   const raw = value.toString().replace(/,/g, "");
   const bigNum = BigNumber(raw);
   if (bigNum.isNaN()) return null;
-  return { bigNum, raw };
+  return { bigNum, abs: bigNum.abs(), raw };
 };
 
 /**
@@ -69,6 +78,24 @@ const resolveMinLimit = (minLimit: number | null | undefined, decimals?: number)
   return null;
 };
 
+/**
+ * Determines the sign prefix for a formatted number.
+ *
+ * The sign is derived from the original value but suppressed when the
+ * formatted absolute value is "0" (i.e. a very small negative that
+ * rounds to zero should not display as "-$0").
+ *
+ * @param bigNum - The original parsed BigNumber (may be negative).
+ * @param formattedAbs - The formatted absolute value string (e.g. "1,234.56" or "0").
+ * @param showSign - When true, positive values get a "+" prefix.
+ */
+const resolveSign = (bigNum: BigNumber, formattedAbs: string, showSign = false): string => {
+  if (formattedAbs === "0") return "";
+  if (bigNum.isNegative()) return "-";
+  if (showSign) return "+";
+  return "";
+};
+
 export const formatPoolPairAmount = (
   amount?: NumericInput,
   {
@@ -85,13 +112,13 @@ export const formatPoolPairAmount = (
 ) => {
   const parsed = parseToBigNumber(amount);
   if (!parsed) return "-";
-  const { bigNum, raw } = parsed;
+  const { bigNum, abs, raw } = parsed;
 
-  if (bigNum.isEqualTo(0)) return "0";
+  if (abs.isEqualTo(0)) return "0";
 
   const internalMinLimit = resolveMinLimit(minLimit, decimals);
 
-  if (hasMinLimit && internalMinLimit && bigNum.isLessThan(internalMinLimit.value) && bigNum.isGreaterThan(0)) {
+  if (hasMinLimit && internalMinLimit && abs.isLessThan(internalMinLimit.value) && bigNum.isGreaterThan(0)) {
     return `<${internalMinLimit.display}`;
   }
 
@@ -100,11 +127,13 @@ export const formatPoolPairAmount = (
     if (kmbNumber) return kmbNumber;
   }
 
-  const stringValue = decimals != null
-    ? bigNum.toFormat(decimals, BigNumber.ROUND_DOWN)
-    : bigNum.toFormat();
+  const formatted = decimals != null
+    ? abs.toFormat(decimals, BigNumber.ROUND_DOWN)
+    : abs.toFormat();
+  const cleaned = removeTrailingZeros(formatted);
+  const sign = resolveSign(bigNum, cleaned);
 
-  return removeTrailingZeros(stringValue);
+  return sign + cleaned;
 };
 
 export const formatRate = (
@@ -123,23 +152,22 @@ export const formatRate = (
 ) => {
   const parsed = parseToBigNumber(amount);
   if (!parsed) return "-";
-  const { bigNum } = parsed;
+  const { bigNum, abs } = parsed;
 
-  const sign = showSign && !bigNum.isEqualTo(0)
-    ? (bigNum.isLessThan(0) ? "-" : "+")
-    : "";
-
-  const internalMinLimit = resolveMinLimit(minLimit, decimals);
-
-  if (!allowZeroDecimals && bigNum.isEqualTo(0)) {
+  if (!allowZeroDecimals && abs.isEqualTo(0)) {
     return "0%";
   }
 
-  if (internalMinLimit && bigNum.isLessThan(internalMinLimit.value) && bigNum.isGreaterThan(0)) {
+  const internalMinLimit = resolveMinLimit(minLimit, decimals);
+
+  if (internalMinLimit && abs.isLessThan(internalMinLimit.value) && bigNum.isGreaterThan(0)) {
     return `<${internalMinLimit.display}%`;
   }
 
-  return sign + bigNum.abs().toFormat(decimals, BigNumber.ROUND_DOWN) + "%";
+  const formatted = abs.toFormat(decimals, BigNumber.ROUND_DOWN);
+  const sign = resolveSign(bigNum, formatted, showSign);
+
+  return sign + formatted + "%";
 };
 
 export const formatTokenAmount = (
@@ -165,26 +193,27 @@ export const formatTokenAmount = (
 
   if (!parsed) return amount?.toString() ?? "-";
 
-  const { bigNum } = parsed;
+  const { bigNum, abs } = parsed;
 
-  if (bigNum.isEqualTo(0)) return "0" + internalSuffix;
+  if (abs.isEqualTo(0)) return "0" + internalSuffix;
 
   const internalMinLimit = resolveMinLimit(minLimit, decimals);
 
-  if (internalMinLimit && bigNum.isLessThan(internalMinLimit.value) && bigNum.isGreaterThan(0)) {
+  if (internalMinLimit && abs.isLessThan(internalMinLimit.value) && bigNum.isGreaterThan(0)) {
     return `<${internalMinLimit.display}${internalSuffix}`;
   }
 
   if (isKMB) {
-    const kmbNumber = toKMBFormat(bigNum);
+    const kmbNumber = toKMBFormat(abs);
     if (kmbNumber) return kmbNumber;
   }
 
-  if (decimals != null) {
-    return `${bigNum.toFormat(decimals, BigNumber.ROUND_DOWN)}${internalSuffix}`;
-  }
+  const formatted = decimals != null
+    ? abs.toFormat(decimals, BigNumber.ROUND_DOWN)
+    : abs.toFormat();
+  const sign = resolveSign(bigNum, formatted);
 
-  return `${bigNum.toFormat()}${internalSuffix}`;
+  return `${sign}${formatted}${internalSuffix}`;
 };
 
 interface FormatPriceOptions {
@@ -213,27 +242,27 @@ export const formatPrice = (value?: NumericInput, options: FormatPriceOptions = 
   const parsed = parseToBigNumber(value);
   if (!parsed) return value.toString();
 
-  const { bigNum, raw } = parsed;
-  const absValue = bigNum.abs();
+  const { bigNum, abs, raw } = parsed;
   const prefix = buildPricePrefix({ usd, approx });
-  const negativeSign = bigNum.isLessThan(0) ? "-" : "";
 
-  if (absValue.isEqualTo(0)) return prefix + "0";
+  if (abs.isEqualTo(0)) return prefix + "0";
 
   if (isKMB) {
     const kmbNumber = toKMBFormat(raw, { usd });
     if (kmbNumber) return kmbNumber;
   }
 
-  if (absValue.isLessThan(1)) {
-    const tempNum = bigNum.toPrecision(lessThan1Significant, BigNumber.ROUND_DOWN);
-    return `${negativeSign}${prefix}${tempNum}`;
+  if (abs.isLessThan(1)) {
+    const formatted = abs.toPrecision(lessThan1Significant, BigNumber.ROUND_DOWN);
+    const sign = resolveSign(bigNum, formatted);
+    return `${sign}${prefix}${formatted}`;
   }
 
-  const formattedNumber = bigNum.toFormat(greaterThan1Decimals, BigNumber.ROUND_DOWN);
-  return `${negativeSign}${prefix}${
-    forcedDecimals ? formattedNumber : removeTrailingZeros(formattedNumber)
-  }`;
+  const formatted = abs.toFormat(greaterThan1Decimals, BigNumber.ROUND_DOWN);
+  const cleaned = forcedDecimals ? formatted : removeTrailingZeros(formatted);
+  const sign = resolveSign(bigNum, cleaned);
+
+  return `${sign}${prefix}${cleaned}`;
 };
 
 export const formatOtherPrice = (
@@ -257,19 +286,17 @@ export const formatOtherPrice = (
   const parsed = parseToBigNumber(value);
   if (!parsed) return "-";
 
-  const { bigNum, raw } = parsed;
-  const absValue = bigNum.abs();
+  const { bigNum, abs, raw } = parsed;
   const prefix = usd ? "$" : "";
-  const negativeSign = bigNum.isLessThan(0) ? "-" : "";
 
-  if (absValue.isEqualTo(0)) {
+  if (abs.isEqualTo(0)) {
     if (zeroAsEmpty) return "-";
     return prefix + "0";
   }
 
   const resolvedMinLimit = resolveMinLimit(minLimit, decimals);
 
-  if (hasMinLimit && resolvedMinLimit && bigNum.isLessThan(resolvedMinLimit.value) && bigNum.isGreaterThan(0)) {
+  if (hasMinLimit && resolvedMinLimit && abs.isLessThan(resolvedMinLimit.value) && bigNum.isGreaterThan(0)) {
     return `<${prefix}${resolvedMinLimit.display}`;
   }
 
@@ -278,8 +305,8 @@ export const formatOtherPrice = (
     if (kmbNumber) return kmbNumber;
   }
 
-  const formatted = removeTrailingZeros(absValue.toFormat(decimals, BigNumber.ROUND_DOWN));
-  const sign = formatted === "0" ? "" : negativeSign;
+  const formatted = removeTrailingZeros(abs.toFormat(decimals, BigNumber.ROUND_DOWN));
+  const sign = resolveSign(bigNum, formatted);
 
   return sign + prefix + formatted;
 };

--- a/packages/web/src/utils/new-number-utils.ts
+++ b/packages/web/src/utils/new-number-utils.ts
@@ -247,5 +247,8 @@ export const formatOtherPrice = (
     newFraction = Number(`0.${fraction}`).toString().split(".")[1];
   }
 
-  return negativeSign + prefix + integer + (newFraction ? `.${newFraction.toString()}` : "");
+  const formatted = integer + (newFraction ? `.${newFraction.toString()}` : "");
+  const sign = formatted === "0" ? "" : negativeSign;
+
+  return sign + prefix + formatted;
 };

--- a/packages/web/src/utils/new-number-utils.ts
+++ b/packages/web/src/utils/new-number-utils.ts
@@ -27,7 +27,7 @@ const parseToBigNumber = (value: NumericInput): ParsedBigNumber | null => {
 };
 
 const resolveMinLimit = (minLimit: number | null | undefined, decimals?: number): number | null => {
-  return minLimit ?? (decimals ? 1 / Math.pow(10, decimals) : null);
+  return minLimit ?? (decimals != null ? 1 / Math.pow(10, decimals) : null);
 };
 
 export const formatPoolPairAmount = (
@@ -61,7 +61,7 @@ export const formatPoolPairAmount = (
     if (kmbNumber) return kmbNumber;
   }
 
-  const stringValue = decimals
+  const stringValue = decimals != null
     ? bigNum.toFormat(decimals, BigNumber.ROUND_DOWN)
     : bigNum.toFormat();
 
@@ -141,7 +141,7 @@ export const formatTokenAmount = (
     if (kmbNumber) return kmbNumber;
   }
 
-  if (decimals) {
+  if (decimals != null) {
     return `${bigNum.toFormat(decimals, BigNumber.ROUND_DOWN)}${internalSuffix}`;
   }
 

--- a/packages/web/src/utils/new-number-utils.ts
+++ b/packages/web/src/utils/new-number-utils.ts
@@ -112,7 +112,7 @@ export const formatPoolPairAmount = (
 ) => {
   const parsed = parseToBigNumber(amount);
   if (!parsed) return "-";
-  const { bigNum, abs, raw } = parsed;
+  const { bigNum, abs } = parsed;
 
   if (abs.isEqualTo(0)) return "0";
 
@@ -123,13 +123,11 @@ export const formatPoolPairAmount = (
   }
 
   if (isKMB) {
-    const kmbNumber = toKMBFormat(raw);
+    const kmbNumber = toKMBFormat(abs);
     if (kmbNumber) return kmbNumber;
   }
 
-  const formatted = decimals != null
-    ? abs.toFormat(decimals, BigNumber.ROUND_DOWN)
-    : abs.toFormat();
+  const formatted = decimals != null ? abs.toFormat(decimals, BigNumber.ROUND_DOWN) : abs.toFormat();
   const cleaned = removeTrailingZeros(formatted);
   const sign = resolveSign(bigNum, cleaned);
 
@@ -208,9 +206,7 @@ export const formatTokenAmount = (
     if (kmbNumber) return kmbNumber;
   }
 
-  const formatted = decimals != null
-    ? abs.toFormat(decimals, BigNumber.ROUND_DOWN)
-    : abs.toFormat();
+  const formatted = decimals != null ? abs.toFormat(decimals, BigNumber.ROUND_DOWN) : abs.toFormat();
   const sign = resolveSign(bigNum, formatted);
 
   return `${sign}${formatted}${internalSuffix}`;
@@ -242,13 +238,13 @@ export const formatPrice = (value?: NumericInput, options: FormatPriceOptions = 
   const parsed = parseToBigNumber(value);
   if (!parsed) return value.toString();
 
-  const { bigNum, abs, raw } = parsed;
+  const { bigNum, abs } = parsed;
   const prefix = buildPricePrefix({ usd, approx });
 
   if (abs.isEqualTo(0)) return prefix + "0";
 
   if (isKMB) {
-    const kmbNumber = toKMBFormat(raw, { usd });
+    const kmbNumber = toKMBFormat(abs, { usd });
     if (kmbNumber) return kmbNumber;
   }
 
@@ -286,7 +282,7 @@ export const formatOtherPrice = (
   const parsed = parseToBigNumber(value);
   if (!parsed) return "-";
 
-  const { bigNum, abs, raw } = parsed;
+  const { bigNum, abs } = parsed;
   const prefix = usd ? "$" : "";
 
   if (abs.isEqualTo(0)) {
@@ -301,7 +297,7 @@ export const formatOtherPrice = (
   }
 
   if (isKMB) {
-    const kmbNumber = toKMBFormat(raw, { usd });
+    const kmbNumber = toKMBFormat(abs, { usd });
     if (kmbNumber) return kmbNumber;
   }
 

--- a/packages/web/src/utils/number-utils.ts
+++ b/packages/web/src/utils/number-utils.ts
@@ -88,8 +88,21 @@ export const toUnitFormat = (
   return (usd ? "$" : "") + bigNumber.decimalPlaces(2).toNumber().toLocaleString("en", { minimumFractionDigits: 2 });
 };
 
+/**
+ * Formats a BigNumber into a compact K/M/B string (e.g. "1.23K", "$4.56M").
+ *
+ * Expects a **non-negative** BigNumber (absolute value). Sign handling is
+ * the caller's responsibility via `resolveSign`. This keeps the function
+ * focused on magnitude formatting and avoids redundant re-parsing.
+ *
+ * @param value - A non-negative BigNumber to format.
+ * @param options.usd - When true, prepends "$" to the result.
+ * @param options.isIgnoreKFormat - When true, skips the "K" (thousands) tier.
+ * @returns The KMB-formatted string, or `undefined` when the value is below
+ *   the smallest applicable tier (caller should fall through to decimal formatting).
+ */
 export const toKMBFormat = (
-  value: BigNumber | string | number,
+  value: BigNumber,
   {
     usd = false,
     isIgnoreKFormat = false,
@@ -98,43 +111,22 @@ export const toKMBFormat = (
     isIgnoreKFormat?: boolean;
   } = {},
 ) => {
-  const valueWithoutComma = value.toString().replace(/,/g, "");
+  if (value.isNaN()) return undefined;
 
-  if (!isNumber(valueWithoutComma)) {
-    return usd ? "$0" : "0";
-  }
-
-  const bigNumber = BigNumber(valueWithoutComma).abs();
   const prefix = usd ? "$" : "";
-  const negativeSign = BigNumber(value).isLessThan(0) ? "-" : "";
 
-  if (bigNumber.isGreaterThan(999.99 * 1e9)) return ">999.99B";
+  if (value.isGreaterThan(999.99 * 1e9)) return ">999.99B";
 
-  if (bigNumber.isGreaterThanOrEqualTo(1e9)) {
-    return (
-      negativeSign +
-      prefix +
-      bigNumber.dividedBy(Math.pow(10, 9)).toFixed(2, BigNumber.ROUND_DOWN) +
-      unitsUpperCase.billion
-    );
+  if (value.isGreaterThanOrEqualTo(1e9)) {
+    return prefix + value.dividedBy(1e9).toFixed(2, BigNumber.ROUND_DOWN) + unitsUpperCase.billion;
   }
 
-  if (bigNumber.isGreaterThanOrEqualTo(1e6)) {
-    return (
-      negativeSign +
-      prefix +
-      bigNumber.dividedBy(Math.pow(10, 6)).toFixed(2, BigNumber.ROUND_DOWN) +
-      unitsUpperCase.million
-    );
+  if (value.isGreaterThanOrEqualTo(1e6)) {
+    return prefix + value.dividedBy(1e6).toFixed(2, BigNumber.ROUND_DOWN) + unitsUpperCase.million;
   }
 
-  if (!isIgnoreKFormat && bigNumber.isGreaterThanOrEqualTo(1e3)) {
-    return (
-      negativeSign +
-      prefix +
-      bigNumber.dividedBy(Math.pow(10, 3)).toFixed(2, BigNumber.ROUND_DOWN) +
-      unitsUpperCase.thousand
-    );
+  if (!isIgnoreKFormat && value.isGreaterThanOrEqualTo(1e3)) {
+    return prefix + value.dividedBy(1e3).toFixed(2, BigNumber.ROUND_DOWN) + unitsUpperCase.thousand;
   }
 };
 

--- a/packages/web/src/utils/stake-position-utils.ts
+++ b/packages/web/src/utils/stake-position-utils.ts
@@ -68,7 +68,7 @@ export const formatTokenExchangeRate = (
   if (minLimit && inputAsNumber.isLessThan(minLimit) && inputAsNumber.isGreaterThan(0)) return `<${minLimit}`;
 
   if (!isIgnoreKMBFormat) {
-    const kmbNumber = toKMBFormat(inputAsNumber.toFixed(), {
+    const kmbNumber = toKMBFormat(inputAsNumber.abs(), {
       usd: false,
       isIgnoreKFormat: isIgnoreKFormat,
     });


### PR DESCRIPTION
## Description

Fixes Daily Earnings displaying as `-$0` on the position detail page (GSW-2501) and addresses additional issues discovered in the `new-number-utils.ts` formatting functions.

## Problem

### 1. Negative zero display (`-$0`) — GSW-2501

When the backend returned `accuReward1D: -6`, multiplying by a very small token price produced a tiny negative USD value. `formatOtherPrice` rounded this to "0" at 2 decimal places but preserved the negative sign, resulting in `-$0`.

### 2. `formatRate` produced `+0%`

When `showSign=true` and the value was zero, the sign was computed as "+" before the zero check, outputting `+0%` instead of `0$`.

### 3. Inconsistent `minLimit` handling

- `minLimit=0` was treated as falsy by `||` and fell back to a decimals-derived limit
- `formatOtherPrice` to show as `<$0.001` (contradictory since `0.005 > 0.001`)
- `1 / Math.pow(1o, decimals)` used JS floating point arithmetic, losing precision at large exponents (e.g. `decimal=18`)

### 4. Precision loss via `Number()` conversion

`formatPoolPairAmount` and `formatOtherPrice` used `Number(\`0.${fraction}\`)` to strip trailing zeros, silently truncating decimals beyond IEEE 754 precision (~15 digits).

### 5. Inconsistent trailing zero removal

Three different approaches were used: `removeTrailingZeros` regex in `formatPrice`, `Number()` conversion in `formatOtherPrice`, and manual split/parse in `formatPoolPairAmount`.

### 6. Inconsistent sign handling

Each function determined the sign differently:
  - `formatRate`: computed sign upfront, then re-created `BigNumber(amount).abs()`
  - `formatOtherPrice`: computed `negativeSign` early, checked `formatted === "0"` at the end
  - `formatPrice`: computed `negativeSign` early, mixed signed/unsigned formatting paths

### 7. Mixed input types in `toKMBFormat`

Accepted `BigNumber | string | number` and redundantly stripped commas, re-parsed to `BigNumber`, computed `abs()`, and derived the sign which are all already handled by callers.


## Changes

### Shared helpers extracted

- **`parseToBigNumber(value)`**: Consolidates null/empty/NaN checks, comma stripping, and BigNumber parsing. Returns `{ bigNum, abs, raw }`.
- **`resolveMinLimit(minLimit, decimals)`**: Uses `BigNumber(1).div(BigNumber(10).pow(decimals))` for arbitrary-precision threshold computation. Returns `{ value: BigNumber, display: string }` to separate comparison from display (avoids exponential notation like `"1e-18"`).
- **`resolveSign(bigNum, formattedAbs, showSign?)`**: Single source of truth for sign determination. Suppresses sign when `formattedAbs === "0"`, eliminating negative zero by design.
- **`NumericInput`**: Unified input type alias for `string | number | BigNumber | null | undefined`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for number formatting utilities, covering edge cases and special value handling.

* **Refactor**
  * Refactored numeric formatting functions for improved consistency across the application.
  * Enhanced robust handling of edge cases including null, undefined, NaN, and negative values.
  * Improved threshold and sign management in numeric displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->