### PR TITLE
fix(governance): correct delegate modal decimals

### DIFF
--- a/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
+++ b/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
@@ -414,7 +414,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
       {isOpenDelegateModal && (
         <MyDelegationDelegateModal
           currentDelegatedAmount={displayVotingWeight}
-          totalDelegatedAmount={totalDelegatedAmount}
+          totalDelegatedAmount={displayTotalDelegatedAmount}
           apy={apy}
           delegatees={delegatees}
           isWalletConnected={isWalletConnected}

--- a/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
+++ b/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
@@ -138,12 +138,12 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
       .sort((a, b) => b.usdValue - a.usdValue);
   }, [myDelegationInfo.claimableRewards, getTokenUSDPrice, tokens, getGnotPath]);
 
-  const displayVotingWeight = useMemo(() => {
+  const currentDelegatedDisplayAmount = useMemo(() => {
     const votingWeight = Number(myDelegationInfo.votingWeight) || 0;
     return rawToDisplayAmount(votingWeight, XGNS_TOKEN.decimals);
   }, [myDelegationInfo.votingWeight]);
 
-  const displayTotalDelegatedAmount = useMemo(() => {
+  const totalDelegatedDisplayAmount = useMemo(() => {
     return rawToDisplayAmount(totalDelegatedAmount, XGNS_TOKEN.decimals);
   }, [totalDelegatedAmount]);
 
@@ -413,8 +413,8 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
       </div>
       {isOpenDelegateModal && (
         <MyDelegationDelegateModal
-          currentDelegatedAmount={displayVotingWeight}
-          totalDelegatedAmount={displayTotalDelegatedAmount}
+          currentDelegatedDisplayAmount={currentDelegatedDisplayAmount}
+          totalDelegatedDisplayAmount={totalDelegatedDisplayAmount}
           apy={apy}
           delegatees={delegatees}
           isWalletConnected={isWalletConnected}
@@ -425,8 +425,8 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
       )}
       {isOpenUndelegateModal && (
         <MyDelegationUndelegateModal
-          currentDelegatedAmount={displayVotingWeight}
-          totalDelegatedAmount={displayTotalDelegatedAmount}
+          currentDelegatedAmount={currentDelegatedDisplayAmount}
+          totalDelegatedAmount={totalDelegatedDisplayAmount}
           apy={apy}
           delegatedInfos={myDelegatesInfo}
           isWalletConnected={isWalletConnected}

--- a/packages/web/src/layouts/governance/components/my-delegation/my-delegation-modals/MyDelegationDelegateModal.tsx
+++ b/packages/web/src/layouts/governance/components/my-delegation/my-delegation-modals/MyDelegationDelegateModal.tsx
@@ -34,8 +34,8 @@ import {
 import { rawToDisplayAmount } from "@utils/number-utils";
 
 interface MyDelegationDelegateModalProps {
-  currentDelegatedAmount: number;
-  totalDelegatedAmount: number;
+  currentDelegatedDisplayAmount: number;
+  totalDelegatedDisplayAmount: number;
   apy: number;
   delegatees: VerifiedDelegateInfo[];
   isWalletConnected: boolean;
@@ -45,8 +45,8 @@ interface MyDelegationDelegateModalProps {
 }
 
 const MyDelegationDelegateModal: React.FC<MyDelegationDelegateModalProps> = ({
-  currentDelegatedAmount,
-  totalDelegatedAmount,
+  currentDelegatedDisplayAmount,
+  totalDelegatedDisplayAmount,
   apy,
   delegatees,
   isWalletConnected,
@@ -68,12 +68,12 @@ const MyDelegationDelegateModal: React.FC<MyDelegationDelegateModalProps> = ({
   const [tmpDelegatee, setTmpDelegatee] = useState<VerifiedDelegateInfo>(defaultDelegateeInfo);
   const [selfAddress, setSelfAddress] = useState("");
 
-  const safeDisplayAmount = (displayValue: string | number): number => {
+  const toSafeDisplayAmountNumber = (displayValue: string | number): number => {
     const result = Number(displayValue);
     return isNaN(result) ? 0 : result;
   };
 
-  const safeRawVotingPowerAmount = (rawValue: string | number): number => {
+  const toDisplayVotingPowerFromRaw = (rawValue: string | number): number => {
     const result = rawToDisplayAmount(rawValue, XGNS_TOKEN.decimals);
     return isNaN(result) ? 0 : result;
   };
@@ -90,11 +90,11 @@ const MyDelegationDelegateModal: React.FC<MyDelegationDelegateModalProps> = ({
   }, [isValidSelfAddress, selfAddress, t]);
 
   const votingPowerPercentage = useMemo(() => {
-    const displayVotingPower = safeRawVotingPowerAmount(tmpDelegatee.votingPower);
-    const displayTotalDelegated = safeDisplayAmount(totalDelegatedAmount);
+    const displayVotingPower = toDisplayVotingPowerFromRaw(tmpDelegatee.votingPower);
+    const displayTotalDelegated = toSafeDisplayAmountNumber(totalDelegatedDisplayAmount);
 
     return displayTotalDelegated ? (displayVotingPower * 100) / displayTotalDelegated : 0;
-  }, [tmpDelegatee.votingPower, totalDelegatedAmount]);
+  }, [tmpDelegatee.votingPower, totalDelegatedDisplayAmount]);
 
   const handleClickSelfDelegateeAddress = useCallback((address: string) => setSelfAddress(address), [delegatees]);
 
@@ -154,8 +154,8 @@ const MyDelegationDelegateModal: React.FC<MyDelegationDelegateModalProps> = ({
   );
 
   const delegationCalculations = useMemo(() => {
-    const displayTotalDelegated = safeDisplayAmount(totalDelegatedAmount);
-    const displayCurrentDelegated = safeDisplayAmount(currentDelegatedAmount);
+    const displayTotalDelegated = toSafeDisplayAmountNumber(totalDelegatedDisplayAmount);
+    const displayCurrentDelegated = toSafeDisplayAmountNumber(currentDelegatedDisplayAmount);
     const inputAmount = Number(gnsAmountInput.amount) || 0;
 
     const currentPercentage = displayTotalDelegated ? (displayCurrentDelegated / displayTotalDelegated) * 100 : 0;
@@ -171,7 +171,7 @@ const MyDelegationDelegateModal: React.FC<MyDelegationDelegateModalProps> = ({
       currentPercentage,
       newPercentage,
     };
-  }, [currentDelegatedAmount, totalDelegatedAmount, gnsAmountInput.amount]);
+  }, [currentDelegatedDisplayAmount, totalDelegatedDisplayAmount, gnsAmountInput.amount]);
 
   const showDelegateInfo = () => (
     <>
@@ -236,7 +236,7 @@ const MyDelegationDelegateModal: React.FC<MyDelegationDelegateModalProps> = ({
           <div className="label">{t("Governance:myDel.delModal.step3.currentlyDel")}</div>
           <div className="value">
             <MissingLogo symbol={XGNS_TOKEN.symbol} url={XGNS_TOKEN.logoURI} width={24} />
-            {formatOtherPrice(safeDisplayAmount(currentDelegatedAmount), {
+            {formatOtherPrice(toSafeDisplayAmountNumber(currentDelegatedDisplayAmount), {
               isKMB: false,
               usd: false,
             })}
@@ -391,7 +391,7 @@ const MyDelegationDelegateModal: React.FC<MyDelegationDelegateModalProps> = ({
           <div className="label">{t("Governance:myDel.delModal.selectDel.votingPower")}</div>
           <div className="value no-wrap">
             <MissingLogo symbol="xGNS" url={XGNS_TOKEN.logoURI} width={24} />
-            {formatOtherPrice(safeRawVotingPowerAmount(tmpDelegatee.votingPower), {
+            {formatOtherPrice(toDisplayVotingPowerFromRaw(tmpDelegatee.votingPower), {
               isKMB: false,
               usd: false,
             })}{" "}

--- a/packages/web/src/layouts/governance/components/my-delegation/my-delegation-modals/MyDelegationDelegateModal.tsx
+++ b/packages/web/src/layouts/governance/components/my-delegation/my-delegation-modals/MyDelegationDelegateModal.tsx
@@ -68,7 +68,12 @@ const MyDelegationDelegateModal: React.FC<MyDelegationDelegateModalProps> = ({
   const [tmpDelegatee, setTmpDelegatee] = useState<VerifiedDelegateInfo>(defaultDelegateeInfo);
   const [selfAddress, setSelfAddress] = useState("");
 
-  const safeDisplayAmount = (rawValue: string | number): number => {
+  const safeDisplayAmount = (displayValue: string | number): number => {
+    const result = Number(displayValue);
+    return isNaN(result) ? 0 : result;
+  };
+
+  const safeRawVotingPowerAmount = (rawValue: string | number): number => {
     const result = rawToDisplayAmount(rawValue, XGNS_TOKEN.decimals);
     return isNaN(result) ? 0 : result;
   };
@@ -85,7 +90,7 @@ const MyDelegationDelegateModal: React.FC<MyDelegationDelegateModalProps> = ({
   }, [isValidSelfAddress, selfAddress, t]);
 
   const votingPowerPercentage = useMemo(() => {
-    const displayVotingPower = safeDisplayAmount(tmpDelegatee.votingPower);
+    const displayVotingPower = safeRawVotingPowerAmount(tmpDelegatee.votingPower);
     const displayTotalDelegated = safeDisplayAmount(totalDelegatedAmount);
 
     return displayTotalDelegated ? (displayVotingPower * 100) / displayTotalDelegated : 0;
@@ -386,7 +391,7 @@ const MyDelegationDelegateModal: React.FC<MyDelegationDelegateModalProps> = ({
           <div className="label">{t("Governance:myDel.delModal.selectDel.votingPower")}</div>
           <div className="value no-wrap">
             <MissingLogo symbol="xGNS" url={XGNS_TOKEN.logoURI} width={24} />
-            {formatOtherPrice(safeDisplayAmount(tmpDelegatee.votingPower), {
+            {formatOtherPrice(safeRawVotingPowerAmount(tmpDelegatee.votingPower), {
               isKMB: false,
               usd: false,
             })}{" "}


### PR DESCRIPTION
## Summary
- fix the Governance > Delegate modal so delegated amounts are normalized to display units exactly once
- keep raw API voting power conversion only where the modal still receives raw delegatee voting power data
- clarify the modal prop/helper naming so raw vs display-scaled amount contracts are explicit

## Validation
- yarn install
- yarn lint --file src/layouts/governance/components/my-delegation/MyDelegation.tsx --file src/layouts/governance/components/my-delegation/my-delegation-modals/MyDelegationDelegateModal.tsx
- yarn workspace @gnoswap-labs/web test:ci --runInBand --testPathPatterns=src/utils/number-utils.spec.ts

## Notes
- full web lint still reports pre-existing repository-wide ESLint issues unrelated to this change
- confirmed the backend delegation summary API returns raw atomic-unit strings, so this fix stays frontend-only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized display amount handling in delegation modals with improved variable naming and consistent helper functions for formatting values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->