### PR TITLE
fix(governance): scale delegated ratio display

### DIFF
--- a/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.spec.tsx
+++ b/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.spec.tsx
@@ -1,0 +1,115 @@
+/// <reference types="jest" />
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Provider as JotaiProvider } from "jotai";
+
+import { GovernanceSummaryInfo } from "@repositories/governance";
+
+import GovernanceSummary from "./GovernanceSummary";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("@hooks/common/use-window-size", () => ({
+  useWindowSize: () => ({
+    isMobile: false,
+  }),
+}));
+
+jest.mock("@hooks/token/data/use-token-data", () => ({
+  useTokenData: () => ({
+    getTokenUSDPrice: () => 0,
+    tokens: [],
+  }),
+}));
+
+jest.mock("@hooks/token/data/use-gnot-wugnot", () => ({
+  useGnotToGnot: () => ({
+    getGnotPath: () => ({}),
+  }),
+}));
+
+jest.mock("@providers/gnoswap-theme-provider/GnoswapThemeProvider", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("@components/common/tooltip/Tooltip", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("@components/common/divider/divider", () => ({
+  Divider: () => <div />,
+}));
+
+jest.mock("@components/common/missing-logo/MissingLogo", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock("@components/common/video-guide-trigger/VideoGuideTrigger", () => ({
+  __esModule: true,
+  default: ({ text }: { text: string }) => <button type="button">{text}</button>,
+}));
+
+jest.mock("../token-chip/TokenChip", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock("../info-box/InfoBox", () => ({
+  __esModule: true,
+  default: ({ title, value }: { title: string; value: React.ReactNode }) => (
+    <div>{`${title}:${typeof value === "string" ? value : ""}`}</div>
+  ),
+}));
+
+jest.mock("./GovernanceSummary.styles", () => ({
+  __esModule: true,
+  GovernanceSummaryWrapper: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  GovernanceSummaryTooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const baseGovernanceSummary: GovernanceSummaryInfo = {
+  delegationInfo: {
+    totalDelegationAmount: "0",
+    governanceDelegationAmount: "0",
+    launchpadDelegationAmount: "0",
+  },
+  delegatedRatio: "0",
+  apy: "0",
+  communityPoolUsd: "0",
+};
+
+const renderGovernanceSummary = (delegatedRatio: string) => {
+  render(
+    <JotaiProvider>
+      <GovernanceSummary
+        governanceSummary={{
+          ...baseGovernanceSummary,
+          delegatedRatio,
+        }}
+        governanceCommunityPoolBalances={[]}
+        isLoading={false}
+        onOpenVideoGuide={jest.fn()}
+      />
+    </JotaiProvider>,
+  );
+};
+
+describe("GovernanceSummary Component", () => {
+  it.each<[string, string]>([
+    ["0", "0%"],
+    ["0.725", "72.5%"],
+    ["1", "100%"],
+  ])("renders delegated ratio %s as %s", (delegatedRatio, expectedDelegatedRatio) => {
+    renderGovernanceSummary(delegatedRatio);
+
+    expect(screen.getByText(`Governance:summary.delRatio.title:${expectedDelegatedRatio}`)).toBeDefined();
+  });
+});

--- a/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.tsx
+++ b/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.tsx
@@ -113,6 +113,13 @@ const GovernanceSummary: React.FC<GovernanceSummaryProps> = ({
       .sort((a, b) => b.usdValue - a.usdValue);
   }, [governanceCommunityPoolBalances]);
 
+  const delegatedRatioValue = React.useMemo(() => {
+    return `${formatOtherPrice(Number(governanceSummary.delegatedRatio) * 100, {
+      isKMB: false,
+      usd: false,
+    })}%`;
+  }, [governanceSummary.delegatedRatio]);
+
   const handleOpenVideoGuide = React.useCallback(() => {
     onOpenVideoGuide(VIDEO_GUIDE_TYPES.GOVERNANCE);
   }, [onOpenVideoGuide]);
@@ -180,10 +187,7 @@ const GovernanceSummary: React.FC<GovernanceSummaryProps> = ({
         />
         <InfoBox
           title={t("Governance:summary.delRatio.title")}
-          value={`${formatOtherPrice(Number(governanceSummary.delegatedRatio) * 100, {
-            isKMB: false,
-            usd: false,
-          })}%`}
+          value={delegatedRatioValue}
           tooltip={t("Governance:summary.delRatio.tooltip")}
           isLoading={isLoading}
         />

--- a/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.tsx
+++ b/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.tsx
@@ -180,7 +180,7 @@ const GovernanceSummary: React.FC<GovernanceSummaryProps> = ({
         />
         <InfoBox
           title={t("Governance:summary.delRatio.title")}
-          value={`${formatOtherPrice(governanceSummary.delegatedRatio, {
+          value={`${formatOtherPrice(Number(governanceSummary.delegatedRatio) * 100, {
             isKMB: false,
             usd: false,
           })}%`}


### PR DESCRIPTION
## Summary
- scale the governance delegated ratio display by 100 before appending `%` so the UI matches the raw ratio returned by the API
- add a focused governance summary spec covering representative ratio-to-percent rendering cases
- verify the API contract on dev: `/v1/governance/summary` returns delegatedRatio as a 0-1 ratio string

## Verification
- `yarn workspace @gnoswap-labs/web test GovernanceSummary.spec.tsx --runInBand`
- `yarn workspace @gnoswap-labs/web build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the delegated ratio percentage display to properly format and present calculated values.

* **Tests**
  * Added test coverage for the governance summary component with multiple delegated ratio scenarios (0%, 72.5%, 100%).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->