### PR TITLE
fix(swap): display incentivize history

### DIFF
--- a/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
@@ -1,27 +1,25 @@
-import React from "react";
-import Link from "next/link";
-import { useTranslation, Trans } from "react-i18next";
 import { css } from "@emotion/react";
+import Link from "next/link";
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
 
-import { ExtendedPoolStakingModel } from "@models/pool/pool-staking";
-import { capitalize } from "@utils/string-utils";
-import { useGetPoolDetailByPath } from "@query/pools";
 import { getDateUtcToLocal } from "@common/utils/date-util";
-import { toNumberFormat } from "@utils/number-utils";
-import { PoolMapper } from "@models/pool/mapper/pool-mapper";
-import { makeDisplayTokenAmount } from "@utils/token-utils";
 import { GNS_TOKEN } from "@common/values/token-constant";
+import { PoolMapper } from "@models/pool/mapper/pool-mapper";
+import { ExtendedPoolStakingModel } from "@models/pool/pool-staking";
+import { useGetPoolDetailByPath } from "@query/pools";
+import { toNumberFormat } from "@utils/number-utils";
+import { capitalize } from "@utils/string-utils";
 
-import { IncentivizePoolHistoryBoxWrapper } from "./IncentivizePoolHistoryBox.styles";
 import Button, { ButtonHierarchy } from "@components/common/button/Button";
-import IconInfo from "@components/common/icons/IconInfo";
-import Tooltip from "@components/common/tooltip/Tooltip";
 import DoubleLogo from "@components/common/double-logo/DoubleLogo";
-import MissingLogo from "@components/common/missing-logo/MissingLogo";
+import IconInfo from "@components/common/icons/IconInfo";
 import IconOpenLink from "@components/common/icons/IconOpenLink";
-import { historyTooltipContent } from "./IncentivizePoolHistoryBox.styles";
-import { useRemoveExternalIncentive } from "@query/pools/use-remove-external-incentive";
+import MissingLogo from "@components/common/missing-logo/MissingLogo";
+import Tooltip from "@components/common/tooltip/Tooltip";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
+import { useRemoveExternalIncentive } from "@query/pools/use-remove-external-incentive";
+import { historyTooltipContent, IncentivizePoolHistoryBoxWrapper } from "./IncentivizePoolHistoryBox.styles";
 
 interface IncentivizePoolHistoryBoxProps {
   stakingData: ExtendedPoolStakingModel;
@@ -63,10 +61,10 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
     return currentPool?.feeRate ? currentPool.feeRate : "-";
   }, [currentPool]);
 
-  const formatAmount = (amount: string | null) => {
+  const formatAmount = (amount: string | null, decimals: number = GNS_TOKEN.decimals) => {
     if (amount == null || amount === "") return "-";
 
-    return toNumberFormat(Number(makeDisplayTokenAmount(GNS_TOKEN, amount)), GNS_TOKEN.decimals);
+    return toNumberFormat(Number(amount), decimals);
   };
 
   const isClaimableTime = React.useMemo(() => {
@@ -123,7 +121,7 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
             </Tooltip>
           </div>
           <div className="value">
-            {toNumberFormat(stakingData.incentivizedAmount, 6)} {rewardToken.symbol}
+            {formatAmount(stakingData.incentivizedAmount, rewardToken.decimals)} {rewardToken.symbol}
           </div>
         </div>
         <div className="row">
@@ -145,7 +143,7 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
             </Tooltip>
           </div>
           <div className="value">
-            {toNumberFormat(stakingData.remainingAmount, 6)} {rewardToken.symbol}
+            {formatAmount(stakingData.remainingAmount, rewardToken.decimals)} {rewardToken.symbol}
           </div>
         </div>
         <div className="row">
@@ -177,7 +175,9 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
               <IconInfo size={16} />
             </Tooltip>
           </div>
-          <div className="value">-</div>
+          <div className="value">
+            {formatAmount(stakingData.unvestedAmount, rewardToken.decimals)} {rewardToken.symbol}
+          </div>
         </div>
 
         <div className="row">
@@ -199,7 +199,7 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
             </Tooltip>
           </div>
           <div className="value">
-            {formatAmount(stakingData.depositGnsAmount)} {GNS_TOKEN.symbol}
+            {formatAmount(stakingData.depositGnsAmount, GNS_TOKEN.decimals)} {GNS_TOKEN.symbol}
           </div>
         </div>
 

--- a/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
@@ -64,7 +64,7 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
   const formatAmount = (amount: string | null, decimals: number = GNS_TOKEN.decimals) => {
     if (amount == null || amount === "") return "-";
 
-    return toNumberFormat(Number(amount), decimals);
+    return toNumberFormat(amount, decimals);
   };
 
   const isClaimableTime = React.useMemo(() => {

--- a/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
@@ -30,13 +30,13 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
   const { t } = useTranslation();
   const { rpcProvider } = useGnoswapContext();
 
-  const { rewardToken, startTimestamp, endTimestamp } = stakingData;
+  const { rewardToken, incentiveId } = stakingData;
 
   const { data: pool = null } = useGetPoolDetailByPath(poolPath, {
     enabled: !!poolPath,
   });
 
-  const { removeExternalIncentive } = useRemoveExternalIncentive(poolPath, rewardToken, startTimestamp, endTimestamp);
+  const { removeExternalIncentive } = useRemoveExternalIncentive(poolPath, incentiveId);
 
   const currentPool = React.useMemo(() => {
     const temp = pool ? PoolMapper.toPoolSelectItemInfo(pool) : null;

--- a/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
@@ -36,7 +36,7 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
     enabled: !!poolPath,
   });
 
-  const { removeExternalIncentive } = useRemoveExternalIncentive(poolPath, incentiveId);
+  const { removeExternalIncentive } = useRemoveExternalIncentive(poolPath, incentiveId ?? "");
 
   const currentPool = React.useMemo(() => {
     const temp = pool ? PoolMapper.toPoolSelectItemInfo(pool) : null;
@@ -203,7 +203,7 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
           </div>
         </div>
 
-        {isClaimableTime && (
+        {isClaimableTime && !!incentiveId && (
           <div className="button-wrapper">
             <Button
               text={"Claim"}

--- a/packages/web/src/layouts/pool/pool-incentivize/containers/incentivize-pool-history-container/IncentivizePoolHistoryContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/containers/incentivize-pool-history-container/IncentivizePoolHistoryContainer.tsx
@@ -28,9 +28,9 @@ const IncentivizePoolHistoryContainer = () => {
       return {
         ...item,
         rewardToken: displayToken,
-        remainingAmount: String(makeDisplayTokenAmount(item.rewardToken, item.remainingAmount || "0") ?? "0"),
-        incentivizedAmount: String(makeDisplayTokenAmount(item.rewardToken, item.incentivizedAmount || "0") ?? "0"),
-        unvestedAmount: String(makeDisplayTokenAmount(item.rewardToken, item.unvestedAmount || "0") ?? "0"),
+        remainingAmount: String(makeDisplayTokenAmount(displayToken, item.remainingAmount || "0") ?? "0"),
+        incentivizedAmount: String(makeDisplayTokenAmount(displayToken, item.incentivizedAmount || "0") ?? "0"),
+        unvestedAmount: String(makeDisplayTokenAmount(displayToken, item.unvestedAmount || "0") ?? "0"),
         depositGnsAmount: String(
           makeDisplayTokenAmount(GNS_TOKEN, (item as ExtendedPoolStakingModel).depositGnsAmount || "0") ?? "0",
         ),

--- a/packages/web/src/layouts/pool/pool-incentivize/containers/incentivize-pool-history-container/IncentivizePoolHistoryContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/containers/incentivize-pool-history-container/IncentivizePoolHistoryContainer.tsx
@@ -1,11 +1,20 @@
+import BigNumber from "bignumber.js";
+
 import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { ExtendedPoolStakingModel } from "@models/pool/pool-staking";
+import { TokenModel } from "@models/token/token-model";
 import { useGetPoolStakingListByAddress } from "@query/pools/use-get-pool-staking-list-by-address";
 
 import { GNS_TOKEN } from "@common/values/token-constant";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
-import { makeDisplayTokenAmount } from "@utils/token-utils";
 import IncentivizePoolHistory from "../../components/incentivize-pool-history/IncentivizePoolHistory";
+
+// String/BigNumber-based shift so raw integer amounts keep full precision even beyond
+const shiftToDisplay = (token: Pick<TokenModel, "decimals">, amount: string) => {
+  const bn = new BigNumber(amount);
+  if (bn.isNaN()) return "0";
+  return bn.shiftedBy(-(token.decimals || 0)).toFixed();
+};
 
 const IncentivizePoolHistoryContainer = () => {
   const { account } = useWallet();
@@ -28,12 +37,10 @@ const IncentivizePoolHistoryContainer = () => {
       return {
         ...item,
         rewardToken: displayToken,
-        remainingAmount: String(makeDisplayTokenAmount(displayToken, item.remainingAmount || "0") ?? "0"),
-        incentivizedAmount: String(makeDisplayTokenAmount(displayToken, item.incentivizedAmount || "0") ?? "0"),
-        unvestedAmount: String(makeDisplayTokenAmount(displayToken, item.unvestedAmount || "0") ?? "0"),
-        depositGnsAmount: String(
-          makeDisplayTokenAmount(GNS_TOKEN, (item as ExtendedPoolStakingModel).depositGnsAmount || "0") ?? "0",
-        ),
+        remainingAmount: shiftToDisplay(displayToken, item.remainingAmount || "0"),
+        incentivizedAmount: shiftToDisplay(displayToken, item.incentivizedAmount || "0"),
+        unvestedAmount: shiftToDisplay(displayToken, item.unvestedAmount || "0"),
+        depositGnsAmount: shiftToDisplay(GNS_TOKEN, (item as ExtendedPoolStakingModel).depositGnsAmount || "0"),
       };
     })
     .sort((a, b) => {

--- a/packages/web/src/layouts/pool/pool-incentivize/containers/incentivize-pool-history-container/IncentivizePoolHistoryContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/containers/incentivize-pool-history-container/IncentivizePoolHistoryContainer.tsx
@@ -1,13 +1,15 @@
-import React from "react";
-
 import { useWallet } from "@hooks/wallet/data/use-wallet";
-import { useGetPoolStakingListByAddress } from "@query/pools/use-get-pool-staking-list-by-address";
 import { ExtendedPoolStakingModel } from "@models/pool/pool-staking";
+import { useGetPoolStakingListByAddress } from "@query/pools/use-get-pool-staking-list-by-address";
 
+import { GNS_TOKEN } from "@common/values/token-constant";
+import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
+import { makeDisplayTokenAmount } from "@utils/token-utils";
 import IncentivizePoolHistory from "../../components/incentivize-pool-history/IncentivizePoolHistory";
 
 const IncentivizePoolHistoryContainer = () => {
   const { account } = useWallet();
+  const { gnot, wugnotPath, getGnotPath } = useGnotToGnot();
 
   const { data: rawPoolStakingList = [], isFetched: isFetchedStakingList } = useGetPoolStakingListByAddress(
     account?.address || "",
@@ -17,10 +19,23 @@ const IncentivizePoolHistoryContainer = () => {
   );
 
   const poolStakingList: ExtendedPoolStakingModel[] = rawPoolStakingList
-    .map(item => ({
-      ...item,
-      depositGnsAmount: (item as ExtendedPoolStakingModel).depositGnsAmount,
-    }))
+    .map(item => {
+      const isWugnot = item.rewardToken.path === wugnotPath;
+      const displayToken = isWugnot
+        ? { ...item.rewardToken, ...getGnotPath(item.rewardToken), path: gnot?.path || item.rewardToken.path }
+        : item.rewardToken;
+
+      return {
+        ...item,
+        rewardToken: displayToken,
+        remainingAmount: String(makeDisplayTokenAmount(item.rewardToken, item.remainingAmount || "0") ?? "0"),
+        incentivizedAmount: String(makeDisplayTokenAmount(item.rewardToken, item.incentivizedAmount || "0") ?? "0"),
+        unvestedAmount: String(makeDisplayTokenAmount(item.rewardToken, item.unvestedAmount || "0") ?? "0"),
+        depositGnsAmount: String(
+          makeDisplayTokenAmount(GNS_TOKEN, (item as ExtendedPoolStakingModel).depositGnsAmount || "0") ?? "0",
+        ),
+      };
+    })
     .sort((a, b) => {
       const dateA = new Date(a.startTimestamp);
       const dateB = new Date(b.startTimestamp);

--- a/packages/web/src/models/pool/mapper/pool-staking-mapper.ts
+++ b/packages/web/src/models/pool/mapper/pool-staking-mapper.ts
@@ -10,6 +10,7 @@ export class PoolStakingMapper {
   public static fromResponse(poolStaking: PoolStakingResponse): PoolStakingModel {
     return {
       ...poolStaking,
+      incentiveId: poolStaking?.incentiveId || "",
       unvestedAmount: poolStaking.penaltyAmount || "0",
       incentiveType: poolStaking.incentiveType as INCENTIVE_TYPE,
     };

--- a/packages/web/src/models/pool/mapper/pool-staking-mapper.ts
+++ b/packages/web/src/models/pool/mapper/pool-staking-mapper.ts
@@ -10,6 +10,7 @@ export class PoolStakingMapper {
   public static fromResponse(poolStaking: PoolStakingResponse): PoolStakingModel {
     return {
       ...poolStaking,
+      unvestedAmount: poolStaking.penaltyAmount || "0",
       incentiveType: poolStaking.incentiveType as INCENTIVE_TYPE,
     };
   }

--- a/packages/web/src/models/pool/mapper/pool-staking-mapper.ts
+++ b/packages/web/src/models/pool/mapper/pool-staking-mapper.ts
@@ -10,8 +10,8 @@ export class PoolStakingMapper {
   public static fromResponse(poolStaking: PoolStakingResponse): PoolStakingModel {
     return {
       ...poolStaking,
-      incentiveId: poolStaking?.incentiveId || "",
-      unvestedAmount: poolStaking.penaltyAmount || "0",
+      incentiveId: poolStaking?.incentiveId || null,
+      unvestedAmount: poolStaking.penaltyAmount || poolStaking.unvestedAmount || "0",
       incentiveType: poolStaking.incentiveType as INCENTIVE_TYPE,
     };
   }

--- a/packages/web/src/models/pool/pool-staking.ts
+++ b/packages/web/src/models/pool/pool-staking.ts
@@ -2,6 +2,7 @@ import { INCENTIVE_TYPE } from "@constants/option.constant";
 import { TokenModel } from "@models/token/token-model";
 
 export interface PoolStakingModel {
+  incentiveId: string;
   incentiveType: INCENTIVE_TYPE;
   tier: string;
   poolPath: string;

--- a/packages/web/src/models/pool/pool-staking.ts
+++ b/packages/web/src/models/pool/pool-staking.ts
@@ -2,7 +2,7 @@ import { INCENTIVE_TYPE } from "@constants/option.constant";
 import { TokenModel } from "@models/token/token-model";
 
 export interface PoolStakingModel {
-  incentiveId: string;
+  incentiveId: string | null;
   incentiveType: INCENTIVE_TYPE;
   tier: string;
   poolPath: string;

--- a/packages/web/src/react-query/pools/use-remove-external-incentive.ts
+++ b/packages/web/src/react-query/pools/use-remove-external-incentive.ts
@@ -2,21 +2,15 @@ import React from "react";
 
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 
-import { useWallet } from "@hooks/wallet/data/use-wallet";
-import { TokenModel } from "@models/token/token-model";
-import { useNetworkFee } from "@hooks/common/use-network-fee";
-import { RemoveExternalIncentiveRequest } from "@repositories/pool/request/remove-external-incentive-request";
 import { GnoProvider } from "@common/clients/gno-provider/gno-provider";
-import { CommonError } from "@common/errors";
 import { fetchAllowance } from "@common/clients/wallet-client/transaction-messages";
+import { CommonError } from "@common/errors";
+import { useNetworkFee } from "@hooks/common/use-network-fee";
+import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { makeRemoveExternalIncentiveMessageWithApproves } from "@repositories/pool/pool.message";
+import { RemoveExternalIncentiveRequest } from "@repositories/pool/request/remove-external-incentive-request";
 
-export const useRemoveExternalIncentive = (
-  poolPath: string,
-  rewardToken: TokenModel,
-  startTimestamp: string,
-  endTimestamp: string,
-) => {
+export const useRemoveExternalIncentive = (poolPath: string, incentiveID: string) => {
   const { poolRepository, transactionService } = useGnoswapContext();
   const { account, walletClient } = useWallet();
   const { estimateNetworkFee } = useNetworkFee(null);
@@ -67,9 +61,7 @@ export const useRemoveExternalIncentive = (
 
       const request: RemoveExternalIncentiveRequest = {
         poolPath,
-        rewardToken,
-        startTimestamp,
-        endTimestamp,
+        incentiveID,
       };
 
       const walletType = walletClient?.getWalletType();
@@ -78,7 +70,7 @@ export const useRemoveExternalIncentive = (
         ? buildAdenaWalletRemoveIncentiveAction(request)
         : buildSocialWalletRemoveIncentiveAction(rpcProvider, request, address);
     },
-    [walletClient, account?.address, poolRepository, poolPath, rewardToken],
+    [walletClient, account?.address, poolRepository, poolPath, incentiveID],
   );
 
   return { removeExternalIncentive };

--- a/packages/web/src/repositories/pool/pool-repository-impl.ts
+++ b/packages/web/src/repositories/pool/pool-repository-impl.ts
@@ -10,8 +10,8 @@ import { CommonError } from "@common/errors";
 import { PoolError } from "@common/errors/pool";
 import { DEFAULT_GAS_FEE, DEFAULT_GAS_WANTED } from "@common/values";
 import { PACKAGE_POOL_PATH, PACKAGE_STAKER_PATH } from "@constants/environment.constant";
-import { GnoProvider } from "@gnolang/gno-js-client";
 import { CHART_DAY_SCOPE_TYPE } from "@constants/option.constant";
+import { GnoProvider } from "@gnolang/gno-js-client";
 import { PoolMapper } from "@models/pool/mapper/pool-mapper";
 import { PoolStakingMapper } from "@models/pool/mapper/pool-staking-mapper";
 import { PoolBinModel } from "@models/pool/pool-bin-model";
@@ -25,7 +25,7 @@ import {
   evaluateExpressionToUint256,
   makeABCIParams,
 } from "@utils/rpc-utils";
-import { withTransactionGuard, generateSendTransactionParams } from "@utils/transaction-utils";
+import { generateSendTransactionParams, withTransactionGuard } from "@utils/transaction-utils";
 import { PoolListResponse, PoolPricesResponse, PoolRepository, PoolResponse } from ".";
 import {
   makeCreateExternalIncentiveMessageWithApproves,
@@ -103,7 +103,7 @@ export class PoolRepositoryImpl implements PoolRepository {
     const response = await this.networkClient.get<{
       data: PoolStakingResponse[];
     }>({
-      url: `/staking/?provider=${address}`,
+      url: `/staking?address=${address}`,
     });
     const pools = response?.data?.data ? response.data.data.map(PoolStakingMapper.fromResponse) : [];
     return pools;

--- a/packages/web/src/repositories/pool/pool.message.ts
+++ b/packages/web/src/repositories/pool/pool.message.ts
@@ -259,39 +259,18 @@ export function makeCreateExternalIncentiveMessageWithApproves(
 export function makeRemoveExternalIncentiveMessageWithApproves(
   {
     poolPath,
-    rewardToken,
-    startTimestamp,
-    endTimestamp,
+    incentiveID,
     caller,
   }: {
     poolPath: string;
-    rewardToken: TokenModel;
-    startTimestamp: string;
-    endTimestamp: string;
+    incentiveID: string;
     caller: string;
   },
   fetchAllowance: (packagePath: string, owner: string, spender: string) => Promise<number>,
 ): Promise<TransactionMessage[]> {
-  const tokenPath = wrapNativeTokenPath(rewardToken.path);
-
   const approveMessageInfos: TokenApproveMessageInfo[] = [];
 
-  if (isGNOTPath(tokenPath)) {
-    approveMessageInfos.push({
-      tokenPath: tokenPath,
-      targetAddress: PACKAGE_STAKER_ADDRESS,
-      amount: MAX_INT64,
-      caller,
-    });
-  }
-
-  const removeExternalIncentiveMessage = makeRemoveIncentiveMessage(
-    poolPath,
-    tokenPath,
-    startTimestamp,
-    endTimestamp,
-    caller,
-  );
+  const removeExternalIncentiveMessage = makeRemoveIncentiveMessage(poolPath, incentiveID, caller);
 
   return makeTransactionMessagesWithApproves([removeExternalIncentiveMessage], approveMessageInfos, fetchAllowance);
 }
@@ -390,18 +369,12 @@ function makePositionMintWithStakeMessage(
   });
 }
 
-function makeRemoveIncentiveMessage(
-  poolPath: string,
-  rewardTokenPath: string,
-  startTimestamp: string,
-  endTimestamp: string,
-  caller: string,
-) {
+function makeRemoveIncentiveMessage(poolPath: string, incentiveID: string, caller: string) {
   return makeTransactionMessage({
     send: "",
     func: PoolTransactionMessageFunctionType.EndExternalIncentive,
     packagePath: PACKAGE_STAKER_PATH,
-    args: [caller, poolPath, rewardTokenPath, startTimestamp, endTimestamp],
+    args: [poolPath, incentiveID, caller],
     caller,
   });
 }

--- a/packages/web/src/repositories/pool/request/remove-external-incentive-request.ts
+++ b/packages/web/src/repositories/pool/request/remove-external-incentive-request.ts
@@ -1,13 +1,7 @@
-import { TokenModel } from "@models/token/token-model";
-
 export interface RemoveExternalIncentiveRequest {
   poolPath: string;
 
-  rewardToken: TokenModel;
-
-  startTimestamp: string;
-
-  endTimestamp: string;
+  incentiveID: string;
 
   gasFee?: string;
 

--- a/packages/web/src/repositories/pool/response/pool-staking-response.ts
+++ b/packages/web/src/repositories/pool/response/pool-staking-response.ts
@@ -10,5 +10,6 @@ export interface PoolStakingResponse {
   startTimestamp: string;
   endTimestamp: string;
   unvestedAmount: string;
+  penaltyAmount: string;
   createdBlockHeight: string;
 }

--- a/packages/web/src/repositories/pool/response/pool-staking-response.ts
+++ b/packages/web/src/repositories/pool/response/pool-staking-response.ts
@@ -1,6 +1,7 @@
 import { TokenModel } from "@models/token/token-model";
 
 export interface PoolStakingResponse {
+  incentiveId: string;
   incentiveType: string;
   tier: string;
   poolPath: string;


### PR DESCRIPTION
## Descriptions

### Summary
This PR fixes incentivize history data accuracy for swap providers by aligning staking API parameters, mapping missing fields, and normalizing displayed token amounts by token decimals.  
It also improves WUGNOT display handling so users see the expected token presentation in history entries.

### Changes
- Updated staking history API request in `PoolRepositoryImpl`:
  - Changed query from `provider` to `address` (`/staking?address=...`) to match backend contract.
- Extended staking response/model mapping:
  - Added `penaltyAmount` to `PoolStakingResponse`.
  - Mapped `unvestedAmount` from `penaltyAmount` with a safe fallback in `PoolStakingMapper`.
- Improved incentivize history container data normalization:
  - Converted `remainingAmount`, `incentivizedAmount`, `unvestedAmount`, and `depositGnsAmount` into display units before rendering.
  - Applied WUGNOT -> GNOT display transformation for reward token metadata in history.
- Updated history UI rendering:
  - Replaced fixed decimal formatting with token-decimal-aware formatting.
  - Displayed `unvestedAmount` value instead of `-`.
- Included minor import-order cleanup (no functional impact).

### Why
Users were seeing incorrect or incomplete incentivize history values due to API parameter mismatch and inconsistent amount/decimal handling in the UI layer.  
This change ensures fetched data maps correctly and displays consistently across reward token types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token amount formatting in pool incentivization history to use each token's actual decimals (including deposit amounts).
  * Fixed API request parameter used when fetching pool staking data by address.
  * Corrected display of wrapped/alternate token variants so reward tokens show the expected token details.

* **New Features**
  * Display previously hidden unvested amount in incentivization history by populating and showing the unvested value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->