### PR TITLE
chore: create vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://beta.api.gnoswap.io/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` rewrite rule to proxy `/api/*` requests through Vercel edge network
- update `NEXT_PUBLIC_DEFAULT_CHAIN_API_URL` environment variable to use relative path `/api/v1`
- update `NEXT_PUBLIC_DEFAULT_CHAIN_ROUTER_URL` environment variable to use relative path `/api`

## Problem
API requests from Korean users were connecting directly to the Virginia ALB, resulting in ~800ms response times due to TCP handshake latency (~190ms) caused by physical distance between Korea and us-east-1.

## Solution
By routing API requests through Vercel's edge network, TLS termination now happens at the nearest edge node (Seoul/ICN), reducing TCP connection time from ~190ms to ~10ms.

## Verification
- Open `beta.gnoswap.io` in browser
- Open DevTools → Network tab
- Confirm `chain` request shows:
  - `Request URL: https://beta.gnoswap.io/api/v1/chain`
  - `Remote Address: 216.150.x.x` (Vercel IP)
  - Response time < 100ms