### PR TITLE
feat: add default memo support

### DIFF
--- a/packages/web/src/common/clients/wallet-client/adena/adena-client.ts
+++ b/packages/web/src/common/clients/wallet-client/adena/adena-client.ts
@@ -17,10 +17,12 @@ import { parseTransactionResponse } from "./adena-client.util";
 export class AdenaClient implements WalletClient {
   private adena: Adena | null;
   private address: string | null;
+  private defaultMemo: string | null;
 
-  constructor() {
+  constructor(defaultMemo?: string) {
     this.adena = null;
     this.address = null;
+    this.defaultMemo = defaultMemo || null;
   }
 
   public initAdena = () => {
@@ -89,6 +91,7 @@ export class AdenaClient implements WalletClient {
         };
       }),
       gasWanted: transaction.gasWanted || DEFAULT_GAS_WANTED,
+      memo: transaction.memo || this.defaultMemo || "",
     };
     return createTimeout<WalletResponse<SendTransactionResponse<T | null>>>(
       this.getAdena()
@@ -111,11 +114,11 @@ export class AdenaClient implements WalletClient {
     this.getAdena().On("changedNetwork", callback);
   };
 
-  public static createAdenaClient() {
+  public static createAdenaClient(defaultMemo?: string) {
     if (typeof window === "undefined" || typeof window.adena === "undefined") {
       return null;
     }
-    return new AdenaClient();
+    return new AdenaClient(defaultMemo);
   }
 
   public switchNetwork = (chainId: string): Promise<WalletResponse<SwitchNetworkResponse>> => {

--- a/packages/web/src/hooks/wallet/data/use-wallet.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.ts
@@ -151,7 +151,7 @@ export const useWallet = () => {
   const switchNetwork = async () => {
     try {
       setLoadingConnect("loading");
-      const adena = AdenaClient.createAdenaClient();
+      const adena = AdenaClient.createAdenaClient(defaultGnoswapMemo);
       if (!adena) {
         setLoadingConnect("error");
         return;
@@ -183,7 +183,7 @@ export const useWallet = () => {
       setLoadingConnect("loading");
     }
 
-    const adena = AdenaClient.createAdenaClient();
+    const adena = AdenaClient.createAdenaClient(defaultGnoswapMemo);
     if (adena !== null) {
       sessionStorage.setItem(GNOSWAP_WALLET_TYPE_KEY, "ADENA");
       adena.initAdena();
@@ -198,7 +198,7 @@ export const useWallet = () => {
       setLoadingConnect("loading");
 
       if (walletClient === null) {
-        const adena = AdenaClient.createAdenaClient();
+        const adena = AdenaClient.createAdenaClient(defaultGnoswapMemo);
         setWalletClient(adena);
         return;
       }

--- a/packages/web/src/hooks/wallet/data/use-wallet.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.ts
@@ -1,27 +1,28 @@
 import { WalletClient } from "@common/clients/wallet-client";
 import { AdenaClient } from "@common/clients/wallet-client/adena";
-import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
-import { CommonState, WalletState } from "@states/index";
-import { useAtom } from "jotai";
-import { useCallback, useEffect, useMemo } from "react";
 import { NetworkData } from "@constants/chains.constant";
-import * as uuid from "uuid";
+import { DEFAULT_CHAIN_ID, SUPPORT_CHAIN_IDS } from "@constants/environment.constant";
+import { AUTH_STORE_KEY } from "@hooks/common/use-auto-disconnect";
+import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
+import { useSocialWalletContext } from "@hooks/common/use-social-wallet-context";
+import { useGetTokenBalancesFromChain } from "@query/address";
 import {
   ACCOUNT_SESSION_INFO_KEY,
+  ADENA_SDK_CONNECTION_STATE_KEY,
   GNOSWAP_SESSION_ID_KEY,
   GNOSWAP_SOCIAL_LOGIN_TYPE_KEY,
   GNOSWAP_WALLET_TYPE_KEY,
   GNOWSWAP_CONNECTED_KEY,
-  ADENA_SDK_CONNECTION_STATE_KEY,
 } from "@states/common";
+import { CommonState, WalletState } from "@states/index";
 import { useQueryClient } from "@tanstack/react-query";
-import { SUPPORT_CHAIN_IDS, DEFAULT_CHAIN_ID } from "@constants/environment.constant";
-import { useGetTokenBalancesFromChain } from "@query/address";
-import { useSocialWalletContext } from "@hooks/common/use-social-wallet-context";
+import { useAtom } from "jotai";
+import { useCallback, useEffect, useMemo } from "react";
 import { AdenaSdkConnectionState, SocialLoginType, WalletType } from "src/types/wallet.types";
-import { AUTH_STORE_KEY } from "@hooks/common/use-auto-disconnect";
+import * as uuid from "uuid";
 
 const balanceQueryKey = ["token-balance", "ugnot"];
+const defaultGnoswapMemo = "Executed through gnoswap.io";
 
 export const useWallet = () => {
   const { accountRepository } = useGnoswapContext();
@@ -80,14 +81,14 @@ export const useWallet = () => {
     return !availNetwork;
   }, [availNetwork, walletAccount]);
 
-  const {
-    data: balance,
-    isLoading: isLoadingBalance,
-    isStale: isBalanceStale,
-    refetch,
-  } = useGetTokenBalancesFromChain(currentChainId, walletAccount?.address, "ugnot", {
-    enabled: !!walletAccount?.address && availNetwork,
-  });
+  const { data: balance, isLoading: isLoadingBalance, isStale: isBalanceStale, refetch } = useGetTokenBalancesFromChain(
+    currentChainId,
+    walletAccount?.address,
+    "ugnot",
+    {
+      enabled: !!walletAccount?.address && availNetwork,
+    },
+  );
 
   useEffect(() => {
     if (walletClient) {
@@ -135,7 +136,7 @@ export const useWallet = () => {
       if (savedWalletType === "ADENA") {
         connectAdenaClient();
 
-        const adena = AdenaClient.createAdenaClient();
+        const adena = AdenaClient.createAdenaClient(defaultGnoswapMemo);
         const data = await adena?.getAccount();
         if (data?.status === "failure" && data.type !== "WALLET_LOCKED") {
           disconnectWallet();


### PR DESCRIPTION
## Summary
- Added support for a default transaction memo in the Adena wallet client.
- Passed a predefined memo (`Executed through gnoswap.io`) when creating the Adena client in the wallet hook.
- Updated transaction payload construction so `memo` is resolved with this priority: `transaction.memo` > `defaultMemo` > empty string.

## Why
- Ensures transactions sent via Adena include a consistent default memo when no explicit memo is provided.
- Improves transaction traceability without changing existing behavior for flows that already set a memo.

## Changes
- `packages/web/src/common/clients/wallet-client/adena/adena-client.ts`
  - Added `defaultMemo` field and constructor parameter.
  - Added memo fallback logic in `sendTransaction`.
  - Extended `createAdenaClient` to accept `defaultMemo`.
- `packages/web/src/hooks/wallet/data/use-wallet.ts`
  - Added `defaultGnoswapMemo` constant.
  - Passed `defaultGnoswapMemo` into `AdenaClient.createAdenaClient(...)` during auto-connect.
