### PR TITLE
fix(leaderboard): improve next update time calculation

### DIFF
--- a/packages/web/src/repositories/leaderboard/leaderboard-repository-impl.ts
+++ b/packages/web/src/repositories/leaderboard/leaderboard-repository-impl.ts
@@ -83,13 +83,14 @@ export class LeaderboardRepositoryImpl implements LeaderboardRepository {
   public getNextUpdateTime = async () => {
     const now = new Date();
 
-    const nextHour = new Date(now);
-    nextHour.setMinutes(nextHour.getMinutes() + 10);
-    nextHour.setSeconds(0);
-    nextHour.setMilliseconds(0);
+    const next = new Date(now);
+    const nextMinute = Math.floor(now.getMinutes() / 10) * 10 + 10;
+    next.setMinutes(nextMinute);
+    next.setSeconds(0);
+    next.setMilliseconds(0);
 
     return {
-      nextUpdateTime: nextHour.toISOString(),
+      nextUpdateTime: next.toISOString(),
     };
   };
 }


### PR DESCRIPTION
## Description

### Summary

Fixes the client-side “next leaderboard update” timestamp so it points to the **next 10-minute boundary** (e.g. `:00`, `:10`, `:20`, …) instead of a naive “current time + 10 minutes”. This matches periodic refresh expectations and avoids misleading countdowns right after a boundary.

### Changes

- Update `LeaderboardRepositoryImpl.getNextUpdateTime` to compute the next slot with  
  `Math.floor(minutes / 10) * 10 + 10`, then zero out seconds and milliseconds.  
  JavaScript `Date#setMinutes` overflow correctly rolls over to the next hour/day when needed.

### Technical notes

- **Before:** `setMinutes(getMinutes() + 10)` always added 10 minutes from “now”, which does not necessarily land on the same schedule as “every 10 minutes on the clock.”  
- **After:** Snap to the upcoming 10-minute tick so the displayed “next update” is consistent with aligned refresh windows.
