### PR TITLE
chore: update refetch intervals across various hooks

### DIFF
--- a/packages/web/src/hooks/gas/use-get-estimate-gas-info.ts
+++ b/packages/web/src/hooks/gas/use-get-estimate-gas-info.ts
@@ -8,7 +8,7 @@ import { Document } from "src/types/transaction-messages.types";
 import { QUERY_KEY } from "@query/query-keys";
 import { buildGasInfo } from "./build-gas-info";
 
-const REFETCH_INTERVAL = 10_000;
+const REFETCH_INTERVAL = 5_000;
 
 export const useGetEstimateGasInfo = (
   document: Document | null | undefined,

--- a/packages/web/src/hooks/pool/data/use-select-pool.tsx
+++ b/packages/web/src/hooks/pool/data/use-select-pool.tsx
@@ -171,12 +171,12 @@ export const useSelectPool = ({
 
   const { data: poolFromDb, isLoading: isLoadingPoolFromDb } = useGetPoolFromDb(convertPath, {
     enabled: !!convertPath && !isCreate,
-    refetchInterval: shouldRefetch ? 10_000 : false,
+    refetchInterval: shouldRefetch ? 5_000 : false,
   });
 
   const { data: liquidity, isLoading: isLoadingLiquidity } = useGetPoolLiquidity(calculatedPoolPath, {
     enabled: !!calculatedPoolPath && !isCreate,
-    refetchInterval: shouldRefetch ? 10_000 : false,
+    refetchInterval: shouldRefetch ? 5_000 : false,
   });
 
   const { data: ticks, isLoading: isLoadingTicks } = useGetPoolTicks(calculatedPoolPath, {
@@ -191,7 +191,7 @@ export const useSelectPool = ({
 
   const { data: sqrtPriceX96, isLoading: isLoadingSqrtPriceX96 } = useGetPoolSqrtPriceX96(calculatedPoolPath, {
     enabled: !!calculatedPoolPath && !isCreate,
-    refetchInterval: shouldRefetch ? 10_000 : false,
+    refetchInterval: shouldRefetch ? 5_000 : false,
   });
 
   const isLoadingPoolInfo =

--- a/packages/web/src/react-query/common/use-emit-transaction-events.ts
+++ b/packages/web/src/react-query/common/use-emit-transaction-events.ts
@@ -5,7 +5,7 @@ import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 
 import { QUERY_KEY } from "../query-keys";
 
-const REFETCH_INTERVAL = 1_000;
+const REFETCH_INTERVAL = 5_000;
 
 export const useEmitTransactionEvents = (options?: UseQueryOptions<Event<string[]>[], Error>) => {
   const { statusRepository, eventStore } = useGnoswapContext();

--- a/packages/web/src/react-query/common/use-get-notifications.ts
+++ b/packages/web/src/react-query/common/use-get-notifications.ts
@@ -6,7 +6,7 @@ import { QUERY_KEY } from "../query-keys";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { TransactionGroupsType } from "@models/notification";
 
-const REFETCH_INTERVAL = 10_000;
+const REFETCH_INTERVAL = 5_000;
 
 export const useGetNotifications = (options?: UseQueryOptions<TransactionGroupsType[], Error>) => {
   const { notificationRepository } = useGnoswapContext();

--- a/packages/web/src/react-query/dashboard/use-get-dashbaord-tvl.ts
+++ b/packages/web/src/react-query/dashboard/use-get-dashbaord-tvl.ts
@@ -5,7 +5,7 @@ import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 
 import { QUERY_KEY } from "../query-keys";
 
-const REFETCH_INTERVAL = 10_000;
+const REFETCH_INTERVAL = 5_000;
 
 export const useGetDashboardTVL = (options?: UseQueryOptions<TvlResponse, Error>) => {
   const { dashboardRepository } = useGnoswapContext();

--- a/packages/web/src/react-query/dashboard/use-get-dashboard-activities.ts
+++ b/packages/web/src/react-query/dashboard/use-get-dashboard-activities.ts
@@ -6,7 +6,7 @@ import { ActivityType } from "@repositories/dashboard";
 
 import { QUERY_KEY } from "../query-keys";
 
-const REFETCH_INTERVAL = 10_000;
+const REFETCH_INTERVAL = 5_000;
 
 export const useGetDashboardActivities = (
   activityType: ActivityType,

--- a/packages/web/src/react-query/dashboard/use-get-dashboard-volume.ts
+++ b/packages/web/src/react-query/dashboard/use-get-dashboard-volume.ts
@@ -5,7 +5,7 @@ import { IVolumeResponse } from "@repositories/dashboard/response/volume-respons
 
 import { QUERY_KEY } from "../query-keys";
 
-const REFETCH_INTERVAL = 10_000;
+const REFETCH_INTERVAL = 5_000;
 
 export const useGetDashboardVolume = (options?: UseQueryOptions<IVolumeResponse, Error>) => {
   const { dashboardRepository } = useGnoswapContext();

--- a/packages/web/src/react-query/token/use-get-all-token-prices.ts
+++ b/packages/web/src/react-query/token/use-get-all-token-prices.ts
@@ -5,7 +5,7 @@ import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 import { TokenPriceModel } from "@models/token/token-price-model";
 import { QUERY_KEY } from "../query-keys";
 
-const REFETCH_INTERVAL = 10_000;
+const REFETCH_INTERVAL = 5_000;
 
 export const useGetAllTokenPrices = (options?: UseQueryOptions<Record<string, TokenPriceModel>, Error>) => {
   const { tokenRepository } = useGnoswapContext();

--- a/packages/web/src/react-query/token/use-get-chain-info.ts
+++ b/packages/web/src/react-query/token/use-get-chain-info.ts
@@ -5,7 +5,7 @@ import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 
 import { QUERY_KEY } from "../query-keys";
 
-const REFETCH_INTERVAL = 10_000;
+const REFETCH_INTERVAL = 5_000;
 
 export const useGetChainInfo = (options?: UseQueryOptions<IChainResponse, Error>) => {
   const { tokenRepository } = useGnoswapContext();


### PR DESCRIPTION
## Descriptions
### Summary
- Standardized React Query `refetchInterval` values across affected hooks.
- Updated all sub-60s intervals in this change set (`1s`, `10s`) to `5s`.
- Kept long-polling targets at `60s` where applicable, aligning with the new polling policy.

### Why
- Enforces a consistent polling strategy across data-fetching hooks.
- Reduces uneven refresh behavior between dashboard/token/gas/notification/pool-related queries.
- Simplifies future maintenance by using only two operational polling tiers (`5s` and `60s`).

### Scope
- Updated polling intervals in:
  - gas info query hooks
  - pool selection-related conditional refetches
  - common event/notification queries
  - dashboard data queries
  - token data queries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Updates**
  * Accelerated data polling intervals for gas estimates, pool data, transaction events, notifications, dashboard metrics, and token pricing to deliver more current information across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->