### PR TITLE
fix(pool): normalize token-order price handling in add liquidity flow

### DIFF
--- a/packages/web/src/hooks/pool/data/use-select-pool.tsx
+++ b/packages/web/src/hooks/pool/data/use-select-pool.tsx
@@ -83,6 +83,7 @@ export interface SelectPool {
   liquidityOfTickPoints: [number, number][];
   setInteractionType: (type: "NONE" | "INTERACTION" | "TICK_UPDATE" | "FINISH") => void;
   isChangeMinMax: boolean;
+  isOrderedPrice: boolean;
   setIsChangeMinMax: (value: boolean) => void;
   isLoading: boolean;
 }
@@ -267,27 +268,43 @@ export const useSelectPool = ({
     return maxPosition;
   }, [fullRange, maxPosition, swapFeeTierMaxPriceRangeMap?.maxPrice]);
 
+  const isOrderedPrice = useMemo(() => {
+    if (isCreate) {
+      return true;
+    }
+
+    if (!tokenA || !tokenB || !compareToken) {
+      return true;
+    }
+
+    const isOrderedTokenPath = checkGnotPath(tokenA.path) <= checkGnotPath(tokenB.path);
+    const isOrderedCompareTokenPath = checkGnotPath(compareToken.path) === checkGnotPath(tokenA.path);
+    return isOrderedTokenPath === isOrderedCompareTokenPath;
+  }, [isCreate, tokenA, tokenB, compareToken]);
+
   const depositRatio = useMemo(() => {
     if (!tokenA || !tokenB || minPrice === null || maxPrice === null || !compareToken) {
       return null;
     }
 
-    const ordered = checkGnotPath(compareToken.path) === checkGnotPath(tokenA.path);
-    const currentPrice = isCreate ? startPrice : ordered ? price : 1 / price;
+    const currentPrice = isCreate ? startPrice : isOrderedPrice ? price : 1 / price;
     if (!currentPrice) {
       return null;
     }
 
-    if (maxPrice < currentPrice) {
+    const orderedMinPrice = isOrderedPrice ? minPrice : 1 / maxPrice;
+    const orderedMaxPrice = isOrderedPrice ? maxPrice : 1 / minPrice;
+
+    if (orderedMaxPrice < currentPrice) {
       return 0;
     }
 
-    if (minPrice > currentPrice) {
+    if (orderedMinPrice > currentPrice) {
       return 100;
     }
 
-    const currentMinPrice = fullRange ? swapFeeTierMaxPriceRangeMap.minPrice : minPrice;
-    const currentMaxPrice = fullRange ? swapFeeTierMaxPriceRangeMap.maxPrice : maxPrice;
+    const currentMinPrice = fullRange ? swapFeeTierMaxPriceRangeMap.minPrice : orderedMinPrice;
+    const currentMaxPrice = fullRange ? swapFeeTierMaxPriceRangeMap.maxPrice : orderedMaxPrice;
 
     const adjustAmountA = 1_000_000_000n;
 
@@ -320,6 +337,7 @@ export const useSelectPool = ({
     swapFeeTierMaxPriceRangeMap,
     isCreate,
     startPrice,
+    isOrderedPrice,
     price,
     fullRange,
   ]);
@@ -543,6 +561,7 @@ export const useSelectPool = ({
     setInteractionType,
     isChangeMinMax,
     setIsChangeMinMax,
+    isOrderedPrice,
     isLoading: isLoading || isLoadingPoolInfo,
     currentPoolPath,
     poolFromDb,

--- a/packages/web/src/hooks/pool/data/use-select-pool.tsx
+++ b/packages/web/src/hooks/pool/data/use-select-pool.tsx
@@ -21,6 +21,7 @@ import {
 } from "@query/pools";
 import { EarnState } from "@states/index";
 import { checkGnotPath, encryptId } from "@utils/common";
+import { isValidCurrentPrice } from "@utils/pool-utils";
 import { sortTokenPaths } from "@utils/sort-utils";
 import {
   feeBoostRateByPrices,
@@ -293,7 +294,7 @@ export const useSelectPool = ({
     }
 
     const currentPrice = isCreate ? startPrice : isOrderedPrice ? price : 1 / price;
-    if (!currentPrice || !Number.isFinite(currentPrice)) {
+    if (!isValidCurrentPrice(currentPrice)) {
       return null;
     }
 

--- a/packages/web/src/hooks/pool/data/use-select-pool.tsx
+++ b/packages/web/src/hooks/pool/data/use-select-pool.tsx
@@ -277,8 +277,13 @@ export const useSelectPool = ({
       return true;
     }
 
-    const isOrderedTokenPath = checkGnotPath(tokenA.path) <= checkGnotPath(tokenB.path);
-    const isOrderedCompareTokenPath = checkGnotPath(compareToken.path) === checkGnotPath(tokenA.path);
+    const checkedTokenAPath = checkGnotPath(tokenA.path);
+    const checkedTokenBPath = checkGnotPath(tokenB.path);
+
+    const isOrderedTokenPath = [checkedTokenAPath, checkedTokenBPath].sort(sortTokenPaths)[0] === checkedTokenAPath;
+
+    const isOrderedCompareTokenPath = checkGnotPath(compareToken.path) === checkedTokenAPath;
+
     return isOrderedTokenPath === isOrderedCompareTokenPath;
   }, [isCreate, tokenA, tokenB, compareToken]);
 
@@ -288,7 +293,7 @@ export const useSelectPool = ({
     }
 
     const currentPrice = isCreate ? startPrice : isOrderedPrice ? price : 1 / price;
-    if (!currentPrice) {
+    if (!currentPrice || !Number.isFinite(currentPrice)) {
       return null;
     }
 

--- a/packages/web/src/layouts/pool/pool-add/containers/earn-add-liquidity-container/EarnAddLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-add/containers/earn-add-liquidity-container/EarnAddLiquidityContainer.tsx
@@ -12,14 +12,15 @@ import { useSlippage } from "@hooks/common/use-slippage";
 import { useSelectPool } from "@hooks/pool/data/use-select-pool";
 import { useTokenAmountInput } from "@hooks/token/data/use-token-amount-input";
 import { useTokenData } from "@hooks/token/data/use-token-data";
-import { useConnectWalletModal } from "@hooks/wallet/ui/use-connect-wallet-modal";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
+import { useConnectWalletModal } from "@hooks/wallet/ui/use-connect-wallet-modal";
 import { PoolModel } from "@models/pool/pool-model";
 import { isNativeToken, TokenModel } from "@models/token/token-model";
 import { SwapState } from "@states/index";
 import { formatRate } from "@utils/new-number-utils";
 import { makeRouteUrl } from "@utils/page.utils";
-import { checkPoolStakingRewards } from "@utils/pool-utils";
+import { checkPoolStakingRewards, invertSqrtPriceX96 } from "@utils/pool-utils";
+import { sortTokenPaths } from "@utils/sort-utils";
 import {
   getDepositAmountsByAmountA,
   getDepositAmountsByAmountB,
@@ -28,13 +29,12 @@ import {
   priceToTick,
 } from "@utils/swap-utils";
 import { makeDisplayTokenAmount, makeRawTokenAmount } from "@utils/token-utils";
-import { sortTokenPaths } from "@utils/sort-utils";
 
-import PoolAddLiquidity, { PriceRangeSummary } from "../../components/pool-add-liquidity/PoolAddLiquidity";
+import { useReferral } from "@hooks/common/use-referral";
 import { usePool } from "@hooks/pool/data/use-pool";
 import { usePoolAddLiquidityConfirmModal } from "@hooks/pool/ui/use-pool-add-liquidity-confirm-modal";
 import { isSameToken } from "@utils/common";
-import { useReferral } from "@hooks/common/use-referral";
+import PoolAddLiquidity, { PriceRangeSummary } from "../../components/pool-add-liquidity/PoolAddLiquidity";
 
 export const SWAP_FEE_TIERS: SwapFeeTierType[] = ["FEE_100", "FEE_500", "FEE_3000", "FEE_10000"];
 
@@ -113,8 +113,17 @@ const EarnAddLiquidityContainer: React.FC = () => {
   const { isLoading: isLoadingCommon } = useLoading();
 
   const sqrtPriceX96 = useMemo(() => {
-    return selectPool?.sqrtPriceX96 ?? null;
-  }, [selectPool]);
+    if (selectPool?.isOrderedPrice === undefined || selectPool?.isOrderedPrice === null) {
+      return null;
+    }
+
+    const sqrtPriceX96 = selectPool?.sqrtPriceX96 ?? 0n;
+    if (!selectPool.isOrderedPrice) {
+      return invertSqrtPriceX96(sqrtPriceX96);
+    }
+
+    return sqrtPriceX96;
+  }, [selectPool, selectPool.isOrderedPrice]);
 
   const priceRangeSummary: PriceRangeSummary = useMemo(() => {
     let depositRatio = "-";
@@ -730,10 +739,9 @@ const EarnAddLiquidityContainer: React.FC = () => {
     return isFetchingPools || isLoadingCommon;
   }, [isFetchingPools, isLoadingCommon]);
 
-  const showOneClickStaking = useMemo(
-    () => checkPoolStakingRewards(selectPool.poolFromDb?.incentivized),
-    [selectPool.poolFromDb?.incentivized],
-  );
+  const showOneClickStaking = useMemo(() => checkPoolStakingRewards(selectPool.poolFromDb?.incentivized), [
+    selectPool.poolFromDb?.incentivized,
+  ]);
 
   return (
     <PoolAddLiquidity

--- a/packages/web/src/utils/pool-utils.spec.ts
+++ b/packages/web/src/utils/pool-utils.spec.ts
@@ -1,0 +1,133 @@
+import { invertSqrtPriceX96, isOrderedTokenPaths } from "./pool-utils";
+
+const TWO_192 = BigInt("6277101735386680763835789423207666416102355444464034512896");
+
+describe("invertSqrtPriceX96", () => {
+  it("should return 0n when input is 0n", () => {
+    expect(invertSqrtPriceX96(0n)).toBe(0n);
+  });
+
+  it("should return TWO_192 when input is 1n", () => {
+    expect(invertSqrtPriceX96(1n)).toBe(TWO_192);
+  });
+
+  it("should return 1n when input is TWO_192", () => {
+    expect(invertSqrtPriceX96(TWO_192)).toBe(1n);
+  });
+
+  it("should correctly invert a typical sqrtPriceX96 value", () => {
+    // A common sqrtPriceX96 value representing price ~1.0 (2^96)
+    const sqrtPriceX96 = BigInt("79228162514264337593543950336"); // 2^96
+    const result = invertSqrtPriceX96(sqrtPriceX96);
+    // TWO_192 / 2^96 = 2^192 / 2^96 = 2^96
+    expect(result).toBe(sqrtPriceX96);
+  });
+
+  it("should satisfy the invariant: invert(invert(x)) ≈ x for large values", () => {
+    const original = BigInt("79228162514264337593543950336"); // 2^96
+    const inverted = invertSqrtPriceX96(original);
+    const doubleInverted = invertSqrtPriceX96(inverted);
+    expect(doubleInverted).toBe(original);
+  });
+
+  it("should handle small sqrtPriceX96 values", () => {
+    const small = 100n;
+    const result = invertSqrtPriceX96(small);
+    expect(result).toBe(TWO_192 / small);
+    expect(result > 0n).toBe(true);
+  });
+
+  it("should handle large sqrtPriceX96 values", () => {
+    const large = TWO_192 - 1n;
+    const result = invertSqrtPriceX96(large);
+    expect(result).toBe(TWO_192 / large);
+    expect(result).toBe(1n);
+  });
+});
+
+describe("isOrderedTokenPaths", () => {
+  it("should return true when tokenA path comes first lexicographically", () => {
+    expect(isOrderedTokenPaths("gno.land/r/aaa", "gno.land/r/zzz")).toBe(true);
+  });
+
+  it("should return false when tokenA path comes after tokenB", () => {
+    expect(isOrderedTokenPaths("gno.land/r/zzz", "gno.land/r/aaa")).toBe(false);
+  });
+
+  it("should return true when paths are identical", () => {
+    expect(isOrderedTokenPaths("gno.land/r/abc", "gno.land/r/abc")).toBe(true);
+  });
+
+  it("should handle typical token paths (GNS vs GNOT)", () => {
+    const gnsPath = "gno.land/r/gnoswap/gns";
+    const wgnotPath = "gno.land/r/gnoland/wugnot";
+    // "gno.land/r/gnoland/wugnot" < "gno.land/r/gnoswap/gns" lexicographically
+    expect(isOrderedTokenPaths(wgnotPath, gnsPath)).toBe(true);
+    expect(isOrderedTokenPaths(gnsPath, wgnotPath)).toBe(false);
+  });
+});
+
+describe("isOrderedPrice comparator consistency", () => {
+  // This test demonstrates the potential inconsistency between
+  // lexical `<=` comparison and `sortTokenPaths`
+  it("sortTokenPaths and <= should produce consistent ordering for distinct paths", () => {
+    const paths = [
+      "gno.land/r/gnoswap/gns",
+      "gno.land/r/gnoland/wugnot",
+      "gno.land/r/demo/bar",
+      "gno.land/r/demo/foo",
+      "gno.land/r/demo/usdt",
+    ];
+
+    for (const pathA of paths) {
+      for (const pathB of paths) {
+        if (pathA === pathB) continue;
+
+        const lexicalOrder = pathA <= pathB;
+        const sortOrder =
+          [pathA, pathB].sort((a, b) => {
+            if (a === b) return 0;
+            return a > b ? 1 : -1;
+          })[0] === pathA;
+
+        expect(lexicalOrder).toBe(sortOrder);
+      }
+    }
+  });
+
+  // When paths are equal, `<=` returns true, but sortTokenPaths[0] === pathA is also true.
+  // This is fine. The real concern is whether checkGnotPath could introduce a case
+  // where GNOT -> wrappedPath changes the ordering result.
+  it("should handle equal paths correctly - both <= and sort return true", () => {
+    const samePath = "gno.land/r/gnoswap/gns";
+    expect(samePath <= samePath).toBe(true);
+    expect([samePath, samePath].sort()[0] === samePath).toBe(true);
+  });
+});
+
+describe("depositRatio price inversion edge cases", () => {
+  it("1 / 0 produces Infinity which is truthy", () => {
+    const price = 0;
+    const currentPrice = 1 / price;
+    // This demonstrates the bug: Infinity is truthy, so `!currentPrice` is false
+    expect(currentPrice).toBe(Infinity);
+    expect(!currentPrice).toBe(false); // Infinity passes the !currentPrice check
+    expect(Number.isFinite(currentPrice)).toBe(false); // but fails isFinite
+  });
+
+  it("1 / -0 produces -Infinity which is also truthy", () => {
+    const price = -0;
+    const currentPrice = 1 / price;
+    expect(currentPrice).toBe(-Infinity);
+    expect(!currentPrice).toBe(false);
+    expect(Number.isFinite(currentPrice)).toBe(false);
+  });
+
+  it("Number.isFinite correctly guards against Infinity", () => {
+    expect(Number.isFinite(Infinity)).toBe(false);
+    expect(Number.isFinite(-Infinity)).toBe(false);
+    expect(Number.isFinite(NaN)).toBe(false);
+    expect(Number.isFinite(0)).toBe(true);
+    expect(Number.isFinite(1.5)).toBe(true);
+  });
+});

--- a/packages/web/src/utils/pool-utils.spec.ts
+++ b/packages/web/src/utils/pool-utils.spec.ts
@@ -1,4 +1,4 @@
-import { invertSqrtPriceX96, isOrderedTokenPaths } from "./pool-utils";
+import { invertSqrtPriceX96, isOrderedTokenPaths, isValidCurrentPrice } from "./pool-utils";
 
 const TWO_192 = BigInt("6277101735386680763835789423207666416102355444464034512896");
 
@@ -68,9 +68,7 @@ describe("isOrderedTokenPaths", () => {
 });
 
 describe("isOrderedPrice comparator consistency", () => {
-  // This test demonstrates the potential inconsistency between
-  // lexical `<=` comparison and `sortTokenPaths`
-  it("sortTokenPaths and <= should produce consistent ordering for distinct paths", () => {
+  it("isOrderedTokenPaths should agree with lexical <= for distinct paths", () => {
     const paths = [
       "gno.land/r/gnoswap/gns",
       "gno.land/r/gnoland/wugnot",
@@ -84,50 +82,53 @@ describe("isOrderedPrice comparator consistency", () => {
         if (pathA === pathB) continue;
 
         const lexicalOrder = pathA <= pathB;
-        const sortOrder =
-          [pathA, pathB].sort((a, b) => {
-            if (a === b) return 0;
-            return a > b ? 1 : -1;
-          })[0] === pathA;
+        const sortOrder = isOrderedTokenPaths(pathA, pathB);
 
         expect(lexicalOrder).toBe(sortOrder);
       }
     }
   });
 
-  // When paths are equal, `<=` returns true, but sortTokenPaths[0] === pathA is also true.
-  // This is fine. The real concern is whether checkGnotPath could introduce a case
-  // where GNOT -> wrappedPath changes the ordering result.
-  it("should handle equal paths correctly - both <= and sort return true", () => {
-    const samePath = "gno.land/r/gnoswap/gns";
-    expect(samePath <= samePath).toBe(true);
-    expect([samePath, samePath].sort()[0] === samePath).toBe(true);
+  it("should handle equal paths correctly", () => {
+    const samePathA = "gno.land/r/gnoswap/gns";
+    const samePathB = "gno.land/r/gnoswap/gns";
+    expect(samePathA <= samePathB).toBe(true);
+    expect(isOrderedTokenPaths(samePathA, samePathB)).toBe(true);
   });
 });
 
-describe("depositRatio price inversion edge cases", () => {
-  it("1 / 0 produces Infinity which is truthy", () => {
-    const price = 0;
-    const currentPrice = 1 / price;
-    // This demonstrates the bug: Infinity is truthy, so `!currentPrice` is false
-    expect(currentPrice).toBe(Infinity);
-    expect(!currentPrice).toBe(false); // Infinity passes the !currentPrice check
-    expect(Number.isFinite(currentPrice)).toBe(false); // but fails isFinite
+describe("isValidCurrentPrice", () => {
+  it("should reject null", () => {
+    expect(isValidCurrentPrice(null)).toBe(false);
   });
 
-  it("1 / -0 produces -Infinity which is also truthy", () => {
-    const price = -0;
-    const currentPrice = 1 / price;
-    expect(currentPrice).toBe(-Infinity);
-    expect(!currentPrice).toBe(false);
-    expect(Number.isFinite(currentPrice)).toBe(false);
+  it("should reject undefined", () => {
+    expect(isValidCurrentPrice(undefined)).toBe(false);
   });
 
-  it("Number.isFinite correctly guards against Infinity", () => {
-    expect(Number.isFinite(Infinity)).toBe(false);
-    expect(Number.isFinite(-Infinity)).toBe(false);
-    expect(Number.isFinite(NaN)).toBe(false);
-    expect(Number.isFinite(0)).toBe(true);
-    expect(Number.isFinite(1.5)).toBe(true);
+  it("should reject 0", () => {
+    expect(isValidCurrentPrice(0)).toBe(false);
+  });
+
+  it("should reject Infinity (1 / 0 case)", () => {
+    expect(isValidCurrentPrice(1 / 0)).toBe(false);
+  });
+
+  it("should reject -Infinity", () => {
+    expect(isValidCurrentPrice(-Infinity)).toBe(false);
+  });
+
+  it("should reject NaN", () => {
+    expect(isValidCurrentPrice(NaN)).toBe(false);
+  });
+
+  it("should accept positive finite numbers", () => {
+    expect(isValidCurrentPrice(1.5)).toBe(true);
+    expect(isValidCurrentPrice(0.001)).toBe(true);
+    expect(isValidCurrentPrice(1000000)).toBe(true);
+  });
+
+  it("should accept negative finite numbers", () => {
+    expect(isValidCurrentPrice(-1.5)).toBe(true);
   });
 });

--- a/packages/web/src/utils/pool-utils.ts
+++ b/packages/web/src/utils/pool-utils.ts
@@ -62,6 +62,10 @@ export function checkPoolStakingRewards(incentivized?: boolean) {
   return incentivized === true;
 }
 
+export function isValidCurrentPrice(price: number | null | undefined): price is number {
+  return price !== null && price !== undefined && !!price && Number.isFinite(price);
+}
+
 export function isOrderedTokenPaths(tokenAPath: string, tokenBPath: string): boolean {
   return [tokenAPath, tokenBPath].sort(sortTokenPaths)?.[0] === tokenAPath;
 }

--- a/packages/web/src/utils/pool-utils.ts
+++ b/packages/web/src/utils/pool-utils.ts
@@ -4,14 +4,24 @@ import {
   SwapFeeTierMaxPriceRangeMap,
   SwapFeeTierType,
 } from "@constants/option.constant";
-import { TokenModel } from "@models/token/token-model";
-import { tickToPriceStr } from "./swap-utils";
-import { sortTokenPaths } from "./sort-utils";
-import { checkGnotPath } from "./common";
 import { PoolModel } from "@models/pool/pool-model";
+import { TokenModel } from "@models/token/token-model";
+import { checkGnotPath } from "./common";
+import { sortTokenPaths } from "./sort-utils";
+import { tickToPriceStr } from "./swap-utils";
 
 const maxTicks = Object.values(SwapFeeTierMaxPriceRangeMap).map(range => range.maxTick);
 const minTicks = Object.values(SwapFeeTierMaxPriceRangeMap).map(range => range.maxTick);
+
+const TWO_192 = BigInt("6277101735386680763835789423207666416102355444464034512896");
+
+export function invertSqrtPriceX96(sqrtPriceX96: bigint): bigint {
+  if (sqrtPriceX96 === 0n) {
+    return 0n;
+  }
+
+  return TWO_192 / sqrtPriceX96;
+}
 
 export function makePoolPath(
   tokenA: TokenModel | null,


### PR DESCRIPTION
## Descriptions

This PR fixes price-order inconsistencies in the pool selection and add-liquidity flow when token ordering differs from the compare token orientation. It ensures the UI and deposit calculations use a consistent price direction.

## Problem
When token order was reversed, price-dependent logic could be interpreted in the wrong direction, causing:
- incorrect current price reference (`price` vs `1 / price`),
- incorrect min/max range comparisons for deposit ratio,
- mismatched `sqrtPriceX96` usage in add-liquidity calculations.

As a result, users could see inaccurate ratio/range behavior in certain token-order combinations.

## Changes
- Added `isOrderedPrice` in `use-select-pool` to explicitly track whether current price orientation matches token order.
- Updated deposit ratio logic to normalize price bounds for reversed order:
  - uses ordered min/max (`orderedMinPrice`, `orderedMaxPrice`),
  - applies normalized bounds consistently in range checks and ratio calculation.
- Added `invertSqrtPriceX96` utility in `pool-utils.ts` and applied it in `EarnAddLiquidityContainer` when order is reversed.
- Wired `isOrderedPrice` through the select pool state so container-level calculations use the same orientation rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a public price-ordering flag and wired it through pool selection to affect displayed/current price behavior.

* **Refactor**
  * Added robust price utilities including price inversion and validity checks; adjusted square-root price handling to respect ordering semantics.

* **Tests**
  * Added comprehensive unit tests for price inversion, ordering logic, token-path ordering, and numeric edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->