### PR TITLE
refactor(position): align mint tx message

### DIFF
--- a/packages/web/src/repositories/pool/pool.message.ts
+++ b/packages/web/src/repositories/pool/pool.message.ts
@@ -326,6 +326,7 @@ function makePositionMintMessage(
       BigNumber(tokenAAmount).multipliedBy(slippageRatio).toFixed(0),
       BigNumber(tokenBAmount).multipliedBy(slippageRatio).toFixed(0),
       deadline,
+      caller, // LP Token Receiver
       referrerAddress || "", // Referral address
     ],
   });

--- a/packages/web/src/repositories/pool/pool.message.ts
+++ b/packages/web/src/repositories/pool/pool.message.ts
@@ -326,8 +326,6 @@ function makePositionMintMessage(
       BigNumber(tokenAAmount).multipliedBy(slippageRatio).toFixed(0),
       BigNumber(tokenBAmount).multipliedBy(slippageRatio).toFixed(0),
       deadline,
-      caller, // LP Token Receiver
-      caller, // Replace OriginCaller
       referrerAddress || "", // Referral address
     ],
   });


### PR DESCRIPTION
## Summary
- Remove the deprecated `mintTo` and `caller` arguments from the frontend `Position.Mint` transaction message.
- Keep the transaction caller unchanged; the contract now derives the LP receiver/caller from `runtime.PreviousRealm()`.

## Validation
- `yarn workspace @gnoswap-labs/web next lint --file src/repositories/pool/pool.message.ts`

## Notes
- Full `yarn workspace @gnoswap-labs/web lint` is currently blocked by an unrelated existing duplicate import error in `src/layouts/launchpad/components/launchpad-pool-tier-chip/LaunchpadPoolTierChip.tsx`.
- `yarn exec tsc -p packages/web/tsconfig.json --noEmit` is currently blocked by unrelated existing spec type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the structure of pool minting transaction messages to correctly order the LP token receiver parameter and referral address arguments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/867)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->