### PR TITLE
fix: normalize token symbols/logos in incentivize history

### DIFF
--- a/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
@@ -18,6 +18,7 @@ import IconOpenLink from "@components/common/icons/IconOpenLink";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import Tooltip from "@components/common/tooltip/Tooltip";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
+import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { useRemoveExternalIncentive } from "@query/pools/use-remove-external-incentive";
 import { historyTooltipContent, IncentivizePoolHistoryBoxWrapper } from "./IncentivizePoolHistoryBox.styles";
 
@@ -37,11 +38,28 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
   });
 
   const { removeExternalIncentive } = useRemoveExternalIncentive(poolPath, incentiveId ?? "");
+  const { getGnotPath } = useGnotToGnot();
 
   const currentPool = React.useMemo(() => {
-    const temp = pool ? PoolMapper.toPoolSelectItemInfo(pool) : null;
-    return temp;
-  }, [pool]);
+    if (!pool) {
+      return null;
+    }
+
+    const poolInfo = PoolMapper.toPoolSelectItemInfo(pool);
+    return {
+      ...poolInfo,
+      tokenA: {
+        ...poolInfo.tokenA,
+        symbol: getGnotPath(poolInfo.tokenA).symbol,
+        logoURI: getGnotPath(poolInfo.tokenA).logoURI,
+      },
+      tokenB: {
+        ...poolInfo.tokenB,
+        symbol: getGnotPath(poolInfo.tokenB).symbol,
+        logoURI: getGnotPath(poolInfo.tokenB).logoURI,
+      },
+    };
+  }, [pool, getGnotPath]);
 
   const isSelected = currentPool != null;
 


### PR DESCRIPTION
## Descriptions
- Fixes token symbol/logo rendering in `IncentivizePoolHistoryBox` by normalizing pool token metadata through `getGnotPath`.
- Ensures wrapped/native GNOT variants are displayed consistently in incentive history rows.
- Refactors pool memoization logic to safely handle missing pool data before mapping token metadata.

## Changes
- Added `useGnotToGnot` hook usage in `IncentivizePoolHistoryBox`.
- Updated `currentPool` memo logic to:
  - return early when pool is unavailable
  - map `tokenA` and `tokenB` symbol/logo values via `getGnotPath(...)`

## Motivation
Incentive history could show inconsistent token symbols/logos depending on wrapped/native token representation. This change standardizes display output for better UX and data clarity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token symbol and logo display in the pool incentivization history view to ensure accurate token information is shown for all assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->