### PR TITLE
fix(launchpad): align deposit apr field

### DIFF
--- a/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-my-participation/launchpad-my-participation-box/LaunchpadMyParticipationBox.tsx
+++ b/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-my-participation/launchpad-my-participation-box/LaunchpadMyParticipationBox.tsx
@@ -42,10 +42,10 @@ const LaunchpadMyParticipationBox = ({ item, idx, rewardInfo, handleClickClaim }
     };
   }, [item]);
 
-  const aprStr = item?.depositAPR ? (
+  const aprStr = item?.depositApr !== null && item?.depositApr !== undefined ? (
     <>
-      {Number(item.depositAPR) > 100 && "✨"}
-      {formatRate(item.depositAPR)} APR
+      {Number(item.depositApr) > 100 && "✨"}
+      {formatRate(item.depositApr)} APR
     </>
   ) : (
     "-"

--- a/packages/web/src/models/launchpad/launchpad-participation-model.ts
+++ b/packages/web/src/models/launchpad/launchpad-participation-model.ts
@@ -40,5 +40,5 @@ export interface LaunchpadParticipationModel {
 
   claimedRewardAmount: number;
 
-  depositAPR: number | null;
+  depositApr: number | null;
 }

--- a/packages/web/src/repositories/launchpad/mock/launchpad-participation-list.json
+++ b/packages/web/src/repositories/launchpad/mock/launchpad-participation-list.json
@@ -21,7 +21,7 @@
         "claimableBlockHeight": 300,
         "claimableRewardAmount": 1249249,
         "claimedRewardAmount": 200,
-        "depositAPR": 5399.7217246
+        "depositApr": 5399.7217246
       },
       {
         "id": 1,
@@ -42,7 +42,7 @@
         "claimableBlockHeight": 300,
         "claimableRewardAmount": 1249249,
         "claimedRewardAmount": 200,
-        "depositAPR": 5399.7217246
+        "depositApr": 5399.7217246
       }
     ]
   }


### PR DESCRIPTION
## Summary
- align the launchpad participation model and mock payload with the live `depositApr` field name
- update the participation APR renderer to use `depositApr` and preserve valid `0` values instead of falling back to `-`

## Verification
- `yarn install --immutable`
- `yarn build`
- `yarn workspace @gnoswap-labs/web lint` *(fails on pre-existing unrelated repo lint errors; changed files lint clean aside from one existing warning in `LaunchpadMyParticipationBox.tsx`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed APR display to properly handle missing or null data by showing "-" instead of potentially incorrect values.

* **Refactor**
  * Standardized internal field naming conventions for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->