### PR TITLE
feat: aggregate claim-all rewards across all positions

### DIFF
--- a/packages/web/src/hooks/pool/data/use-position.ts
+++ b/packages/web/src/hooks/pool/data/use-position.ts
@@ -1,19 +1,58 @@
 import { GnoProvider } from "@common/clients/gno-provider/gno-provider";
 import { fetchAllowance } from "@common/clients/wallet-client/transaction-messages";
 import { CommonError } from "@common/errors";
+import { WRAPPED_GNOT_PATH } from "@constants/environment.constant";
 import { useNetworkFee } from "@hooks/common/use-network-fee";
 import { getGasUsed } from "@hooks/gas";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { PositionModel } from "@models/position/position-model";
-import { makeClaimAllMessageWithApproves, makeClaimMessageWithApproves } from "@repositories/position/position.message";
+import { makeClaimAllMessageWithApprovesByIds, makeClaimMessageWithApproves } from "@repositories/position/position.message";
 import { ClaimAllRequest } from "@repositories/position/request";
 import { ClaimRequest } from "@repositories/position/request/claim-request";
-import BigNumber from "bignumber.js";
+import { checkGnotPath } from "@utils/common";
 import { useCallback } from "react";
 import { useGnoswapContext } from "../../common/use-gnoswap-context";
 
-export const usePosition = (positions: PositionModel[]) => {
+export interface ClaimAllInput {
+  swapFeeTokenPaths: string[];
+  hasGnotStakingReward: boolean;
+  positionsWithSwapFee: string[];
+  positionsWithStakingReward: string[];
+}
+
+export const buildClaimAllInputFromPositions = (positions: PositionModel[]): ClaimAllInput => {
+  const swapFeeTokenPathSet = new Set<string>();
+  const positionsWithSwapFeeSet = new Set<string>();
+  const positionsWithStakingRewardSet = new Set<string>();
+  let hasGnotStakingReward = false;
+
+  positions.forEach(position => {
+    position.rewards.forEach(reward => {
+      if (Number(reward.claimableAmount ?? "0") <= 0) return;
+
+      if (reward.rewardToken.rewardType === "SWAP_FEE") {
+        swapFeeTokenPathSet.add(reward.rewardToken.path);
+        positionsWithSwapFeeSet.add(position.lpTokenId);
+      } else {
+        positionsWithStakingRewardSet.add(position.lpTokenId);
+        if (checkGnotPath(reward.rewardToken.path) === WRAPPED_GNOT_PATH) {
+          hasGnotStakingReward = true;
+        }
+      }
+    });
+  });
+
+  return {
+    swapFeeTokenPaths: Array.from(swapFeeTokenPathSet),
+    hasGnotStakingReward,
+    positionsWithSwapFee: Array.from(positionsWithSwapFeeSet),
+    positionsWithStakingReward: Array.from(positionsWithStakingRewardSet),
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const usePosition = (_positions?: PositionModel[]) => {
   const { transactionService, positionRepository } = useGnoswapContext();
   const { walletClient, account } = useWallet();
   const { estimateNetworkFee } = useNetworkFee(null);
@@ -34,9 +73,12 @@ export const usePosition = (positions: PositionModel[]) => {
 
     const makeMessagesRequests = {
       caller: request.recipient,
-      positions: request.positions,
+      swapFeeTokenPaths: request.swapFeeTokenPaths,
+      hasGnotStakingReward: request.hasGnotStakingReward,
+      positionsWithSwapFee: request.positionsWithSwapFee,
+      positionsWithStakingReward: request.positionsWithStakingReward,
     };
-    const txMessages = await makeClaimAllMessageWithApproves(makeMessagesRequests, getAllowance);
+    const txMessages = await makeClaimAllMessageWithApprovesByIds(makeMessagesRequests, getAllowance);
 
     const txDoc = await transactionService.createDocument({ messages: txMessages });
     await transactionService.createTransaction(txDoc);
@@ -52,32 +94,31 @@ export const usePosition = (positions: PositionModel[]) => {
   };
 
   const claimAll = useCallback(
-    async ({ rpcProvider }: { rpcProvider: GnoProvider | null }) => {
+    async ({ rpcProvider, input }: { rpcProvider: GnoProvider | null; input: ClaimAllInput }) => {
       const address = account?.address;
       if (!address) {
         return null;
       }
 
-      const claimablePositions = positions.filter(
-        position =>
-          position.rewards.reduce(
-            (accum, currReward) =>
-              BigNumber(accum)
-                .plus(Number(currReward.claimableAmount ?? "0"))
-                .toNumber(),
-            0,
-          ) > 0,
-      );
+      if (input.positionsWithSwapFee.length === 0 && input.positionsWithStakingReward.length === 0) {
+        return null;
+      }
 
       const walletType = walletClient?.getWalletType();
 
-      const request: ClaimAllRequest = { positions: claimablePositions, recipient: address };
+      const request: ClaimAllRequest = {
+        swapFeeTokenPaths: input.swapFeeTokenPaths,
+        hasGnotStakingReward: input.hasGnotStakingReward,
+        positionsWithSwapFee: input.positionsWithSwapFee,
+        positionsWithStakingReward: input.positionsWithStakingReward,
+        recipient: address,
+      };
 
       return await (walletType === "ADENA"
         ? buildAdenaWalletClaimAllAction(request)
         : buildSocialWalletClaimAllAction(rpcProvider, request));
     },
-    [walletClient, account?.address, positionRepository, positions],
+    [walletClient, account?.address, positionRepository],
   );
 
   const buildAdenaWalletClaimAction = async (request: ClaimRequest) => {

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -7,7 +7,7 @@ import { useInvalidateQueries } from "@hooks/common/use-invalidate-queries";
 import { useMessage } from "@hooks/common/use-message";
 import { useTransactionConfirmModal } from "@hooks/common/use-transaction-confirm-modal";
 import { useWindowSize } from "@hooks/common/use-window-size";
-import { usePosition } from "@hooks/pool/data/use-position";
+import { buildClaimAllInputFromPositions, usePosition } from "@hooks/pool/data/use-position";
 import { usePositionData } from "@hooks/pool/data/use-position-data";
 import { useTokenData } from "@hooks/token/data/use-token-data";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
@@ -247,7 +247,8 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     broadcastLoading(getMessage(DexEvent.CLAIM_FEE, "pending", messageData));
 
     setLoadingTransactionClaim(true);
-    claimAll({ rpcProvider }).then(response => {
+    const claimAllInput = buildClaimAllInputFromPositions(openedPosition.filter(item => !item.closed));
+    claimAll({ rpcProvider, input: claimAllInput }).then(response => {
       if (response) {
         if (response.code === 0 || response.code === ERROR_VALUE.TRANSACTION_FAILED.status) {
           enqueueEvent({

--- a/packages/web/src/layouts/portfolio/components/wallet-balance/WalletBalance.spec.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-balance/WalletBalance.spec.tsx
@@ -33,6 +33,8 @@ describe("WalletBalance Component", () => {
       isSwitchNetwork: false,
       loadngTransactionClaim: false,
       positions: [],
+      positionRewards: null,
+      tokens: [],
       tokenPrices: {},
       walletType: {
         type: "ADENA" as WalletType,

--- a/packages/web/src/layouts/portfolio/components/wallet-balance/WalletBalance.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-balance/WalletBalance.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 
-import { PoolPositionModel } from "@models/position/pool-position-model";
+import { PositionModel } from "@models/position/position-model";
+import { TokenModel } from "@models/token/token-model";
 import { TokenPriceModel } from "@models/token/token-price-model";
+import { PositionRewardsResponse } from "@repositories/position/response";
 import { DEVICE_TYPE } from "@styles/media";
 
 import WalletBalanceDetail, { BalanceDetailInfo } from "./wallet-balance-detail/WalletBalanceDetail";
@@ -17,7 +19,9 @@ interface WalletBalanceProps {
   balanceDetailInfo: BalanceDetailInfo;
   isSwitchNetwork: boolean;
   loadngTransactionClaim: boolean;
-  positions: PoolPositionModel[];
+  positions: PositionModel[];
+  positionRewards: PositionRewardsResponse | null;
+  tokens: TokenModel[];
   tokenPrices: Record<string, TokenPriceModel>;
   walletType: WalletTypeState;
 
@@ -38,6 +42,8 @@ const WalletBalance: React.FC<WalletBalanceProps> = ({
   isSwitchNetwork,
   loadngTransactionClaim,
   positions,
+  positionRewards,
+  tokens,
   tokenPrices,
   walletType,
 }) => {
@@ -60,6 +66,8 @@ const WalletBalance: React.FC<WalletBalanceProps> = ({
         isSwitchNetwork={isSwitchNetwork}
         loadngTransactionClaim={loadngTransactionClaim}
         positions={positions}
+        positionRewards={positionRewards}
+        tokens={tokens}
         tokenPrices={tokenPrices}
       />
     </WalletBalanceWrapper>

--- a/packages/web/src/layouts/portfolio/components/wallet-balance/wallet-balance-detail/WalletBalanceDetail.spec.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-balance/wallet-balance-detail/WalletBalanceDetail.spec.tsx
@@ -33,6 +33,8 @@ describe("WalletBalanceDetail Component", () => {
       isSwitchNetwork: false,
       loadngTransactionClaim: false,
       positions: [],
+      positionRewards: null,
+      tokens: [],
       tokenPrices: {},
     };
 

--- a/packages/web/src/layouts/portfolio/components/wallet-balance/wallet-balance-detail/WalletBalanceDetail.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-balance/wallet-balance-detail/WalletBalanceDetail.tsx
@@ -1,5 +1,3 @@
-// Todo: Delete this code
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -8,12 +6,16 @@ import LoadingSpinner from "@components/common/loading-spinner/LoadingSpinner";
 import RewardTooltipContent, {
   PositionRewardForTooltip,
 } from "@components/common/reward-tooltip-content/RewardTooltipContent";
-import { RewardType, DisplayRewardType } from "@constants/option.constant";
-import { PoolPositionModel } from "@models/position/pool-position-model";
+import { DisplayRewardType } from "@constants/option.constant";
+import { PositionModel } from "@models/position/position-model";
+import { TokenModel } from "@models/token/token-model";
 import { TokenPriceModel } from "@models/token/token-price-model";
+import {
+  PositionRewardTokenAmount,
+  PositionRewardsGroupResponse,
+  PositionRewardsResponse,
+} from "@repositories/position/response";
 import { DEVICE_TYPE } from "@styles/media";
-import { mapToDisplayRewardType } from "@utils/reward-utils";
-import { PositionConverter } from "@services/converters/position";
 
 import StakedPostionsTooltipContent from "./sateked-positions-tooltip/StakedPositinosTooltipContent";
 import WalletBalanceDetailInfo from "./wallet-balance-detail-info/WalletBalanceDetailInfo";
@@ -37,9 +39,26 @@ export interface WalletBalanceDetailProps {
   claimAll: () => void;
   breakpoint: DEVICE_TYPE;
   loadngTransactionClaim: boolean;
-  positions: PoolPositionModel[];
+  positions: PositionModel[];
+  positionRewards: PositionRewardsResponse | null;
+  tokens: TokenModel[];
   tokenPrices: Record<string, TokenPriceModel>;
 }
+
+type RewardGroupKey = "swapFee" | "internalReward" | "externalReward";
+
+const REWARD_GROUP_TO_DISPLAY: Record<RewardGroupKey, DisplayRewardType> = {
+  swapFee: "SWAP_FEE",
+  internalReward: "INTERNAL_REWARD",
+  externalReward: "EXTERNAL_REWARD",
+};
+
+const emptyTooltipInfo = (): { [key in DisplayRewardType]: PositionRewardForTooltip[] } => ({
+  SWAP_FEE: [],
+  INTERNAL_REWARD: [],
+  EXTERNAL_REWARD: [],
+  NONE: [],
+});
 
 const WalletBalanceDetail: React.FC<WalletBalanceDetailProps> = ({
   balanceDetailInfo,
@@ -49,199 +68,78 @@ const WalletBalanceDetail: React.FC<WalletBalanceDetailProps> = ({
   isSwitchNetwork,
   loadngTransactionClaim,
   positions,
-  tokenPrices,
+  positionRewards,
+  tokens,
 }) => {
   const { t } = useTranslation();
 
-  const accountPositions: PoolPositionModel[] = useMemo(() => {
-    return PositionConverter.convertPositions(positions);
-  }, [positions]);
+  const tokenByPath = useMemo(() => {
+    const map: Record<string, TokenModel> = {};
+    tokens.forEach(token => {
+      map[token.path] = token;
+    });
+    return map;
+  }, [tokens]);
 
   const stakedPositions = useMemo(() => {
-    if (!accountPositions || accountPositions.length === 0) return [];
+    if (!positions || positions.length === 0) return [];
 
-    return accountPositions
-      .filter(item => item.staked === true)
+    return positions
+      .filter(item => item.staked && !item.closed)
       .map(item => ({
         lpId: item.lpTokenId,
         totalValue: item.stakedUsdValue,
         stakedDate: item.stakedAt,
         tokenUri: item.tokenUri,
       }));
-  }, [accountPositions]);
+  }, [positions]);
 
-  const { claimedRewardInfo, claimableRewardInfo } = useMemo((): {
-    claimedRewardInfo: { [key in DisplayRewardType]: PositionRewardForTooltip[] };
-    claimableRewardInfo: { [key in DisplayRewardType]: PositionRewardForTooltip[] };
-  } => {
-    const initRewardTypeMap = () => ({
-      SWAP_FEE: {},
-      INTERNAL_REWARD: {},
-      EXTERNAL_REWARD: {},
-      NONE: {},
+  const buildRewardInfo = (group: PositionRewardsGroupResponse) => {
+    const result = emptyTooltipInfo();
+
+    (Object.keys(REWARD_GROUP_TO_DISPLAY) as RewardGroupKey[]).forEach(groupKey => {
+      const displayType = REWARD_GROUP_TO_DISPLAY[groupKey];
+      const items: PositionRewardTokenAmount[] = group[groupKey] ?? [];
+
+      const tooltipItems: PositionRewardForTooltip[] = [];
+
+      items.forEach(item => {
+        const token = tokenByPath[item.tokenPath];
+        if (!token) return;
+
+        tooltipItems.push({
+          rewardType: displayType,
+          token,
+          amount: Number(item.amount),
+          usd: Number(item.usdValue),
+          accumulatedRewardOf1d: null,
+          accumulatedRewardOf1dUsd: null,
+        });
+      });
+
+      result[displayType] = tooltipItems;
     });
 
-    const claimableMap: {
-      [key in DisplayRewardType]: { [key in string]: PositionRewardForTooltip };
-    } = initRewardTypeMap();
+    return result;
+  };
 
-    const claimedMap: {
-      [key in DisplayRewardType]: { [key in string]: PositionRewardForTooltip };
-    } = initRewardTypeMap();
-
-    if (!accountPositions || accountPositions.length === 0) {
+  const { claimableRewardInfo, claimedRewardInfo } = useMemo(() => {
+    if (!positionRewards) {
       return {
-        claimedRewardInfo: {
-          SWAP_FEE: [],
-          INTERNAL_REWARD: [],
-          EXTERNAL_REWARD: [],
-          NONE: [],
-        },
-        claimableRewardInfo: {
-          SWAP_FEE: [],
-          INTERNAL_REWARD: [],
-          EXTERNAL_REWARD: [],
-          NONE: [],
-        },
+        claimableRewardInfo: emptyTooltipInfo(),
+        claimedRewardInfo: emptyTooltipInfo(),
       };
     }
 
-    const getAccumulatedRewardOf1d = (cached: PositionRewardForTooltip, current: { accuReward1D: string | null }) => {
-      if (cached.accumulatedRewardOf1d === null) {
-        if (current.accuReward1D === null) {
-          return null;
-        }
-        return Number(current.accuReward1D);
-      }
-      if (current.accuReward1D === null) {
-        return cached.accumulatedRewardOf1d;
-      }
-      return cached.accumulatedRewardOf1d + Number(current.accuReward1D);
-    };
-
-    const processClaimableRewards = () => {
-      accountPositions
-        .flatMap(position => position.rewards)
-        .forEach(reward => {
-          const rewardType = reward.rewardToken.rewardType as RewardType;
-          const displayRewardType = mapToDisplayRewardType(rewardType);
-
-          if (!claimableMap[displayRewardType]) {
-            console.warn(`Invalid rewardType: ${rewardType}, mapped to ${displayRewardType}`);
-            return;
-          }
-
-          const tokenPrice = tokenPrices[reward.rewardToken.priceID]?.usd
-            ? Number(tokenPrices[reward.rewardToken.priceID].usd)
-            : null;
-
-          const rewardInfo: PositionRewardForTooltip = {
-            token: reward.rewardToken,
-            rewardType: displayRewardType,
-            amount: reward.claimableAmount ? Number(reward.claimableAmount) : null,
-            usd: reward.claimableUsd ? Number(reward.claimableUsd) : null,
-            accumulatedRewardOf1d: reward.accuReward1D ? Number(reward.accuReward1D) : null,
-            accumulatedRewardOf1dUsd:
-              reward.accuReward1D && tokenPrice ? Number(reward.accuReward1D) * tokenPrice : null,
-          };
-
-          const existingReward = claimableMap[displayRewardType]?.[reward.rewardToken.priceID];
-
-          if (existingReward) {
-            const accumulatedRewardOf1d = getAccumulatedRewardOf1d(existingReward, reward);
-            const accumulatedRewardOf1dUsd =
-              accumulatedRewardOf1d !== null && tokenPrice !== null ? accumulatedRewardOf1d * tokenPrice : null;
-
-            claimableMap[displayRewardType][reward.rewardToken.priceID] = {
-              ...existingReward,
-              amount: (existingReward.amount || 0) + (rewardInfo.amount || 0),
-              usd:
-                existingReward.usd !== null && rewardInfo.usd !== null
-                  ? existingReward.usd + rewardInfo.usd
-                  : existingReward.usd || rewardInfo.usd,
-              accumulatedRewardOf1d,
-              accumulatedRewardOf1dUsd,
-            };
-          } else {
-            claimableMap[displayRewardType][reward.rewardToken.priceID] = rewardInfo;
-          }
-        });
-    };
-
-    const processClaimedRewards = () => {
-      accountPositions
-        .flatMap(position => position.claimedRewards)
-        .forEach(claimed => {
-          const rewardType = claimed.rewardToken.rewardType as RewardType;
-          const displayRewardType = mapToDisplayRewardType(rewardType);
-
-          if (!claimedMap[displayRewardType]) {
-            console.warn(`Invalid rewardType: ${rewardType}, mapped to ${displayRewardType}`);
-            return;
-          }
-
-          const tokenPrice = tokenPrices[claimed.rewardToken.priceID]?.usd
-            ? Number(tokenPrices[claimed.rewardToken.priceID].usd)
-            : null;
-
-          const claimedAmount = Number(claimed.claimedAmount);
-          const claimedUsd = tokenPrice ? claimedAmount * tokenPrice : null;
-
-          const rewardInfo: PositionRewardForTooltip = {
-            token: claimed.rewardToken,
-            rewardType: displayRewardType,
-            amount: claimedAmount,
-            usd: claimedUsd,
-            accumulatedRewardOf1d: null,
-            accumulatedRewardOf1dUsd: null,
-          };
-
-          const existingReward = claimedMap[displayRewardType]?.[claimed.rewardToken.priceID];
-
-          if (existingReward) {
-            claimedMap[displayRewardType][claimed.rewardToken.priceID] = {
-              ...existingReward,
-              amount: (existingReward.amount || 0) + claimedAmount,
-              usd:
-                existingReward.usd !== null && claimedUsd !== null
-                  ? existingReward.usd + claimedUsd
-                  : existingReward.usd || claimedUsd,
-            };
-          } else {
-            claimedMap[displayRewardType][claimed.rewardToken.priceID] = rewardInfo;
-          }
-        });
-    };
-
-    processClaimableRewards();
-    processClaimedRewards();
-
     return {
-      claimedRewardInfo: {
-        SWAP_FEE: Object.values(claimedMap.SWAP_FEE),
-        INTERNAL_REWARD: Object.values(claimedMap.INTERNAL_REWARD),
-        EXTERNAL_REWARD: Object.values(claimedMap.EXTERNAL_REWARD),
-        NONE: Object.values(claimedMap.NONE),
-      },
-      claimableRewardInfo: {
-        SWAP_FEE: Object.values(claimableMap.SWAP_FEE).filter(reward => reward.amount && reward.amount > 0),
-        INTERNAL_REWARD: Object.values(claimableMap.INTERNAL_REWARD).filter(
-          reward => reward.amount && reward.amount > 0,
-        ),
-        EXTERNAL_REWARD: Object.values(claimableMap.EXTERNAL_REWARD).filter(
-          reward => reward.amount && reward.amount > 0,
-        ),
-        NONE: Object.values(claimableMap.NONE).filter(reward => reward.amount && reward.amount > 0),
-      },
+      claimableRewardInfo: buildRewardInfo(positionRewards.claimable),
+      claimedRewardInfo: buildRewardInfo(positionRewards.claimed),
     };
-  }, [accountPositions, tokenPrices]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [positionRewards, tokenByPath]);
 
-  const hasInfo = (data: {
-    [key in DisplayRewardType]: PositionRewardForTooltip[];
-  }): boolean => {
-    if (data.SWAP_FEE.length === 0 && data.INTERNAL_REWARD.length === 0 && data.EXTERNAL_REWARD.length === 0)
-      return false;
-    return true;
+  const hasInfo = (data: { [key in DisplayRewardType]: PositionRewardForTooltip[] }): boolean => {
+    return data.SWAP_FEE.length > 0 || data.INTERNAL_REWARD.length > 0 || data.EXTERNAL_REWARD.length > 0;
   };
 
   const isClaimableAll = useMemo(() => {
@@ -272,7 +170,6 @@ const WalletBalanceDetail: React.FC<WalletBalanceDetailProps> = ({
         }
         breakpoint={breakpoint}
       />
-      {/* Todo: Change to claimableRewardInfo -> claimedRewardInfo */}
       <WalletBalanceDetailInfo
         loading={balanceDetailInfo.loadingPositions}
         title={t("Wallet:overral.totalClaimed.label")}

--- a/packages/web/src/layouts/portfolio/containers/wallet-balance-container/WalletBalanceContainer.tsx
+++ b/packages/web/src/layouts/portfolio/containers/wallet-balance-container/WalletBalanceContainer.tsx
@@ -17,13 +17,12 @@ import { usePosition } from "@hooks/pool/data/use-position";
 import { usePositionData } from "@hooks/pool/data/use-position-data";
 import { useTokenData } from "@hooks/token/data/use-token-data";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
-import { PoolPositionModel } from "@models/position/pool-position-model";
 import { TokenModel } from "@models/token/token-model";
 import { useGetAvgBlockTime } from "@query/address";
+import { useGetPositionRewards } from "@query/positions";
 import { QUERY_KEY } from "@query/query-keys";
 import { useGetAllTokenPrices } from "@query/token";
 import { DexEvent } from "@repositories/common";
-import { PositionConverter } from "@services/converters/position";
 import { delay } from "@utils/common";
 import { formatOtherPrice } from "@utils/new-number-utils";
 import { toUnitFormat } from "@utils/number-utils";
@@ -51,9 +50,10 @@ const WalletBalanceContainer: React.FC = () => {
   const [sendAssetAmount, setSendAssetAmount] = useState("");
 
   const { data: blockTimeData } = useGetAvgBlockTime();
-  const { balances: balancesPrice, loadingBalance, updateBalances } = useTokenData();
+  const { balances: balancesPrice, loadingBalance, updateBalances, tokens } = useTokenData();
 
   const { positions, loading: loadingPositions } = usePositionData();
+  const { data: positionRewards, isLoading: loadingPositionRewards } = useGetPositionRewards();
 
   const { invalidateQueryKey } = useInvalidateQueries();
 
@@ -61,21 +61,16 @@ const WalletBalanceContainer: React.FC = () => {
     invalidateQueryKey("WalletBalance, ClaimAll", [
       [QUERY_KEY.tokenBalancesByAddress, userAddress],
       [QUERY_KEY.positions, currentChainId, userAddress],
+      [QUERY_KEY.positionRewards, currentChainId, userAddress],
     ]);
   }, [invalidateQueryKey, currentChainId, userAddress]);
 
-  const isClaimablePosition = (position: PoolPositionModel) => position.liquidity > 0 && !position.closed;
+  const isLoadingPosition = useMemo(
+    () => connected && (loadingPositions || loadingPositionRewards),
+    [connected, loadingPositions, loadingPositionRewards],
+  );
 
-  const claimablePositions: PoolPositionModel[] = useMemo(() => {
-    if (!positions || positions.length === 0) return [];
-
-    const filteredPositions = positions.filter(isClaimablePosition);
-    return PositionConverter.convertPositions(filteredPositions);
-  }, [positions, isClaimablePosition]);
-
-  const isLoadingPosition = useMemo(() => connected && loadingPositions, [connected, loadingPositions]);
-
-  const { claimAll } = usePosition(claimablePositions);
+  const { claimAll } = usePosition([]);
   const { broadcastSuccess, broadcastError, broadcastRejected, broadcastLoading } = useBroadcastHandler();
   const { enqueueEvent } = useTransactionEventStore();
 
@@ -106,10 +101,32 @@ const WalletBalanceContainer: React.FC = () => {
     if (!address) return;
   }, [connected, address]);
 
+  const claimAllInput = useMemo(() => {
+    if (!positionRewards) {
+      return {
+        swapFeeTokenPaths: [],
+        hasGnotStakingReward: false,
+        positionsWithSwapFee: [],
+        positionsWithStakingReward: [],
+      };
+    }
+
+    const swapFeeTokenPaths = positionRewards.claimable.swapFee.map(item => item.tokenPath);
+    const hasGnotStakingReward = [
+      ...positionRewards.claimable.internalReward,
+      ...positionRewards.claimable.externalReward,
+    ].some(item => item.tokenPath === WRAPPED_GNOT_PATH);
+
+    return {
+      swapFeeTokenPaths,
+      hasGnotStakingReward,
+      positionsWithSwapFee: positionRewards.positionsWithSwapFee,
+      positionsWithStakingReward: positionRewards.positionsWithStakingReward,
+    };
+  }, [positionRewards]);
+
   const claimAllReward = useCallback(() => {
-    const amount = claimablePositions
-      .flatMap(item => item.rewards)
-      .reduce((acc, item) => acc + Number(item.claimableUsd), 0);
+    const amount = Number(positionRewards?.totalUsd.claimable.total ?? "0");
 
     const messageData = {
       tokenAAmount: toUnitFormat(amount, true, false),
@@ -118,7 +135,7 @@ const WalletBalanceContainer: React.FC = () => {
     broadcastLoading(getMessage(DexEvent.CLAIM_FEE, "pending", messageData));
 
     setLoadingTransactionClaim(true);
-    claimAll({ rpcProvider }).then(response => {
+    claimAll({ rpcProvider, input: claimAllInput }).then(response => {
       if (response) {
         if (response?.code === 0 || response?.code === ERROR_VALUE.TRANSACTION_FAILED.status) {
           enqueueEvent({
@@ -153,7 +170,7 @@ const WalletBalanceContainer: React.FC = () => {
         }
       }
     });
-  }, [claimAll, setLoadingTransactionClaim, claimablePositions, openModal]);
+  }, [claimAll, setLoadingTransactionClaim, claimAllInput, positionRewards, openModal]);
 
   const loadingTotalBalance = useMemo(() => {
     return (
@@ -181,36 +198,35 @@ const WalletBalanceContainer: React.FC = () => {
     return availableBalance;
   }, [availableBalance]);
 
-  const { stakedBalance, unStakedBalance, claimableRewards, totalClaimedRewards } = claimablePositions.reduce(
-    (acc, curPosition) => {
-      acc.totalClaimedRewards = BigNumber(acc.totalClaimedRewards)
-        .plus(Number(curPosition.totalClaimedUsd ?? "0"))
-        .toNumber();
+  const { stakedBalance, unStakedBalance } = useMemo(() => {
+    if (!positions || positions.length === 0) {
+      return { stakedBalance: 0, unStakedBalance: 0 };
+    }
 
-      if (curPosition.staked) {
-        acc.stakedBalance = BigNumber(acc.stakedBalance)
-          .plus(Number(curPosition.stakedUsdValue ?? "0"))
-          .toNumber();
-      } else {
-        acc.unStakedBalance = BigNumber(acc.unStakedBalance)
-          .plus(Number(curPosition.usdValue ?? "0"))
-          .toNumber();
-      }
+    return positions.reduce(
+      (acc, curPosition) => {
+        if (curPosition.closed) {
+          return acc;
+        }
 
-      curPosition.rewards.forEach(rewardInfo => {
-        acc.claimableRewards = BigNumber(acc.claimableRewards)
-          .plus(Number(rewardInfo.claimableUsd ?? "0"))
-          .toNumber();
-      });
-      return acc;
-    },
-    {
-      stakedBalance: 0,
-      unStakedBalance: 0,
-      claimableRewards: 0,
-      totalClaimedRewards: 0,
-    },
-  );
+        if (curPosition.staked) {
+          acc.stakedBalance = BigNumber(acc.stakedBalance)
+            .plus(Number(curPosition.stakedUsdValue ?? "0"))
+            .toNumber();
+        } else {
+          acc.unStakedBalance = BigNumber(acc.unStakedBalance)
+            .plus(Number(curPosition.usdValue ?? "0"))
+            .toNumber();
+        }
+
+        return acc;
+      },
+      { stakedBalance: 0, unStakedBalance: 0 },
+    );
+  }, [positions]);
+
+  const claimableRewards = Number(positionRewards?.totalUsd.claimable.total ?? "0");
+  const totalClaimedRewards = Number(positionRewards?.totalUsd.claimed.total ?? "0");
 
   const sumTotalBalance = useMemo(() => {
     return formatOtherPrice(
@@ -315,6 +331,8 @@ const WalletBalanceContainer: React.FC = () => {
         isSwitchNetwork={isSwitchNetwork}
         loadngTransactionClaim={loadngTransactionClaim}
         positions={positions}
+        positionRewards={positionRewards ?? null}
+        tokens={tokens}
         tokenPrices={tokenPrices}
         walletType={walletType}
       />

--- a/packages/web/src/react-query/positions/index.ts
+++ b/packages/web/src/react-query/positions/index.ts
@@ -2,4 +2,5 @@ export * from "./use-get-position-bins";
 export * from "./use-get-position-by-id";
 export * from "./use-get-position-history";
 export * from "./use-get-positions-by-address";
+export * from "./use-get-position-rewards";
 export * from "./use-make-pool-positions";

--- a/packages/web/src/react-query/positions/use-get-position-rewards.ts
+++ b/packages/web/src/react-query/positions/use-get-position-rewards.ts
@@ -1,0 +1,45 @@
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
+import { useWallet } from "@hooks/wallet/data/use-wallet";
+import { PositionRewardsResponse } from "@repositories/position/response";
+
+import { QUERY_KEY } from "../query-keys";
+
+const REFETCH_INTERVAL = 60_000;
+
+interface UseGetPositionRewardsProps {
+  address?: string;
+}
+
+export const useGetPositionRewards = (
+  props?: UseGetPositionRewardsProps,
+  options?: UseQueryOptions<PositionRewardsResponse | null, Error>,
+) => {
+  const { positionRepository } = useGnoswapContext();
+  const { account, currentChainId, availNetwork } = useWallet();
+
+  const address = useMemo(() => {
+    return props?.address || account?.address || "";
+  }, [account?.address, props?.address]);
+
+  return useQuery<PositionRewardsResponse | null, Error>({
+    queryKey: [QUERY_KEY.positionRewards, currentChainId, address],
+    queryFn: async () => {
+      if (!availNetwork || !address) {
+        return null;
+      }
+
+      return await positionRepository.getPositionRewardsByAddress(address).catch(e => {
+        console.error(e);
+        return null;
+      });
+    },
+    keepPreviousData: true,
+    refetchInterval: REFETCH_INTERVAL,
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+    ...options,
+  });
+};

--- a/packages/web/src/react-query/query-keys.ts
+++ b/packages/web/src/react-query/query-keys.ts
@@ -56,6 +56,7 @@ export enum QUERY_KEY {
   poolFromDb = "pool_from_db",
   // positions
   positions = "positions",
+  positionRewards = "positionRewards",
   positionHistory = "positionHistory",
   poolPositions = "poolPositions",
   estimateReposition = "estimateReposition",

--- a/packages/web/src/repositories/position/position-repository-impl.ts
+++ b/packages/web/src/repositories/position/position-repository-impl.ts
@@ -17,7 +17,7 @@ import { getGRC20Allowance } from "@common/clients/gno-provider";
 import { GnoProvider } from "@gnolang/gno-js-client";
 import { PositionRepository } from "./position-repository";
 import {
-  makeClaimAllMessageWithApproves,
+  makeClaimAllMessageWithApprovesByIds,
   makeClaimMessageWithApproves,
   makeDecreaseLiquidityMessagesWithApproves,
   makeIncreaseLiquidityMessagesWithApproves,
@@ -39,6 +39,7 @@ import {
   PositionBinResponse,
   PositionListResponse,
   PositionResponse,
+  PositionRewardsResponse,
   RepositionLiquidityFailedResponse,
   RepositionLiquiditySuccessResponse,
 } from "./response";
@@ -131,6 +132,20 @@ export class PositionRepositoryImpl implements PositionRepository {
     };
   };
 
+  getPositionRewardsByAddress = async (address: string): Promise<PositionRewardsResponse | null> => {
+    if (!this.networkClient) {
+      throw new CommonError("FAILED_INITIALIZE_PROVIDER");
+    }
+
+    const response = await this.networkClient.get<{
+      data: PositionRewardsResponse;
+    }>({
+      url: "/users/" + address + "/position/reward",
+    });
+
+    return response?.data?.data ?? null;
+  };
+
   sendClaim = async (request: ClaimRequest): Promise<WalletResponse<SendTransactionResponse<string[] | null>>> => {
     if (this.walletClient === null) {
       throw new CommonError("FAILED_INITIALIZE_WALLET");
@@ -175,13 +190,24 @@ export class PositionRepositoryImpl implements PositionRepository {
       throw new CommonError("FAILED_INITIALIZE_GNO_PROVIDER");
     }
 
-    const { gasFee, gasUsed, positions, recipient } = request;
+    const {
+      gasFee,
+      gasUsed,
+      swapFeeTokenPaths,
+      hasGnotStakingReward,
+      positionsWithSwapFee,
+      positionsWithStakingReward,
+      recipient,
+    } = request;
     const makeTxMessageRequests = {
       caller: recipient,
-      positions,
+      swapFeeTokenPaths,
+      hasGnotStakingReward,
+      positionsWithSwapFee,
+      positionsWithStakingReward,
     };
 
-    const messages = await makeClaimAllMessageWithApproves(makeTxMessageRequests, (packagePath, owner, spender) =>
+    const messages = await makeClaimAllMessageWithApprovesByIds(makeTxMessageRequests, (packagePath, owner, spender) =>
       getGRC20Allowance(this.rpcProvider!, packagePath, owner, spender),
     );
 

--- a/packages/web/src/repositories/position/position-repository.ts
+++ b/packages/web/src/repositories/position/position-repository.ts
@@ -15,6 +15,7 @@ import {
   GetPositionsByAddressResult,
   IncreaseLiquidityFailedResponse,
   IncreaseLiquiditySuccessResponse,
+  PositionRewardsResponse,
   RepositionLiquidityFailedResponse,
   RepositionLiquiditySuccessResponse,
 } from "./response";
@@ -30,6 +31,8 @@ export interface PositionRepository {
       withClosed?: boolean;
     },
   ) => Promise<GetPositionsByAddressResult>;
+
+  getPositionRewardsByAddress: (address: string) => Promise<PositionRewardsResponse | null>;
 
   getPositionBins: (lpTokenId: string, count: 20 | 40) => Promise<PositionBinModel[]>;
 

--- a/packages/web/src/repositories/position/position.message.ts
+++ b/packages/web/src/repositories/position/position.message.ts
@@ -110,6 +110,77 @@ export function makeClaimMessageWithApproves(
   return makeTransactionMessagesWithApproves(messages, approveMessageInfos, fetchAllowance);
 }
 
+export function makeClaimAllMessageWithApprovesByIds(
+  {
+    swapFeeTokenPaths,
+    hasGnotStakingReward,
+    positionsWithSwapFee,
+    positionsWithStakingReward,
+    caller,
+  }: {
+    swapFeeTokenPaths: string[];
+    hasGnotStakingReward: boolean;
+    positionsWithSwapFee: string[];
+    positionsWithStakingReward: string[];
+    caller: string;
+  },
+  fetchAllowance: (packagePath: string, owner: string, spender: string) => Promise<number>,
+): Promise<TransactionMessage[]> {
+  const approveMessageInfos: TokenApproveMessageInfo[] = [];
+
+  swapFeeTokenPaths.forEach(tokenPath => {
+    approveMessageInfos.push({
+      tokenPath,
+      targetAddress: PACKAGE_POOL_ADDRESS,
+      amount: MAX_INT64,
+      caller,
+    });
+    approveMessageInfos.push({
+      tokenPath,
+      targetAddress: PACKAGE_POSITION_ADDRESS,
+      amount: MAX_INT64,
+      caller,
+    });
+  });
+
+  if (hasGnotStakingReward) {
+    approveMessageInfos.push({
+      tokenPath: WRAPPED_GNOT_PATH,
+      targetAddress: PACKAGE_STAKER_ADDRESS,
+      amount: MAX_INT64,
+      caller,
+    });
+  }
+
+  const messages: TransactionMessage[] = [];
+
+  positionsWithSwapFee.forEach(lpTokenId => {
+    messages.push(
+      makeTransactionMessage({
+        send: "",
+        func: TransactionMessageFunctionType.CollectFee,
+        packagePath: PACKAGE_POSITION_PATH,
+        args: [lpTokenId.toString()],
+        caller,
+      }),
+    );
+  });
+
+  positionsWithStakingReward.forEach(lpTokenId => {
+    messages.push(
+      makeTransactionMessage({
+        send: "",
+        func: TransactionMessageFunctionType.CollectReward,
+        packagePath: PACKAGE_STAKER_PATH,
+        args: [lpTokenId.toString()],
+        caller,
+      }),
+    );
+  });
+
+  return makeTransactionMessagesWithApproves(messages, approveMessageInfos, fetchAllowance);
+}
+
 export function makeClaimAllMessageWithApproves(
   {
     positions,

--- a/packages/web/src/repositories/position/request/claim-all-request.ts
+++ b/packages/web/src/repositories/position/request/claim-all-request.ts
@@ -1,7 +1,11 @@
-import { PositionModel } from "@models/position/position-model";
-
 export interface ClaimAllRequest {
-  positions: PositionModel[];
+  swapFeeTokenPaths: string[];
+
+  hasGnotStakingReward: boolean;
+
+  positionsWithSwapFee: string[];
+
+  positionsWithStakingReward: string[];
 
   recipient: string;
 

--- a/packages/web/src/repositories/position/response/index.ts
+++ b/packages/web/src/repositories/position/response/index.ts
@@ -4,3 +4,4 @@ export * from "./decrease-liquidity-response";
 export * from "./reposition-liquidity-response";
 export * from "./position-bin";
 export * from "./get-positions-by-address-result";
+export * from "./position-rewards-response";

--- a/packages/web/src/repositories/position/response/position-rewards-response.ts
+++ b/packages/web/src/repositories/position/response/position-rewards-response.ts
@@ -1,0 +1,31 @@
+export interface PositionRewardTokenAmount {
+  tokenPath: string;
+  amount: string;
+  usdValue: string;
+}
+
+export interface PositionRewardsGroupResponse {
+  swapFee: PositionRewardTokenAmount[];
+  internalReward: PositionRewardTokenAmount[];
+  externalReward: PositionRewardTokenAmount[];
+}
+
+export interface PositionRewardsTotalUsdGroup {
+  swapFee: string;
+  internalReward: string;
+  externalReward: string;
+  total: string;
+}
+
+export interface PositionRewardsTotalUsd {
+  claimed: PositionRewardsTotalUsdGroup;
+  claimable: PositionRewardsTotalUsdGroup;
+}
+
+export interface PositionRewardsResponse {
+  claimed: PositionRewardsGroupResponse;
+  claimable: PositionRewardsGroupResponse;
+  totalUsd: PositionRewardsTotalUsd;
+  positionsWithSwapFee: string[];
+  positionsWithStakingReward: string[];
+}


### PR DESCRIPTION
## Descriptions

### Summary
Introduces a **server-aggregated position rewards** endpoint and wires **portfolio wallet balance** and **claim-all** flows to it. Claim-all transaction building now uses **explicit LP IDs and token paths** instead of passing full `PositionModel[]` through the repository.

### Changes
- **API / repository**
  - Add `getPositionRewardsByAddress` → `GET /users/{address}/position/reward`.
  - Add `PositionRewardsResponse` DTOs (claimed / claimable groups, USD totals, `positionsWithSwapFee`, `positionsWithStakingReward`).
  - Replace `ClaimAllRequest.positions` with `swapFeeTokenPaths`, `hasGnotStakingReward`, `positionsWithSwapFee`, `positionsWithStakingReward`, and `recipient`.
- **Transactions**
  - Add `makeClaimAllMessageWithApprovesByIds`: approvals for swap-fee tokens (pool + position), optional wugnot approval for staker when GNOT staking rewards exist, then `CollectFee` per LP ID and `CollectReward` per LP ID on the staker.
- **Data fetching**
  - Add `QUERY_KEY.positionRewards` and `useGetPositionRewards` (60s refetch, invalidate on claim with positions + balances).
- **Portfolio UI**
  - `WalletBalanceContainer`: load rewards with `useGetPositionRewards`, derive claim-all input and USD totals from `positionRewards`, keep staked / unstaked liquidity from `positions` (excluding closed).
  - `WalletBalance` / `WalletBalanceDetail`: consume `positionRewards` + `tokens` (path → `TokenModel`) for tooltips; remove client-side aggregation from converted pool positions; tooltip 1d accumulation fields are no longer populated from positions.
- **Pool detail**
  - `MyLiquidityContainer`: build claim-all input with `buildClaimAllInputFromPositions` for non-closed opened positions and pass `input` into `claimAll`.
- **Hooks**
  - `usePosition`: `claimAll` accepts `{ rpcProvider, input }`; export `buildClaimAllInputFromPositions` and `ClaimAllInput`.

