### PR TITLE
refactor(web): refactor `GasInfo` into a discriminated union

### DIFF
--- a/packages/web/src/hooks/common/use-network-fee.ts
+++ b/packages/web/src/hooks/common/use-network-fee.ts
@@ -2,14 +2,12 @@ import React from "react";
 import BigNumber from "bignumber.js";
 import { useAtomValue } from "jotai";
 
-import { GasInfo, NetworkFee, useGetEstimateGasInfo, useGetGasPrice } from "@hooks/gas";
+import { GasInfo, NetworkFee, buildGasInfo, getGasUsed, useGetEstimateGasInfo, useGetGasPrice } from "@hooks/gas";
 import { Document } from "src/types/transaction-messages.types";
 import { GasToken } from "@common/values/token-constant";
 import { useGnoswapContext } from "./use-gnoswap-context";
 import { makeEstimateGasTransaction } from "@utils/transaction-utils";
 import { WalletState } from "@states/index";
-import { GAS_WANTED_BUFFER_MULTIPLIER } from "@common/values";
-import { calculateAdjustedGasFee } from "@utils/gas-utils";
 
 export interface UseNetworkFeeReturn {
   currentGasInfo: GasInfo | null;
@@ -30,7 +28,7 @@ export const useNetworkFee = (document: Document | null, gasInfo?: GasInfo | nul
     data: estimatedGasInfo,
     isLoading: isLoadingGasInfo,
     isFetching: isFetchingGasInfo,
-  } = useGetEstimateGasInfo(document, gasInfo?.gasUsed || 0);
+  } = useGetEstimateGasInfo(document, getGasUsed(gasInfo));
 
   const currentGasInfo = React.useMemo(() => estimatedGasInfo || null, [estimatedGasInfo]);
 
@@ -46,7 +44,7 @@ export const useNetworkFee = (document: Document | null, gasInfo?: GasInfo | nul
   };
 
   const networkFee: NetworkFee | null = React.useMemo(() => {
-    if (!currentGasInfo) return null;
+    if (!currentGasInfo || currentGasInfo.status !== "success") return null;
 
     return {
       amount: formatNetworkFeeAmount(currentGasInfo.gasFee),
@@ -88,41 +86,17 @@ export const useNetworkFee = (document: Document | null, gasInfo?: GasInfo | nul
         }))
         .catch(() => null);
 
-      if (!resultGasUsed) {
-        return {
-          currentGasInfo: {
-            gasFee: 0,
-            gasUsed: 0,
-            gasWanted: 0,
-            gasPrice: 0,
-            hasError: true,
-            simulateErrorMessage: "",
-          },
-          networkFee: null,
-        };
-      }
-
-      const { gasFee, gasUsed, gasWanted } = calculateAdjustedGasFee(
-        resultGasUsed.gasUsed,
-        gasPrice,
-        GAS_WANTED_BUFFER_MULTIPLIER,
-      );
-
-      const gasInfoResult: GasInfo = {
-        gasFee,
-        gasUsed,
-        gasWanted,
-        gasPrice,
-        hasError: resultGasUsed.errorMessage !== null,
-        simulateErrorMessage: resultGasUsed.errorMessage,
-      };
+      const gasInfoResult = buildGasInfo(resultGasUsed, gasPrice);
 
       return {
         currentGasInfo: gasInfoResult,
-        networkFee: {
-          amount: formatNetworkFeeAmount(gasFee),
-          denom: GasToken.symbol,
-        },
+        networkFee:
+          gasInfoResult.status === "success"
+            ? {
+                amount: formatNetworkFeeAmount(gasInfoResult.gasFee),
+                denom: GasToken.symbol,
+              }
+            : null,
       };
     } catch (error) {
       console.error("Error estimating network fee:", error);

--- a/packages/web/src/hooks/gas/build-gas-info.spec.ts
+++ b/packages/web/src/hooks/gas/build-gas-info.spec.ts
@@ -1,0 +1,70 @@
+import { buildGasInfo, getGasUsed } from "./build-gas-info";
+
+describe("buildGasInfo", () => {
+  it("returns error gas info when result is null", () => {
+    expect(buildGasInfo(null, 1)).toEqual({
+      status: "error",
+      simulateErrorMessage: "",
+    });
+  });
+
+  it("returns error gas info when simulation returns an error message", () => {
+    expect(
+      buildGasInfo(
+        {
+          gasUsed: 123,
+          errorMessage: "simulation failed",
+        },
+        1,
+      ),
+    ).toEqual({
+      status: "error",
+      simulateErrorMessage: "simulation failed",
+    });
+  });
+
+  it("returns success gas info with adjusted gas values when simulation succeeds", () => {
+    expect(
+      buildGasInfo(
+        {
+          gasUsed: 100,
+          errorMessage: null,
+        },
+        2,
+      ),
+    ).toEqual({
+      status: "success",
+      gasFee: 220,
+      gasUsed: 110,
+      gasWanted: 110,
+      gasPrice: 2,
+    });
+  });
+});
+
+describe("getGasUsed", () => {
+  it("returns 0 for null gas info", () => {
+    expect(getGasUsed(null)).toBe(0);
+  });
+
+  it("returns 0 for error gas info", () => {
+    expect(
+      getGasUsed({
+        status: "error",
+        simulateErrorMessage: "simulation failed",
+      }),
+    ).toBe(0);
+  });
+
+  it("returns gasUsed for success gas info", () => {
+    expect(
+      getGasUsed({
+        status: "success",
+        gasFee: 220,
+        gasUsed: 110,
+        gasWanted: 110,
+        gasPrice: 2,
+      }),
+    ).toBe(110);
+  });
+});

--- a/packages/web/src/hooks/gas/build-gas-info.ts
+++ b/packages/web/src/hooks/gas/build-gas-info.ts
@@ -1,0 +1,40 @@
+import { GAS_WANTED_BUFFER_MULTIPLIER } from "@common/values";
+import { calculateAdjustedGasFee } from "@utils/gas-utils";
+
+import { GasInfo } from "./types";
+
+export function buildGasInfo(
+  resultGasUsed: { gasUsed: number; errorMessage: string | null } | null,
+  gasPrice: number,
+): GasInfo {
+  if (!resultGasUsed) {
+    return {
+      status: "error",
+      simulateErrorMessage: "",
+    };
+  }
+
+  if (resultGasUsed.errorMessage !== null) {
+    return {
+      status: "error",
+      simulateErrorMessage: resultGasUsed.errorMessage,
+    };
+  }
+
+  const { gasFee, gasUsed, gasWanted } = calculateAdjustedGasFee(
+    resultGasUsed.gasUsed,
+    gasPrice,
+    GAS_WANTED_BUFFER_MULTIPLIER,
+  );
+
+  return {
+    status: "success",
+    gasFee,
+    gasUsed,
+    gasWanted,
+    gasPrice,
+  };
+}
+
+export const getGasUsed = (gasInfo: GasInfo | null | undefined): number =>
+  gasInfo?.status === "success" ? gasInfo.gasUsed : 0;

--- a/packages/web/src/hooks/gas/index.ts
+++ b/packages/web/src/hooks/gas/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
+export * from "./build-gas-info";
 export * from "./use-get-gas-price";
 export * from "./use-get-estimate-gas-info";

--- a/packages/web/src/hooks/gas/types.ts
+++ b/packages/web/src/hooks/gas/types.ts
@@ -1,11 +1,15 @@
-export interface GasInfo {
-  gasFee: number;
-  gasUsed: number;
-  gasWanted: number;
-  gasPrice: number;
-  hasError?: boolean;
-  simulateErrorMessage: string | null;
-}
+export type GasInfo =
+  | {
+      status: "success";
+      gasFee: number;
+      gasUsed: number;
+      gasWanted: number;
+      gasPrice: number;
+    }
+  | {
+      status: "error";
+      simulateErrorMessage: string;
+    };
 
 export interface NetworkFee {
   amount: string;

--- a/packages/web/src/hooks/gas/use-get-estimate-gas-info.ts
+++ b/packages/web/src/hooks/gas/use-get-estimate-gas-info.ts
@@ -6,8 +6,7 @@ import { makeEstimateGasTransaction } from "@utils/transaction-utils";
 
 import { Document } from "src/types/transaction-messages.types";
 import { QUERY_KEY } from "@query/query-keys";
-import { GAS_WANTED_BUFFER_MULTIPLIER } from "@common/values";
-import { calculateAdjustedGasFee } from "@utils/gas-utils";
+import { buildGasInfo } from "./build-gas-info";
 
 const REFETCH_INTERVAL = 10_000;
 
@@ -25,7 +24,7 @@ export const useGetEstimateGasInfo = (
     return makeEstimateGasTransaction(document, transactionService, gasUsed, gasPrice);
   }
 
-  return useQuery({
+  return useQuery<GasInfo | null, Error>({
     queryKey: [QUERY_KEY.gasInfo, document?.msgs],
     queryFn: async () => {
       if (!transactionService || !gasPrice) return null;
@@ -41,31 +40,7 @@ export const useGetEstimateGasInfo = (
         }))
         .catch(() => null);
 
-      if (!resultGasUsed) {
-        return {
-          gasFee: 0,
-          gasUsed: 0,
-          gasWanted: 0,
-          gasPrice: 0,
-          hasError: true,
-          simulateErrorMessage: "",
-        };
-      }
-
-      const { gasFee, gasUsed, gasWanted } = calculateAdjustedGasFee(
-        resultGasUsed.gasUsed,
-        gasPrice,
-        GAS_WANTED_BUFFER_MULTIPLIER,
-      );
-
-      return {
-        gasFee,
-        gasUsed,
-        gasWanted,
-        gasPrice,
-        hasError: resultGasUsed.errorMessage !== null,
-        simulateErrorMessage: resultGasUsed.errorMessage,
-      };
+      return buildGasInfo(resultGasUsed, gasPrice);
     },
     refetchInterval: REFETCH_INTERVAL,
     keepPreviousData: true,

--- a/packages/web/src/hooks/pool/data/use-pool.tsx
+++ b/packages/web/src/hooks/pool/data/use-pool.tsx
@@ -17,6 +17,7 @@ import {
   makePositionMintMessageWithApproves,
 } from "@repositories/pool/pool.message";
 import { GnoProvider } from "@common/clients/gno-provider/gno-provider";
+import { getGasUsed } from "@hooks/gas";
 import { useNetworkFee } from "@hooks/common/use-network-fee";
 import { fetchAllowance } from "@common/clients/wallet-client/transaction-messages";
 
@@ -146,7 +147,7 @@ export const usePool = ({ compareToken, tokenA, tokenB, isReverted = false }: Pr
     const requestWithGasInfo: CreatePoolRequest = {
       ...request,
       gasFee: networkFee?.amount,
-      gasUsed: currentGasInfo?.gasUsed.toString(),
+      gasUsed: getGasUsed(currentGasInfo).toString(),
     };
 
     return poolRepository.createPool(requestWithGasInfo).catch(e => {
@@ -263,7 +264,7 @@ export const usePool = ({ compareToken, tokenA, tokenB, isReverted = false }: Pr
     const requestWithGasInfo: AddLiquidityRequest = {
       ...request,
       gasFee: networkFee?.amount,
-      gasUsed: currentGasInfo?.gasUsed.toString(),
+      gasUsed: getGasUsed(currentGasInfo).toString(),
     };
 
     return poolRepository.addLiquidity({ ...requestWithGasInfo }).catch(e => {

--- a/packages/web/src/hooks/pool/data/use-position.ts
+++ b/packages/web/src/hooks/pool/data/use-position.ts
@@ -2,6 +2,7 @@ import { GnoProvider } from "@common/clients/gno-provider/gno-provider";
 import { fetchAllowance } from "@common/clients/wallet-client/transaction-messages";
 import { CommonError } from "@common/errors";
 import { useNetworkFee } from "@hooks/common/use-network-fee";
+import { getGasUsed } from "@hooks/gas";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { PositionModel } from "@models/position/position-model";
@@ -44,7 +45,7 @@ export const usePosition = (positions: PositionModel[]) => {
     const requestWithGasInfo: ClaimAllRequest = {
       ...request,
       gasFee: networkFee?.amount,
-      gasUsed: currentGasInfo?.gasUsed.toString(),
+      gasUsed: getGasUsed(currentGasInfo).toString(),
     };
 
     return positionRepository.sendClaimAll(requestWithGasInfo).catch(() => null);
@@ -107,7 +108,7 @@ export const usePosition = (positions: PositionModel[]) => {
     const requestWithGasInfo: ClaimRequest = {
       ...request,
       gasFee: networkFee?.amount,
-      gasUsed: currentGasInfo?.gasUsed.toString(),
+      gasUsed: getGasUsed(currentGasInfo).toString(),
     };
 
     return positionRepository.sendClaim(requestWithGasInfo).catch(() => null);

--- a/packages/web/src/hooks/pool/data/use-reposition-handle.tsx
+++ b/packages/web/src/hooks/pool/data/use-reposition-handle.tsx
@@ -27,6 +27,7 @@ import { useReferral } from "@hooks/common/use-referral";
 import { useSlippage } from "@hooks/common/use-slippage";
 import { useTransactionConfirmModal } from "@hooks/common/use-transaction-confirm-modal";
 import { useTransactionEventStore } from "@hooks/common/use-transaction-event-store";
+import { getGasUsed } from "@hooks/gas";
 import { usePositionData } from "@hooks/pool/data/use-position-data";
 import { useSelectPool } from "@hooks/pool/data/use-select-pool";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
@@ -481,7 +482,7 @@ export const useRepositionHandle = () => {
       const requestWithGasInfo: RemoveLiquidityRequest = {
         ...request,
         gasFee: networkFee?.amount,
-        gasUsed: currentGasInfo?.gasUsed.toString(),
+        gasUsed: getGasUsed(currentGasInfo).toString(),
       };
 
       return positionRepository.removeLiquidity(requestWithGasInfo).catch(() => null);
@@ -580,7 +581,7 @@ export const useRepositionHandle = () => {
       const requestWithGasInfo: SwapRouteRequest = {
         ...request,
         gasFee: networkFee?.amount,
-        gasUsed: currentGasInfo?.gasUsed.toString(),
+        gasUsed: getGasUsed(currentGasInfo).toString(),
       };
 
       return isExactIn
@@ -793,7 +794,7 @@ export const useRepositionHandle = () => {
       const requestWithGasInfo: RepositionLiquidityRequest = {
         ...request,
         gasFee: networkFee?.amount,
-        gasUsed: currentGasInfo?.gasUsed.toString(),
+        gasUsed: getGasUsed(currentGasInfo).toString(),
       };
 
       return positionRepository

--- a/packages/web/src/hooks/pool/ui/use-decrease-position-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-decrease-position-modal.tsx
@@ -27,6 +27,7 @@ import { fetchAllowance } from "@common/clients/wallet-client/transaction-messag
 import { CommonError } from "@common/errors";
 import { BROADCAST_ERROR_VALUE } from "@common/errors/broadcast/broadcast-error";
 import { useNetworkFee } from "@hooks/common/use-network-fee";
+import { getGasUsed } from "@hooks/gas";
 import { useTokenData } from "@hooks/token/data/use-token-data";
 import { makeDecreaseLiquidityMessagesWithApproves } from "@repositories/position/position.message";
 import { DecreaseLiquidityRequest } from "@repositories/position/request";
@@ -142,7 +143,7 @@ export const useDecreasePositionModal = ({
     const requestWithGasInfo: DecreaseLiquidityRequest = {
       ...request,
       gasFee: networkFee?.amount,
-      gasUsed: currentGasInfo?.gasUsed.toString(),
+      gasUsed: getGasUsed(currentGasInfo).toString(),
     };
 
     return await positionRepository.decreaseLiquidity(requestWithGasInfo).catch(() => null);

--- a/packages/web/src/hooks/pool/ui/use-increase-position-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-increase-position-modal.tsx
@@ -21,6 +21,7 @@ import { fetchAllowance } from "@common/clients/wallet-client/transaction-messag
 import { CommonError } from "@common/errors";
 import { BROADCAST_ERROR_VALUE } from "@common/errors/broadcast/broadcast-error";
 import { useNetworkFee } from "@hooks/common/use-network-fee";
+import { getGasUsed } from "@hooks/gas";
 import { useTransactionEventStore } from "@hooks/common/use-transaction-event-store";
 import { useTokenData } from "@hooks/token/data/use-token-data";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
@@ -143,7 +144,7 @@ export const useIncreasePositionModal = ({
     const requestWithGasInfo: IncreaseLiquidityRequest = {
       ...request,
       gasFee: networkFee?.amount,
-      gasUsed: currentGasInfo?.gasUsed.toString(),
+      gasUsed: getGasUsed(currentGasInfo).toString(),
     };
 
     return await positionRepository.increaseLiquidity(requestWithGasInfo).catch(() => null);

--- a/packages/web/src/hooks/swap/data/use-swap.tsx
+++ b/packages/web/src/hooks/swap/data/use-swap.tsx
@@ -20,7 +20,7 @@ import { makeDisplayTokenAmount } from "@utils/token-utils";
 import { TransactionMessage } from "@common/clients/wallet-client/protocols";
 import { SwapDirectionType } from "@common/values";
 import { GasToken } from "@common/values/token-constant";
-import { NetworkFee, useGetGasPrice } from "@hooks/gas";
+import { NetworkFee, getGasUsed, useGetGasPrice } from "@hooks/gas";
 import { EstimatedRoute } from "@models/swap/swap-route-info";
 import { TokenModel, isNativeToken } from "@models/token/token-model";
 import { Document } from "src/types/transaction-messages.types";
@@ -43,6 +43,7 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
   const useNetworkFeeReturn = useNetworkFee(transactionDocument);
   const networkFee = useNetworkFeeReturn.networkFee;
   const currentGasInfo = useNetworkFeeReturn.currentGasInfo;
+  const currentGasUsed = getGasUsed(currentGasInfo);
 
   const { account } = useWallet();
   const { data: gasPrice } = useGetGasPrice();
@@ -258,10 +259,10 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
         token: tokenA,
         tokenAmount,
         gasFee: networkFee?.amount,
-        gasUsed: String(currentGasInfo?.gasUsed),
+        gasUsed: String(currentGasUsed),
       });
     },
-    [account, selectedTokenPair, swapRouterRepository, tokenA, networkFee?.amount, currentGasInfo?.gasUsed],
+    [account, selectedTokenPair, swapRouterRepository, tokenA, networkFee?.amount, currentGasUsed],
   );
 
   const swap = useCallback(
@@ -277,7 +278,7 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
 
       const gasInfo = {
         gasFee: networkFee?.amount,
-        gasUsed: String(currentGasInfo?.gasUsed),
+        gasUsed: String(currentGasUsed),
       };
 
       if (direction === "EXACT_IN") {
@@ -323,7 +324,7 @@ export const useSwap = ({ tokenA, tokenB, direction, slippage, swapFee = 15 }: U
       exactOutPadding,
       getNextReferralAddress,
       networkFee?.amount,
-      currentGasInfo?.gasUsed,
+      currentGasUsed,
     ],
   );
 

--- a/packages/web/src/hooks/wallet/data/useSendAsset.tsx
+++ b/packages/web/src/hooks/wallet/data/useSendAsset.tsx
@@ -15,6 +15,7 @@ import { formatPoolPairAmount } from "@utils/new-number-utils";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
 import { makeTransferGNOTTokenMessages, makeTransferGRC20TokenMessages } from "@repositories/wallet/wallet.message";
 import { useNetworkFee } from "@hooks/common/use-network-fee";
+import { getGasUsed } from "@hooks/gas";
 
 type Request = TransferGRC20TokenRequest | TransferNativeTokenRequest;
 export type WithdrawResponse = {
@@ -73,7 +74,7 @@ const useSendAsset = () => {
       const requestWithGasInfo = {
         ...request,
         gasFee: networkFee?.amount,
-        gasUsed: currentGasInfo?.gasUsed.toString(),
+        gasUsed: getGasUsed(currentGasInfo).toString(),
       } as Request & { gasFee?: string; gasUsed?: string };
 
       return isNativeTransfer

--- a/packages/web/src/layouts/pool/pool-incentivize/containers/incentivize-pool-modal-container/IncentivizePoolModalContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/containers/incentivize-pool-modal-container/IncentivizePoolModalContainer.tsx
@@ -20,6 +20,7 @@ import { EarnState } from "@states/index";
 import IncentivizePoolModal from "../../components/incentivize-pool-modal/IncentivizePoolModal";
 import { useTokenData } from "@hooks/token/data/use-token-data";
 import { BROADCAST_ERROR_VALUE } from "@common/errors/broadcast/broadcast-error";
+import { getGasUsed } from "@hooks/gas";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { useNetworkFee } from "@hooks/common/use-network-fee";
 import { CreateExternalIncentiveRequest } from "@repositories/pool/request/create-external-incentive-request";
@@ -107,7 +108,7 @@ const IncentivizePoolModalContainer: React.FC<IncentivizePoolModalContainerProps
     const requestWithGasInfo: CreateExternalIncentiveRequest = {
       ...request,
       gasFee: networkFee?.amount,
-      gasUsed: currentGasInfo?.gasUsed.toString(),
+      gasUsed: getGasUsed(currentGasInfo).toString(),
     };
 
     return poolRepository.createExternalIncentive(requestWithGasInfo);

--- a/packages/web/src/layouts/pool/pool-remove/containers/remove-position-modal-container/RemovePositionModalContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-remove/containers/remove-position-modal-container/RemovePositionModalContainer.tsx
@@ -28,6 +28,7 @@ import { checkGnotPath, delay } from "@utils/common";
 import { formatPoolPairAmount } from "@utils/new-number-utils";
 
 import { BROADCAST_ERROR_VALUE } from "@common/errors/broadcast/broadcast-error";
+import { getGasUsed } from "@hooks/gas";
 import { usePositionsRewards } from "@hooks/pool/data/use-positions-rewards";
 import { useTokenData } from "@hooks/token/data/use-token-data";
 import RemovePositionModal from "../../components/remove-position-modal/RemovePositionModal";
@@ -117,7 +118,7 @@ const RemovePositionModalContainer = ({
     const requestWithGasInfo: RemoveLiquidityRequest = {
       ...request,
       gasFee: networkFee?.amount,
-      gasUsed: currentGasInfo?.gasUsed.toString(),
+      gasUsed: getGasUsed(currentGasInfo).toString(),
     };
 
     return await positionRepository.removeLiquidity(requestWithGasInfo).catch(() => null);

--- a/packages/web/src/layouts/pool/pool-stake/containers/stake-position-modal-container/StakePositionModalContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-stake/containers/stake-position-modal-container/StakePositionModalContainer.tsx
@@ -21,6 +21,7 @@ import { makeStakePositionsMessagesWithApproves } from "@repositories/position/p
 import { useNetworkFee } from "@hooks/common/use-network-fee";
 import { useAddress } from "@hooks/common/use-address";
 import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
+import { getGasUsed } from "@hooks/gas";
 import { QUERY_KEY } from "@query/query-keys";
 import { delay } from "@utils/common";
 
@@ -117,7 +118,7 @@ const StakePositionModalContainer = ({ positions, refetchPositions }: StakePosit
     const requestWithGasInfo: StakePositionsRequest = {
       ...request,
       gasFee: networkFee?.amount,
-      gasUsed: currentGasInfo?.gasUsed.toString(),
+      gasUsed: getGasUsed(currentGasInfo).toString(),
     };
 
     return await positionRepository.stakePositions(requestWithGasInfo).catch(() => null);

--- a/packages/web/src/layouts/pool/pool-unstake/containers/unstake-position-modal-container/UnstakePositionModalContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-unstake/containers/unstake-position-modal-container/UnstakePositionModalContainer.tsx
@@ -17,6 +17,7 @@ import { fetchAllowance } from "@common/clients/wallet-client/transaction-messag
 import { CommonError } from "@common/errors";
 import { BROADCAST_ERROR_VALUE } from "@common/errors/broadcast/broadcast-error";
 import { useNetworkFee } from "@hooks/common/use-network-fee";
+import { getGasUsed } from "@hooks/gas";
 import { useTransactionEventStore } from "@hooks/common/use-transaction-event-store";
 import { usePositionsRewards } from "@hooks/pool/data/use-positions-rewards";
 import { useTokenData } from "@hooks/token/data/use-token-data";
@@ -79,7 +80,7 @@ const UnstakePositionModalContainer = ({ positions, refetchPositions }: UnstakeP
     const requestWithGasInfo: UnstakePositionsRequest = {
       ...request,
       gasFee: networkFee?.amount,
-      gasUsed: currentGasInfo?.gasUsed.toString(),
+      gasUsed: getGasUsed(currentGasInfo).toString(),
     };
 
     return await positionRepository.unstakePositions(requestWithGasInfo).catch(() => null);

--- a/packages/web/src/react-query/pools/use-remove-external-incentive.ts
+++ b/packages/web/src/react-query/pools/use-remove-external-incentive.ts
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
+import { getGasUsed } from "@hooks/gas";
 
 import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { TokenModel } from "@models/token/token-model";
@@ -52,7 +53,7 @@ export const useRemoveExternalIncentive = (
     const requestWithGasInfo: RemoveExternalIncentiveRequest = {
       ...request,
       gasFee: networkFee?.amount,
-      gasUsed: currentGasInfo?.gasUsed.toString(),
+      gasUsed: getGasUsed(currentGasInfo).toString(),
     };
 
     return poolRepository.removeExternalIncentive(requestWithGasInfo);


### PR DESCRIPTION
## Description

This PR refactors `GasInfo` from a product type into a discriminated union to remove impossible states and make gas-related flows safer at the type level.

For example, `GasInfo` allowed contradictory states such as:
- `hasError = false` with an error message
- gas numeric fields present alongside an error state

This change removes this impossible combinations from the type system and makes downstream usage explicit.

It also centralizes gas info construction and updates gas consumers to read gas values only from the success branch.

## Changes

- convert `GasInfo` to a discriminated union with:
    - `status: "success"`
    - `status: "error"`
- remove the legacy `hasError` field
- add `buildGasInfo()` to centralize gas info creation
- add `getGasUsed()` to safely read `gasUsed` from `GasInfo`
- update gas estimation and network fee hooks to use the shared builder
- narrow gas reads across swap, pool, wallet, and modal flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Normalized and centralized gas estimation and gas-used handling across transaction flows for more consistent fee behavior.
* **Bug Fixes**
  * Network fee now only shown for successful estimates and avoids presenting misleading fee values on failures.
* **Tests**
  * Added tests covering gas-info construction and gas-used extraction to ensure correct fee/result handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->