### PR TITLE
feat: add scroll prop to tooltips in StakingContentCard

### DIFF
--- a/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/staking-content-card/StakingContentCard.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/staking-content-card/StakingContentCard.tsx
@@ -233,6 +233,7 @@ const StakingContentCard: React.FC<StakingContentCardProps> = ({
               <span>
                 <Tooltip
                   placement="top"
+                  scroll
                   FloatingContent={
                     <div>
                       <PriceTooltipContent positions={positions} period={periodInfo.period} />
@@ -400,6 +401,7 @@ export const SummuryApr: React.FC<SummuryAprProps> = ({ period, checkPoints, pos
               <span>
                 <Tooltip
                   placement="top"
+                  scroll
                   FloatingContent={
                     <div>
                       <PriceTooltipContent positions={positions} period={periodInfo.period} />


### PR DESCRIPTION
## Descriptions

### Summary
This PR enables scroll behavior for staking value tooltips in the staking section to prevent content overflow when many LP positions are listed.

### Changes
- Added the `scroll` prop to the value tooltip in `StakingContentCard`.
- Added the same `scroll` prop to the value tooltip in `SummuryApr`.
- No business logic changes; this is a UI/UX improvement for tooltip content display.

### Why
When users have multiple staked LP positions, tooltip content can exceed viewport height and become difficult to read.  
Enabling scroll applies the tooltip’s built-in max-height and vertical scrolling behavior for better usability.