### PR TITLE
fix(swap): remove swap fee handling in exact out

### DIFF
--- a/packages/web/src/hooks/swap/data/use-swap.tsx
+++ b/packages/web/src/hooks/swap/data/use-swap.tsx
@@ -33,7 +33,7 @@ interface UseSwapProps {
   swapFee?: number;
 }
 
-export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: UseSwapProps) => {
+export const useSwap = ({ tokenA, tokenB, direction, slippage }: UseSwapProps) => {
   const { transactionService, swapRouterRepository, rpcProvider } = useGnoswapContext();
   const { getNextReferralAddress, nextReferralAddress } = useReferral();
   const { data: gasTokenPrice } = useGetTokenPrices(GasToken.path);
@@ -73,8 +73,6 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
 
   const selectedTokenPair = tokenA !== null && tokenB !== null;
 
-  const exactOutPadding = 1 / (1 - swapFee / 10000);
-
   const isSameToken = useMemo(() => {
     if (!tokenA || !tokenB) {
       return false;
@@ -99,8 +97,8 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
       return debouncedSwapAmount;
     }
 
-    return debouncedSwapAmount ? debouncedSwapAmount * exactOutPadding : debouncedSwapAmount;
-  }, [debouncedSwapAmount, direction, exactOutPadding]);
+    return debouncedSwapAmount;
+  }, [debouncedSwapAmount, direction]);
 
   const { data: estimatedSwapResult, isLoading: isEstimatedSwapLoading, isRefetching, error } = useGetRoutes(
     {
@@ -132,7 +130,14 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
     }
 
     return "SUCCESS";
-  }, [debouncedSwapAmount, estimatedSwapResult?.status, isEstimatedSwapLoading, isSameToken, selectedTokenPair, shouldFetch]);
+  }, [
+    debouncedSwapAmount,
+    estimatedSwapResult?.status,
+    isEstimatedSwapLoading,
+    isSameToken,
+    selectedTokenPair,
+    shouldFetch,
+  ]);
 
   const estimatedRoutes: EstimatedRoute[] | null = useMemo(() => {
     if (isSameToken) {
@@ -299,7 +304,7 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
         return swapRouterRepository.sendExactOutSwapRoute({
           inputToken: tokenA,
           outputToken: tokenB,
-          tokenAmount: Number(tokenAmount) * exactOutPadding,
+          tokenAmount: Number(tokenAmount),
           estimatedRoutes: estimatedRoutes,
           slippage: slippage,
           originAmount: estimatedSwapResult?.originAmount || 0,
@@ -320,7 +325,6 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
       slippage,
       tokenAmountLimit,
       tokenB,
-      exactOutPadding,
       getNextReferralAddress,
       networkFee?.amount,
       currentGasInfo?.gasUsed,
@@ -332,10 +336,7 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
     if (isSameToken) {
       tokenAmount = swapAmount || 0;
     } else {
-      tokenAmount =
-        direction === "EXACT_IN"
-          ? Number(debouncedSwapAmount || 0)
-          : Number(debouncedSwapAmount || 0) * exactOutPadding;
+      tokenAmount = direction === "EXACT_IN" ? Number(debouncedSwapAmount || 0) : Number(debouncedSwapAmount || 0);
     }
 
     return {
@@ -352,7 +353,6 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
     };
   }, [
     direction,
-    exactOutPadding,
     isSameToken,
     tokenA,
     tokenB,

--- a/packages/web/src/repositories/swap-router/swap-router-repository-impl.ts
+++ b/packages/web/src/repositories/swap-router/swap-router-repository-impl.ts
@@ -14,6 +14,7 @@ import { getGRC20Allowance } from "@common/clients/gno-provider";
 import { drySwap } from "@common/clients/gno-provider/methods/dry-swap";
 import { DEFAULT_GAS_FEE, DEFAULT_GAS_WANTED } from "@common/values";
 import { GnoProvider } from "@gnolang/gno-js-client";
+import { generateSendTransactionParams, withTransactionGuard } from "@utils/transaction-utils";
 import { GetRoutesRequest } from "./request/get-routes-request";
 import { DrySwapRequest, SwapRouteRequest } from "./request/swap-route-request";
 import { UnwrapTokenRequest } from "./request/unwrap-token-request";
@@ -27,7 +28,6 @@ import {
   makeUnwrapTokenMessages,
   makeWrapTokenMessages,
 } from "./swap-router.message";
-import { generateSendTransactionParams, withTransactionGuard } from "@utils/transaction-utils";
 
 export class SwapRouterRepositoryImpl implements SwapRouterRepository {
   private rpcProvider: GnoProvider | null;


### PR DESCRIPTION
## Description

### Summary
This PR fixes exact-out swap handling by removing extra fee padding logic that was being applied in the frontend.  
The entered exact-out amount is now passed through consistently for route estimation and transaction submission.

### What changed
- Removed `swapFee` default usage from `useSwap` and eliminated `exactOutPadding` calculations.
- Stopped multiplying exact-out amounts during:
  - debounced amount processing
  - `sendExactOutSwapRoute` request payload generation
  - swap amount display/state derivation
- Kept exact-in behavior unchanged while making exact-out amount handling consistent end-to-end.
- Reordered imports in `swap-router-repository-impl.ts` (non-functional cleanup).

### Why
The router already handles swap fee mechanics internally, so applying additional frontend-side padding for exact-out introduced incorrect amount inflation and mismatch risk between user intent and executed transaction parameters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified swap calculations for exact output trades by removing padding adjustments.
  * Streamlined swap hook configuration by removing optional swap fee parameters.

* **Chores**
  * Reorganized internal utility imports in swap router module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->