### PR TITLE
fix: adjust leaderboard update times

### DIFF
--- a/packages/web/src/repositories/leaderboard/leaderboard-repository-impl.ts
+++ b/packages/web/src/repositories/leaderboard/leaderboard-repository-impl.ts
@@ -3,8 +3,8 @@ import { CommonError } from "@common/errors";
 import { LeaderboardRepository } from "./leaderboard-repository";
 import { GetLeaderboardRequest, UpdateLeaderboardHiddenStateRequest } from "./request";
 import {
-  GetLeaderboardResponse,
   GetLeaderboardByAddressResponse,
+  GetLeaderboardResponse,
   nullLeaderboardInfo,
   UpdateLeaderboardHiddenStateResponse,
 } from "./response";
@@ -84,8 +84,7 @@ export class LeaderboardRepositoryImpl implements LeaderboardRepository {
     const now = new Date();
 
     const nextHour = new Date(now);
-    nextHour.setHours(nextHour.getHours() + 1);
-    nextHour.setMinutes(0);
+    nextHour.setMinutes(nextHour.getMinutes() + 10);
     nextHour.setSeconds(0);
     nextHour.setMilliseconds(0);
 


### PR DESCRIPTION
## Descriptions

### Summary
This PR fixes leaderboard next update time calculation by changing the fallback schedule from the next top-of-hour to a rolling 10-minute interval from the current time.

### Changes
- Updated `getLeaderboardNextUpdateTime` in `LeaderboardRepositoryImpl`:
  - Removed logic that moved the timestamp to the next hour (`setHours(... + 1)` and `setMinutes(0)`).
  - Added logic to set the next update to `now + 10 minutes`.
  - Kept seconds and milliseconds reset to `0` for consistent display.
- Included minor import ordering cleanup (no functional impact).

### Why
The previous fallback could show update times that were too far in the future, which did not match expected leaderboard refresh cadence.  
Using a 10-minute rolling interval provides a more accurate and user-friendly next update indicator.
