### PR TITLE
fix(launchpad): align claim all eligibility

### DIFF
--- a/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/LaunchpadClaimAllModal.tsx
+++ b/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/LaunchpadClaimAllModal.tsx
@@ -1,14 +1,16 @@
 import React from "react";
-import BigNumber from "bignumber.js";
 import { useTranslation } from "react-i18next";
 
 import { LaunchpadParticipationModel } from "@models/launchpad";
 import { type TierType } from "@utils/launchpad-get-tier-number";
 import withLocalModal from "@components/hoc/with-local-modal";
 import { ProjectRewardInfoModel } from "@layouts/launchpad/launchpad-detail/LaunchpadDetail";
-import { safeParseTime } from "@utils/time.utils";
 import { rawToDisplayAmount } from "@utils/number-utils";
 import { GNS_TOKEN } from "@common/values/token-constant";
+import {
+  isLaunchpadParticipationClaimable,
+  isLaunchpadParticipationClaimed,
+} from "@utils/launchpad-claimable-participation";
 
 import { LaunchpadClaimAllModalWrapper } from "./LaunchpadClaimAllModal.styles";
 import IconClose from "@components/common/icons/IconCancel";
@@ -54,15 +56,7 @@ const LaunchpadClaimAllModal = ({
   const claimableRewards: LaunchpadParticipationModel[] = React.useMemo(() => {
     if (!displayLaunchpadParticipations) return [];
 
-    const currentTimestamp = Date.now();
-
-    return displayLaunchpadParticipations.filter(item => {
-      const claimableTimestamp = safeParseTime(item.claimableTime);
-
-      if (claimableTimestamp == null) return false;
-
-      return currentTimestamp >= claimableTimestamp;
-    });
+    return displayLaunchpadParticipations.filter(item => isLaunchpadParticipationClaimable(item));
   }, [displayLaunchpadParticipations]);
 
   const confirm = React.useCallback(() => {
@@ -96,10 +90,7 @@ const LaunchpadClaimAllModal = ({
           <div className="content">
             {claimableRewards.map((item, idx) => {
               const endTimeReached = isEndTime(item);
-
-              const isClaimedReward = BigNumber(item.claimableRewardAmount).isLessThan(0.01);
-              const isClaimedDeposit = BigNumber(item.claimableRewardAmount).isLessThan(0.01);
-              const isClaimed = isClaimedReward && isClaimedDeposit;
+              const isClaimed = isLaunchpadParticipationClaimed(item);
 
               if (isClaimed) return <React.Fragment key={item.id} />;
 

--- a/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-my-participation/LaunchpadMyParticipation.tsx
+++ b/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-my-participation/LaunchpadMyParticipation.tsx
@@ -1,21 +1,20 @@
 import React from "react";
-import BigNumber from "bignumber.js";
 import { useTranslation } from "react-i18next";
 
 import { useLaunchpadHandler } from "@hooks/launchpad/data/use-launchpad-handler";
 import { LaunchpadParticipationModel, LaunchpadPoolModel } from "@models/launchpad";
 import { ProjectRewardInfoModel } from "../../LaunchpadDetail";
-import { useGetLastedBlockHeight } from "@query/pools";
-import { LAUNCHPAD_REFETCH_INTERVAL } from "@common/values";
+import { GNS_TOKEN } from "@common/values/token-constant";
 
 import { MyParticipationWrapper } from "./LaunchpadMyParticipation.styles";
 import Button, { ButtonHierarchy } from "@components/common/button/Button";
 import LaunchpadMyParticipationBox from "./launchpad-my-participation-box/LaunchpadMyParticipationBox";
 import LaunchpadMyParticipationUnconnected from "./launchpad-my-participation-unconnected/LaunchpadMyParticipationUnconnected";
 import LaunchpadMyParticipationNoData from "./launchpad-my-participation-no-data/LaunchpadMyParticipationNoData";
-import { toNumberFormat } from "@utils/number-utils";
+import { rawToDisplayAmount } from "@utils/number-utils";
 import LaunchpadMyParticipationSkeleton from "./launchpad-my-participation-skeleton/LaunchpadMyParticipationSkeleton";
 import LaunchpadClaimAllModal from "@components/common/launchpad-modal/launchpad-claim-all-modal/LaunchpadClaimAllModal";
+import { isLaunchpadParticipationClaimable } from "@utils/launchpad-claimable-participation";
 
 interface LaunchpadMyParticipationProps {
   poolInfos: LaunchpadPoolModel[];
@@ -68,25 +67,15 @@ const LaunchpadMyParticipation = ({
     }, Number(poolInfos?.[0]?.apr ?? 0));
   }, [poolInfos]);
 
-  const { data: blockHeight } = useGetLastedBlockHeight({
-    refetchInterval: LAUNCHPAD_REFETCH_INTERVAL,
-  });
-
   const isShowClaimAllButton = React.useMemo(() => {
-    if (!blockHeight) return;
-
-    const currentBlockHeight = blockHeight;
-
     return data.some(item => {
-      const isClaimableBlockHeight = BigNumber(currentBlockHeight).isGreaterThan(item.claimableBlockHeight);
-
-      const isClaimedReward = Number(toNumberFormat(item.claimableRewardAmount, 2).replace(/,/g, "")) === 0;
-      const isClaimedDeposit = Number(toNumberFormat(item.depositAmount).replace(/,/g, "")) === 0;
-      const isClaimed = isClaimedReward && isClaimedDeposit;
-
-      return !isClaimed && isClaimableBlockHeight;
+      return isLaunchpadParticipationClaimable({
+        claimableTime: item.claimableTime,
+        claimableRewardAmount: rawToDisplayAmount(item.claimableRewardAmount, rewardInfo.rewardTokenDecimals),
+        depositAmount: rawToDisplayAmount(item.depositAmount, GNS_TOKEN.decimals),
+      });
     });
-  }, [data, blockHeight]);
+  }, [data, rewardInfo.rewardTokenDecimals]);
 
   // Conditional rendering
   if (isLoading || !isFetched) {

--- a/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-my-participation/launchpad-my-participation-box/LaunchpadMyParticipationBox.tsx
+++ b/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-my-participation/launchpad-my-participation-box/LaunchpadMyParticipationBox.tsx
@@ -10,7 +10,10 @@ import { getDateUtcToLocal } from "@common/utils/date-util";
 import { rawToDisplayAmount, toNumberFormat } from "@utils/number-utils";
 import { formatRate } from "@utils/new-number-utils";
 import { formatClaimableTime } from "@utils/launchpad-format-claimable-time";
-import { safeParseTime } from "@utils/time.utils";
+import {
+  isLaunchpadParticipationClaimable,
+  isLaunchpadParticipationClaimed,
+} from "@utils/launchpad-claimable-participation";
 
 import { Divider } from "@components/common/divider/divider";
 import IconArrowUp from "@components/common/icons/IconArrowUp";
@@ -40,7 +43,7 @@ const LaunchpadMyParticipationBox = ({ item, idx, rewardInfo, handleClickClaim }
       claimableRewardAmount: rawToDisplayAmount(item.claimableRewardAmount, rewardInfo.rewardTokenDecimals),
       claimedRewardAmount: rawToDisplayAmount(item.claimedRewardAmount, rewardInfo.rewardTokenDecimals),
     };
-  }, [item]);
+  }, [item, rewardInfo.rewardTokenDecimals]);
 
   const aprStr = item?.depositAPR ? (
     <>
@@ -52,19 +55,11 @@ const LaunchpadMyParticipationBox = ({ item, idx, rewardInfo, handleClickClaim }
   );
 
   const isClaimable = React.useMemo(() => {
-    const claimableTimestamp = safeParseTime(displayParticipationModel.claimableTime);
-
-    if (claimableTimestamp == null) return false;
-
-    const currentTimestamp = Date.now();
-    return currentTimestamp >= claimableTimestamp;
-  }, [displayParticipationModel.claimableTime]);
+    return isLaunchpadParticipationClaimable(displayParticipationModel);
+  }, [displayParticipationModel]);
 
   const isClaimed = React.useMemo(() => {
-    const isClaimedReward = Number(toNumberFormat(displayParticipationModel.claimableRewardAmount, 2)) === 0;
-    const isClaimedDeposit = Number(toNumberFormat(displayParticipationModel.depositAmount, 2)) === 0;
-
-    return isClaimedReward && isClaimedDeposit;
+    return isLaunchpadParticipationClaimed(displayParticipationModel);
   }, [displayParticipationModel]);
 
   return (

--- a/packages/web/src/utils/launchpad-claimable-participation.ts
+++ b/packages/web/src/utils/launchpad-claimable-participation.ts
@@ -1,0 +1,33 @@
+import BigNumber from "bignumber.js";
+
+import { safeParseTime } from "./time.utils";
+
+interface LaunchpadParticipationClaimState {
+  claimableTime: string;
+  claimableRewardAmount: number;
+  depositAmount: number;
+}
+
+const CLAIMED_AMOUNT_THRESHOLD = 0.01;
+
+export const isLaunchpadParticipationClaimed = ({
+  claimableRewardAmount,
+  depositAmount,
+}: Omit<LaunchpadParticipationClaimState, "claimableTime">) => {
+  const isClaimedReward = BigNumber(claimableRewardAmount).isLessThan(CLAIMED_AMOUNT_THRESHOLD);
+  const isClaimedDeposit = BigNumber(depositAmount).isLessThan(CLAIMED_AMOUNT_THRESHOLD);
+
+  return isClaimedReward && isClaimedDeposit;
+};
+
+export const isLaunchpadParticipationClaimable = ({
+  claimableTime,
+  claimableRewardAmount,
+  depositAmount,
+}: LaunchpadParticipationClaimState) => {
+  const claimableTimestamp = safeParseTime(claimableTime);
+
+  if (claimableTimestamp == null) return false;
+
+  return !isLaunchpadParticipationClaimed({ claimableRewardAmount, depositAmount }) && Date.now() >= claimableTimestamp;
+};


### PR DESCRIPTION
## Summary
- align Claim All visibility, row-level Claim enablement, and modal filtering to the same `claimableTime`-based claimability rule
- fix the Claim All modal claimed-state check so deposit claim status is evaluated from `depositAmount`
- add a small shared launchpad claimability helper to keep the three UI paths in sync

## Verification
- `yarn install --immutable`
- `yarn build`
- `lsp_diagnostics` on all changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized launchpad participation claimability checks for more consistent eligibility determination.
  * Removed periodic block-height polling from launchpad participation tracking.
  * Centralized claim status logic across launchpad components to improve code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->