### PR TITLE
fix(pool): use distributable amount in staking views

### DIFF
--- a/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/incentivized-token-detail-tooltip-content/IncentivizeTokenDetailTooltipContent.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/incentivized-token-detail-tooltip-content/IncentivizeTokenDetailTooltipContent.tsx
@@ -19,7 +19,7 @@ const IncentivizeTokenDetailTooltipContent: React.FC<Props> = ({ poolStakings }:
   const { getGnotPath } = useGnotToGnot();
   const { t } = useTranslation();
 
-  const displayRemainingAmount = (staking: PoolStakingModel) => {
+  const displayDistributableAmount = (staking: PoolStakingModel) => {
     return staking.incentiveType !== "INTERNAL";
   };
 
@@ -67,11 +67,11 @@ const IncentivizeTokenDetailTooltipContent: React.FC<Props> = ({ poolStakings }:
                     })}
                   </S.ItemDataGridValue>
                 </S.DataGridItem>
-                {displayRemainingAmount(item) && (
+                {displayDistributableAmount(item) && (
                   <S.DataGridItem>
                     <S.ItemDataGridLabel>{t("Pool:staking.tooltip.rewardInfo.remainingAmt")}</S.ItemDataGridLabel>
                     <S.ItemDataGridValue>
-                      {formatPoolPairAmount(item.remainingAmount, {
+                      {formatPoolPairAmount(item.distributableAmount, {
                         isKMB: false,
                         decimals: item.rewardToken.decimals,
                       })}

--- a/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
@@ -12,14 +12,13 @@ import { PoolMapper } from "@models/pool/mapper/pool-mapper";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
 import { GNS_TOKEN } from "@common/values/token-constant";
 
-import { IncentivizePoolHistoryBoxWrapper } from "./IncentivizePoolHistoryBox.styles";
+import { IncentivizePoolHistoryBoxWrapper, historyTooltipContent } from "./IncentivizePoolHistoryBox.styles";
 import Button, { ButtonHierarchy } from "@components/common/button/Button";
 import IconInfo from "@components/common/icons/IconInfo";
 import Tooltip from "@components/common/tooltip/Tooltip";
 import DoubleLogo from "@components/common/double-logo/DoubleLogo";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import IconOpenLink from "@components/common/icons/IconOpenLink";
-import { historyTooltipContent } from "./IncentivizePoolHistoryBox.styles";
 import { useRemoveExternalIncentive } from "@query/pools/use-remove-external-incentive";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 
@@ -145,7 +144,7 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
             </Tooltip>
           </div>
           <div className="value">
-            {toNumberFormat(stakingData.remainingAmount, 6)} {rewardToken.symbol}
+            {toNumberFormat(stakingData.distributableAmount, 6)} {rewardToken.symbol}
           </div>
         </div>
         <div className="row">

--- a/packages/web/src/models/pool/pool-staking.ts
+++ b/packages/web/src/models/pool/pool-staking.ts
@@ -7,7 +7,7 @@ export interface PoolStakingModel {
   poolPath: string;
   rewardToken: TokenModel;
   incentivizedAmount: string;
-  remainingAmount: string;
+  distributableAmount: string;
   startTimestamp: string;
   endTimestamp: string;
   unvestedAmount: string;

--- a/packages/web/src/repositories/pool/response/pool-staking-response.ts
+++ b/packages/web/src/repositories/pool/response/pool-staking-response.ts
@@ -6,6 +6,7 @@ export interface PoolStakingResponse {
   poolPath: string;
   rewardToken: TokenModel;
   incentivizedAmount: string;
+  distributableAmount: string;
   remainingAmount: string;
   startTimestamp: string;
   endTimestamp: string;

--- a/packages/web/src/services/converters/pool/pool.converter.ts
+++ b/packages/web/src/services/converters/pool/pool.converter.ts
@@ -30,7 +30,7 @@ export class PoolConverter {
       return {
         ...data,
         incentivizedAmount: AmountConverter.convertSingle(data.rewardToken, data.incentivizedAmount),
-        remainingAmount: AmountConverter.convertSingle(data.rewardToken, data.remainingAmount),
+        distributableAmount: AmountConverter.convertSingle(data.rewardToken, data.distributableAmount),
       };
     });
   }


### PR DESCRIPTION
## Summary
- switched the pool staking frontend model and converter to consume `distributableAmount`
- updated the staking tooltip and incentivized pool history views to display `distributableAmount` instead of `remainingAmount`
- kept compatibility with the API response while moving active UI usage away from deprecated staking fields


## Testing
- corepack yarn workspace @gnoswap-labs/web build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pool staking reward amounts displayed in tooltips and transaction history views to accurately reflect distributable quantities across incentivized pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->