### PR TITLE
fix(pool): show actual owned position count

### DIFF
--- a/packages/web/src/layouts/pool/pool-add/containers/additional-info-container/AdditionalInfoContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-add/containers/additional-info-container/AdditionalInfoContainer.tsx
@@ -52,9 +52,30 @@ const AdditionalInfoContainer: React.FC = () => {
     return pools.some(pool => pool.poolPath === poolPath);
   }, [poolPath, pools]);
 
+  const {
+    totalPositionCount,
+    loading: isLoadingTotalPositionCount,
+  } = usePositionData({
+    isClosed: false,
+    poolPath: poolPath || "",
+    limit: 1,
+    queryOption: {
+      enabled: !!poolPath,
+    },
+  });
+
+  const positionLimit = useMemo(() => {
+    if (!totalPositionCount) {
+      return 20;
+    }
+
+    return totalPositionCount;
+  }, [totalPositionCount]);
+
   const { positions, loading: isLoadingPosition } = usePositionData({
     isClosed: false,
     poolPath: poolPath || "",
+    limit: positionLimit,
     queryOption: {
       enabled: !!poolPath,
     },
@@ -105,7 +126,13 @@ const AdditionalInfoContainer: React.FC = () => {
       handleClickGotoStaking={handleClickGotoStaking}
       pool={data}
       poolPath={poolPath}
-      isLoadingPool={isLoadingRPCPoolInfo || isFetchingFeetierOfLiquidityMap || isLoadingPoolInfo || isLoadingPosition}
+      isLoadingPool={
+        isLoadingRPCPoolInfo ||
+        isFetchingFeetierOfLiquidityMap ||
+        isLoadingPoolInfo ||
+        isLoadingPosition ||
+        isLoadingTotalPositionCount
+      }
       isLoadingGraph={isLoadingPoolInfo}
       isReversed={isReversed}
     />

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.tsx
@@ -18,6 +18,7 @@ interface MyLiquidityProps {
   isOtherPosition: boolean;
   openedPosition: PoolPositionModel[];
   closedPosition: PoolPositionModel[];
+  totalPositionCount: number;
   breakpoint: DEVICE_TYPE;
   connected: boolean;
   isSwitchNetwork: boolean;
@@ -45,6 +46,7 @@ const MyLiquidity: React.FC<MyLiquidityProps> = ({
   isOwnerAddress,
   addressName,
   openedPosition,
+  totalPositionCount,
   breakpoint,
   connected,
   isSwitchNetwork,
@@ -84,7 +86,7 @@ const MyLiquidity: React.FC<MyLiquidityProps> = ({
           isSwitchNetwork={isSwitchNetwork}
           address={address}
           addressName={addressName}
-          positionLength={showedPositions.length}
+          positionLength={totalPositionCount}
           isShowRemovePositionButton={isShowRemovePositionButton}
           handleClickAddPosition={handleClickAddPosition}
           handleClickRemovePosition={handleClickRemovePosition}

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -47,7 +47,12 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   const { connected: connectedWallet, isSwitchNetwork, account, currentChainId } = useWallet();
   const [currentIndex, setCurrentIndex] = useState(1);
   const poolPath = router.getPoolPath();
-  const { positions: positions, loading: isLoadingPosition, refetch: refetchPositions } = usePositionData({
+  const {
+    positions: positions,
+    totalPositionCount,
+    loading: isLoadingPosition,
+    refetch: refetchPositions,
+  } = usePositionData({
     address,
     poolPath,
     queryOption: {
@@ -276,6 +281,7 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
       isOtherPosition={isOtherPosition}
       openedPosition={visiblePositions ? openedPosition : []}
       closedPosition={closedPosition}
+      totalPositionCount={totalPositionCount}
       breakpoint={breakpoint}
       connected={connectedWallet}
       isSwitchNetwork={isSwitchNetwork}


### PR DESCRIPTION
## Summary
- update pool detail to show the real owned position count from the positions API instead of the paginated slice length
- update pool add additional info to fetch the full pool-specific position set when the total exceeds the default page size so staked and unstaked counts are not capped at 20
- keep the change frontend-only across the affected pool detail and pool add containers

## Validation
- yarn workspace @gnoswap-labs/web build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved position data loading mechanism to dynamically calculate position limits based on total available positions, enhancing performance and display accuracy for pool liquidity positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->