### PR TITLE
chore(launchpad): simplify launchpad pool staking descriptions across locales

### DIFF
--- a/packages/web/public/locales/de/Launchpad.json
+++ b/packages/web/public/locales/de/Launchpad.json
@@ -162,7 +162,7 @@
       "tokensDistributed": "Verteilte Wertmarken",
       "totalDeposits": "Gesamte Einzahlung"
     },
-    "description": "Einsatz für {{month}}.<br/>Belohnungen können ab<br/>nach {{day}} Tagen beansprucht werden.",
+    "description": "Absteckung für {{month}}.",
     "title": "Pool {{idx}}"
   },
   "projects": {

--- a/packages/web/public/locales/en/Launchpad.json
+++ b/packages/web/public/locales/en/Launchpad.json
@@ -162,7 +162,7 @@
       "tokensDistributed": "Tokens Distributed",
       "totalDeposits": "Total Deposit"
     },
-    "description": "Staking for {{month}}.<br/>\nRewards claimable starting<br/>\nafter {{day}} days.",
+    "description": "Staking for {{month}}.",
     "title": "Pool {{idx}}"
   },
   "projects": {

--- a/packages/web/public/locales/es/Launchpad.json
+++ b/packages/web/public/locales/es/Launchpad.json
@@ -162,7 +162,7 @@
       "tokensDistributed": "Fichas distribuidas",
       "totalDeposits": "Depósito total"
     },
-    "description": "Apuesta por {{month}}.<br/>Recompensas reclamables a partir de<br/>después de {{day}} días.",
+    "description": "Estacas para {{month}}.",
     "title": "Piscina {{idx}}"
   },
   "projects": {

--- a/packages/web/public/locales/fr/Launchpad.json
+++ b/packages/web/public/locales/fr/Launchpad.json
@@ -167,7 +167,7 @@
       "tokensDistributed": "Jetons distribués",
       "totalDeposits": "Dépôt total"
     },
-    "description": "Mise en jeu pour {{month}}.<br/>Récompenses à réclamer à partir de<br/>après {{day}} jours.",
+    "description": "Piquetage pour {{month}}.",
     "title": "Piscine {{idx}}"
   },
   "projects": {

--- a/packages/web/public/locales/ja/Launchpad.json
+++ b/packages/web/public/locales/ja/Launchpad.json
@@ -157,7 +157,7 @@
       "tokensDistributed": "トークン配布",
       "totalDeposits": "預金総額"
     },
-    "description": "{{month}}<br/> <br/> {{day}} 日後より請求可能。",
+    "description": "{{month}} 。",
     "title": "プール{{idx}}"
   },
   "projects": {

--- a/packages/web/public/locales/ko/Launchpad.json
+++ b/packages/web/public/locales/ko/Launchpad.json
@@ -157,7 +157,7 @@
       "tokensDistributed": "분배된 토큰",
       "totalDeposits": "총 예치금"
     },
-    "description": "{{month}} 동안 스테이킹.<br/>보상은 {{day}}일 이후부터<br/>청구 가능합니다.",
+    "description": "스테이킹 {{month}}.",
     "title": "Pool {{idx}}"
   },
   "projects": {

--- a/packages/web/public/locales/ru/Launchpad.json
+++ b/packages/web/public/locales/ru/Launchpad.json
@@ -172,7 +172,7 @@
       "tokensDistributed": "Распространение токенов",
       "totalDeposits": "Общий депозит"
     },
-    "description": "Ставка на {{month}}.<br/>Вознаграждение можно получить начиная с<br/>через {{day}} дней.",
+    "description": "Ставки для {{month}}.",
     "title": "Бассейн {{idx}}"
   },
   "projects": {

--- a/packages/web/public/locales/zh/Launchpad.json
+++ b/packages/web/public/locales/zh/Launchpad.json
@@ -157,7 +157,7 @@
       "tokensDistributed": "分发的代币",
       "totalDeposits": "存款总额"
     },
-    "description": "{{month}} 的赌注。<br/> {{day}} 天后可从<br/>开始领取奖励。",
+    "description": "{{month}} 。",
     "title": "游泳池{{idx}}"
   },
   "projects": {

--- a/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-pool-list/launchpad-pool-list-card/LaunchpadPoolListSkeletonCard.tsx
+++ b/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-pool-list/launchpad-pool-list-card/LaunchpadPoolListSkeletonCard.tsx
@@ -1,11 +1,10 @@
 import { getTierDuration, TierType } from "@utils/launchpad-get-tier-number";
-import { getClaimableDays } from "@utils/launchpad-get-claimable";
 import { useTranslation } from "react-i18next";
 
-import { CardWrapper } from "./LaunchpadPoolListCard.styles";
 import { Divider } from "@components/common/select-token/SelectToken.styles";
-import LaunchpadPoolTierChip from "@layouts/launchpad/components/launchpad-pool-tier-chip/LaunchpadPoolTierChip";
 import { pulseSkeletonStyle } from "@constants/skeleton.constant";
+import LaunchpadPoolTierChip from "@layouts/launchpad/components/launchpad-pool-tier-chip/LaunchpadPoolTierChip";
+import { CardWrapper } from "./LaunchpadPoolListCard.styles";
 
 export const LaunchpadPoolListSkeletonCard = ({ idx }: { idx: number }) => {
   const { t } = useTranslation();
@@ -25,11 +24,7 @@ export const LaunchpadPoolListSkeletonCard = ({ idx }: { idx: number }) => {
         </div>
       </div>
 
-      <div className="card-description">
-        Staking for {getTierDuration(data[idx].poolTier as TierType, t)}. <br />
-        Rewards claimable starting <br />
-        after {getClaimableDays(data[idx].poolTier)} days.
-      </div>
+      <div className="card-description">Staking for {getTierDuration(data[idx].poolTier as TierType, t)}.</div>
 
       <Divider />
 


### PR DESCRIPTION
## Descriptions
This PR simplifies the launchpad pool card description by removing the claimable-days sentence and keeping a short, single-line staking description. The same copy update is applied consistently across supported locales.

### Changes
- Updated `description` text in `Launchpad.json` for:
  - `en`, `ko`, `ja`, `zh`, `de`, `es`, `fr`, `ru`
- Simplified skeleton card text in `LaunchpadPoolListSkeletonCard`:
  - Removed claimable-days copy (`Rewards claimable starting after X days`)
  - Removed `getClaimableDays` import and usage
  - Kept only `Staking for {tierDuration}.`

### Impact
- Provides cleaner and more consistent launchpad messaging in both actual content and skeleton UI.
- Reduces translation complexity by removing dynamic claimable-days wording from multiple locales.
- Aligns loading-state text with finalized card copy, improving UX consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Launchpad pool descriptions across 8 languages (English, German, Spanish, French, Japanese, Korean, Russian, Chinese) by removing reward claim timing information and retaining only staking duration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->