### PR TITLE
fix(governance): align text proposal headings

### DIFF
--- a/packages/web/src/layouts/governance/components/proposals-list/view-proposal-modal/ViewProposalModal.styles.spec.tsx
+++ b/packages/web/src/layouts/governance/components/proposals-list/view-proposal-modal/ViewProposalModal.styles.spec.tsx
@@ -1,3 +1,5 @@
+import "@testing-library/jest-dom";
+
 import { render, screen, waitFor } from "@testing-library/react";
 import { Provider as JotaiProvider } from "jotai";
 
@@ -6,23 +8,6 @@ import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapTheme
 import { GNOSWAP_THEME_KEY } from "@states/theme";
 
 import { ProposalContentWrapper } from "./ViewProposalModal.styles";
-
-const hexToRgb = (hexColor: string) => {
-  const hex = hexColor.replace("#", "");
-  const normalized =
-    hex.length === 3
-      ? hex
-          .split("")
-          .map(value => value + value)
-          .join("")
-      : hex;
-
-  const red = Number.parseInt(normalized.slice(0, 2), 16);
-  const green = Number.parseInt(normalized.slice(2, 4), 16);
-  const blue = Number.parseInt(normalized.slice(4, 6), 16);
-
-  return `rgb(${red}, ${green}, ${blue})`;
-};
 
 const renderProposalContent = (themeKey: "dark" | "light") => {
   localStorage.setItem(GNOSWAP_THEME_KEY, JSON.stringify(themeKey));
@@ -71,9 +56,9 @@ describe("ProposalContentWrapper markdown heading hierarchy", () => {
       const heading = screen.getByRole("heading", { level: 1, name: "Markdown Heading" });
       const content = screen.getByTestId("markdown-content");
 
-      expect(getComputedStyle(heading).color).toBe(hexToRgb(headingColor));
-      expect(getComputedStyle(content).color).toBe(hexToRgb(bodyColor));
-      expect(getComputedStyle(heading).color).not.toBe(getComputedStyle(content).color);
+      expect(heading).toHaveStyle({ color: headingColor });
+      expect(content).toHaveStyle({ color: bodyColor });
+      expect(headingColor).not.toBe(bodyColor);
     },
   );
 });

--- a/packages/web/src/layouts/governance/components/proposals-list/view-proposal-modal/ViewProposalModal.styles.spec.tsx
+++ b/packages/web/src/layouts/governance/components/proposals-list/view-proposal-modal/ViewProposalModal.styles.spec.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { Provider as JotaiProvider } from "jotai";
+
+import { DARK_THEME_COLORS, LIGHT_THEME_COLORS } from "@constants/theme.constant";
+import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
+import { GNOSWAP_THEME_KEY } from "@states/theme";
+
+import { ProposalContentWrapper } from "./ViewProposalModal.styles";
+
+const hexToRgb = (hexColor: string) => {
+  const hex = hexColor.replace("#", "");
+  const normalized =
+    hex.length === 3
+      ? hex
+          .split("")
+          .map(value => value + value)
+          .join("")
+      : hex;
+
+  const red = Number.parseInt(normalized.slice(0, 2), 16);
+  const green = Number.parseInt(normalized.slice(2, 4), 16);
+  const blue = Number.parseInt(normalized.slice(4, 6), 16);
+
+  return `rgb(${red}, ${green}, ${blue})`;
+};
+
+const renderProposalContent = (themeKey: "dark" | "light") => {
+  localStorage.setItem(GNOSWAP_THEME_KEY, JSON.stringify(themeKey));
+
+  render(
+    <JotaiProvider>
+      <GnoswapThemeProvider>
+        <ProposalContentWrapper>
+          <div className="content" data-testid="markdown-content">
+            <div className="markdown-style">
+              <h1>Markdown Heading</h1>
+              <p>Markdown Body</p>
+            </div>
+          </div>
+        </ProposalContentWrapper>
+      </GnoswapThemeProvider>
+    </JotaiProvider>,
+  );
+};
+
+describe("ProposalContentWrapper markdown heading hierarchy", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it.each([
+    {
+      themeKey: "dark" as const,
+      headingColor: DARK_THEME_COLORS.text03,
+      bodyColor: DARK_THEME_COLORS.text04,
+    },
+    {
+      themeKey: "light" as const,
+      headingColor: LIGHT_THEME_COLORS.text03,
+      bodyColor: LIGHT_THEME_COLORS.text04,
+    },
+  ])(
+    "uses stronger heading color than body in $themeKey mode",
+    async ({ themeKey, headingColor, bodyColor }) => {
+      renderProposalContent(themeKey);
+
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { level: 1, name: "Markdown Heading" })).toBeTruthy();
+      });
+
+      const heading = screen.getByRole("heading", { level: 1, name: "Markdown Heading" });
+      const content = screen.getByTestId("markdown-content");
+
+      expect(getComputedStyle(heading).color).toBe(hexToRgb(headingColor));
+      expect(getComputedStyle(content).color).toBe(hexToRgb(bodyColor));
+      expect(getComputedStyle(heading).color).not.toBe(getComputedStyle(content).color);
+    },
+  );
+});

--- a/packages/web/src/layouts/governance/components/proposals-list/view-proposal-modal/ViewProposalModal.styles.ts
+++ b/packages/web/src/layouts/governance/components/proposals-list/view-proposal-modal/ViewProposalModal.styles.ts
@@ -150,6 +150,11 @@ export const ProposalContentWrapper = styled.div`
     .markdown-style {
       width: 100%;
       white-space: pre-wrap;
+      h1,
+      h2,
+      h3 {
+        color: ${({ theme }) => theme.color.text03};
+      }
       h1 {
         ${fonts.body5}
       }


### PR DESCRIPTION
## Summary
- apply the stronger `text03` color to markdown headings in the text proposal modal so heading hierarchy matches the existing pool spend label treatment
- keep body text styling unchanged and add a focused regression spec that verifies the heading/body color split in both dark and light themes

## Verification
- `npx jest src/layouts/governance/components/proposals-list/view-proposal-modal/ViewProposalModal.styles.spec.tsx --runInBand`
- `yarn workspace @gnoswap-labs/web build`
- `yarn workspace @gnoswap-labs/web lint` *(currently reports pre-existing unrelated repo errors outside this diff)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed heading color styling in governance proposal content so headings correctly follow light/dark theme colors.

* **Tests**
  * Added tests that verify heading and body text colors across light and dark themes, assert heading color differs from body color, and ensure theme state is cleared between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->