### PR TITLE
fix(pool): add view more for pool positions

### DIFF
--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.styles.ts
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.styles.ts
@@ -45,7 +45,7 @@ export const MyLiquidityWrapper = styled.div`
   }
 
   .view-more-wrap {
-    ${mixins.flexbox("row", "center", "flex-start")};
+    ${mixins.flexbox("row", "center", "center")};
     width: 100%;
   }
 `;

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.styles.ts
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.styles.ts
@@ -47,6 +47,10 @@ export const MyLiquidityWrapper = styled.div`
   .view-more-wrap {
     ${mixins.flexbox("row", "center", "center")};
     width: 100%;
+    margin-top: 8px;
+    ${media.mobile} {
+      margin-top: 4px;
+    }
   }
 `;
 

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.styles.ts
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.styles.ts
@@ -43,6 +43,11 @@ export const MyLiquidityWrapper = styled.div`
       color: ${({ theme }) => theme.color.text03};
     }
   }
+
+  .view-more-wrap {
+    ${mixins.flexbox("row", "center", "flex-start")};
+    width: 100%;
+  }
 `;
 
 export const PoolDivider = styled.div`

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 
+import LoadMoreButton from "@components/common/load-more-button/LoadMoreButton";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { TokenPriceModel } from "@models/token/token-price-model";
 import { DEVICE_TYPE } from "@styles/media";
@@ -37,6 +38,8 @@ interface MyLiquidityProps {
   isHiddenAddPosition: boolean;
   showClosePositionButton: boolean;
   tokenPrices: Record<string, TokenPriceModel>;
+  showViewMorePositions: boolean;
+  handleViewMorePositions: () => void;
 }
 
 const MyLiquidity: React.FC<MyLiquidityProps> = ({
@@ -65,6 +68,8 @@ const MyLiquidity: React.FC<MyLiquidityProps> = ({
   showClosePositionButton,
   tokenPrices,
   closedPosition,
+  showViewMorePositions,
+  handleViewMorePositions,
 }) => {
   const showedPositions = useMemo(() => {
     if (!isShowClosePosition) {
@@ -159,6 +164,7 @@ const MyLiquidity: React.FC<MyLiquidityProps> = ({
             )}
           </>
         ))}
+      {showViewMorePositions && <LoadMoreButton show={true} onClick={handleViewMorePositions} />}
     </MyLiquidityWrapper>
   );
 };

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.tsx
@@ -164,7 +164,11 @@ const MyLiquidity: React.FC<MyLiquidityProps> = ({
             )}
           </>
         ))}
-      {showViewMorePositions && <LoadMoreButton show={true} onClick={handleViewMorePositions} />}
+      {showViewMorePositions && (
+        <div className="view-more-wrap">
+          <LoadMoreButton show={true} onClick={handleViewMorePositions} />
+        </div>
+      )}
     </MyLiquidityWrapper>
   );
 };

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ERROR_VALUE } from "@common/errors/adena";
 import { useBroadcastHandler } from "@hooks/common/use-broadcast-handler";
@@ -24,6 +24,8 @@ import { PoolPositionModel } from "@models/position/pool-position-model";
 import { PositionConverter } from "@services/converters/position";
 import MyLiquidity from "../../components/my-liquidity/MyLiquidity";
 
+const DEFAULT_POSITION_LIMIT = 20;
+
 interface MyLiquidityContainerProps {
   addressContext: {
     urlAddress: string;
@@ -46,10 +48,24 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   const { breakpoint } = useWindowSize();
   const { connected: connectedWallet, isSwitchNetwork, account, currentChainId } = useWallet();
   const [currentIndex, setCurrentIndex] = useState(1);
+  const [isViewAllPositions, setIsViewAllPositions] = useState(false);
+  const [positionLimit, setPositionLimit] = useState(DEFAULT_POSITION_LIMIT);
   const poolPath = router.getPoolPath();
-  const { positions: positions, loading: isLoadingPosition, refetch: refetchPositions } = usePositionData({
+
+  useEffect(() => {
+    setPositionLimit(DEFAULT_POSITION_LIMIT);
+    setIsViewAllPositions(false);
+  }, [address, poolPath]);
+
+  const {
+    positions: positions,
+    loading: isLoadingPosition,
+    refetch: refetchPositions,
+    totalPositionCount,
+  } = usePositionData({
     address,
     poolPath,
+    limit: positionLimit,
     queryOption: {
       enabled: !!poolPath,
     },
@@ -268,6 +284,15 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     return haveNotClosedPosition;
   }, [connectedWallet, haveNotClosedPosition, isSwitchNetwork]);
 
+  const showViewMorePositions = useMemo(() => {
+    return !isViewAllPositions && totalPositionCount > DEFAULT_POSITION_LIMIT;
+  }, [isViewAllPositions, totalPositionCount]);
+
+  const handleViewMorePositions = useCallback(() => {
+    setPositionLimit(Math.max(totalPositionCount, DEFAULT_POSITION_LIMIT));
+    setIsViewAllPositions(true);
+  }, [totalPositionCount]);
+
   return (
     <MyLiquidity
       address={address}
@@ -295,6 +320,8 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
       isHiddenAddPosition={!!((address && account?.address && address !== account?.address) || !account?.address)}
       showClosePositionButton={showClosePositionButton}
       tokenPrices={tokenPrices}
+      showViewMorePositions={showViewMorePositions}
+      handleViewMorePositions={handleViewMorePositions}
     />
   );
 };

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -48,17 +48,18 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   const { breakpoint } = useWindowSize();
   const { connected: connectedWallet, isSwitchNetwork, account, currentChainId } = useWallet();
   const [currentIndex, setCurrentIndex] = useState(1);
-  const [isViewAllPositions, setIsViewAllPositions] = useState(false);
-  const [positionLimit, setPositionLimit] = useState(DEFAULT_POSITION_LIMIT);
+  const [positionPage, setPositionPage] = useState(1);
+  const [loadedPositions, setLoadedPositions] = useState<PoolPositionModel[]>([]);
   const poolPath = router.getPoolPath();
+  const normalizedAddress = useMemo(() => (address || "").toLowerCase(), [address]);
 
   const positionScopeId = useMemo(() => {
-    return ["my-liquidity", address || "", poolPath || "", positionLimit].join("-");
-  }, [address, poolPath, positionLimit]);
+    return ["my-liquidity", address || "", poolPath || "", DEFAULT_POSITION_LIMIT, positionPage].join("-");
+  }, [address, poolPath, positionPage]);
 
   useEffect(() => {
-    setPositionLimit(DEFAULT_POSITION_LIMIT);
-    setIsViewAllPositions(false);
+    setPositionPage(1);
+    setLoadedPositions([]);
   }, [address, poolPath]);
 
   const {
@@ -69,12 +70,38 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   } = usePositionData({
     address,
     poolPath,
-    limit: positionLimit,
+    page: positionPage,
+    limit: DEFAULT_POSITION_LIMIT,
     scopeId: positionScopeId,
     queryOption: {
       enabled: !!poolPath,
     },
   });
+
+  useEffect(() => {
+    if (!address || !poolPath || positions.length === 0) {
+      return;
+    }
+
+    const currentPagePositions = positions.filter(
+      position => position.poolPath === poolPath && position.owner.toLowerCase() === normalizedAddress,
+    );
+
+    if (currentPagePositions.length === 0) {
+      return;
+    }
+
+    setLoadedPositions(prev => {
+      const loadedPositionIds = new Set(prev.map(position => position.id));
+      const nextPositions = currentPagePositions.filter(position => !loadedPositionIds.has(position.id));
+
+      if (nextPositions.length === 0) {
+        return prev;
+      }
+
+      return [...prev, ...nextPositions];
+    });
+  }, [address, poolPath, positions, normalizedAddress]);
 
   const { invalidateQueryKey } = useInvalidateQueries();
 
@@ -86,7 +113,7 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     ]);
   }, [invalidateQueryKey, currentChainId, address]);
 
-  const { claimAll, claim } = usePosition(positions.filter(item => !item.closed));
+  const { claimAll, claim } = usePosition(loadedPositions.filter(item => !item.closed));
   const [loadingTransactionClaim, setLoadingTransactionClaim] = useState(false);
   const [isShowClosePosition, setIsShowClosedPosition] = useState(false);
   const { openModal } = useTransactionConfirmModal();
@@ -104,9 +131,9 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   const accountPositions: PoolPositionModel[] = useMemo(() => {
     if (!address || !poolPath) return [];
 
-    const filteredPositions = positions.filter(position => position.poolPath === poolPath);
+    const filteredPositions = loadedPositions.filter(position => position.poolPath === poolPath);
     return PositionConverter.convertPositions(filteredPositions);
-  }, [address, poolPath, positions]);
+  }, [address, poolPath, loadedPositions]);
 
   const visiblePositions = useMemo(() => {
     if (!address) {
@@ -290,13 +317,16 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   }, [connectedWallet, haveNotClosedPosition, isSwitchNetwork]);
 
   const showViewMorePositions = useMemo(() => {
-    return !isViewAllPositions && totalPositionCount > DEFAULT_POSITION_LIMIT;
-  }, [isViewAllPositions, totalPositionCount]);
+    return accountPositions.length > 0 && accountPositions.length < totalPositionCount;
+  }, [accountPositions.length, totalPositionCount]);
 
   const handleViewMorePositions = useCallback(() => {
-    setPositionLimit(Math.max(totalPositionCount, DEFAULT_POSITION_LIMIT));
-    setIsViewAllPositions(true);
-  }, [totalPositionCount]);
+    if (accountPositions.length >= totalPositionCount) {
+      return;
+    }
+
+    setPositionPage(prev => prev + 1);
+  }, [accountPositions.length, totalPositionCount]);
 
   return (
     <MyLiquidity

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -49,16 +49,18 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   const { connected: connectedWallet, isSwitchNetwork, account, currentChainId } = useWallet();
   const [currentIndex, setCurrentIndex] = useState(1);
   const [positionPage, setPositionPage] = useState(1);
+  const [positionLimit, setPositionLimit] = useState(DEFAULT_POSITION_LIMIT);
   const [loadedPositions, setLoadedPositions] = useState<PoolPositionModel[]>([]);
   const poolPath = router.getPoolPath();
   const normalizedAddress = useMemo(() => (address || "").toLowerCase(), [address]);
 
   const positionScopeId = useMemo(() => {
-    return ["my-liquidity", address || "", poolPath || "", DEFAULT_POSITION_LIMIT, positionPage].join("-");
-  }, [address, poolPath, positionPage]);
+    return ["my-liquidity", address || "", poolPath || "", positionLimit, positionPage].join("-");
+  }, [address, poolPath, positionLimit, positionPage]);
 
   useEffect(() => {
     setPositionPage(1);
+    setPositionLimit(DEFAULT_POSITION_LIMIT);
     setLoadedPositions([]);
   }, [address, poolPath]);
 
@@ -71,7 +73,7 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     address,
     poolPath,
     page: positionPage,
-    limit: DEFAULT_POSITION_LIMIT,
+    limit: positionLimit,
     scopeId: positionScopeId,
     queryOption: {
       enabled: !!poolPath,
@@ -325,7 +327,8 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
       return;
     }
 
-    setPositionPage(prev => prev + 1);
+    setPositionPage(1);
+    setPositionLimit(Math.max(totalPositionCount, DEFAULT_POSITION_LIMIT));
   }, [accountPositions.length, totalPositionCount]);
 
   return (

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -52,6 +52,10 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   const [positionLimit, setPositionLimit] = useState(DEFAULT_POSITION_LIMIT);
   const poolPath = router.getPoolPath();
 
+  const positionScopeId = useMemo(() => {
+    return ["my-liquidity", address || "", poolPath || "", positionLimit].join("-");
+  }, [address, poolPath, positionLimit]);
+
   useEffect(() => {
     setPositionLimit(DEFAULT_POSITION_LIMIT);
     setIsViewAllPositions(false);
@@ -66,6 +70,7 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     address,
     poolPath,
     limit: positionLimit,
+    scopeId: positionScopeId,
     queryOption: {
       enabled: !!poolPath,
     },


### PR DESCRIPTION
## Summary
- add a View More control to pool detail My Liquidity when a user has more than the default 20 positions in the same pool
- keep the initial request capped at 20 positions, then load the full remaining set on expand while preserving the centered placement and reset behavior on pool/address changes
- keep claim and rendered position state in sync with the expanded list

## Validation
- yarn workspace @gnoswap-labs/web build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented paginated loading for user liquidity positions. A "View More" button now appears when additional positions exist, enabling users to load them on-demand. This improves page performance and provides a better experience for users managing multiple liquidity positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->