### PR TITLE
feat(pool): support active incentive claim

### DIFF
--- a/packages/web/src/common/errors/pool/pool-error.ts
+++ b/packages/web/src/common/errors/pool/pool-error.ts
@@ -13,6 +13,10 @@ const ERROR_VALUE = {
     status: 500,
     type: "Failed to remove incentive",
   },
+  FAILED_TO_COLLECT_INCENTIVE: {
+    status: 500,
+    type: "Failed to collect incentive",
+  },
   FAILED_TO_GET_LIQUIDITY: {
     status: 500,
     type: "Failed to get pool liquidity",

--- a/packages/web/src/common/types/global-prop-types.ts
+++ b/packages/web/src/common/types/global-prop-types.ts
@@ -1,3 +1,10 @@
 export type ObjectStringValueType = {
   [key in string]: string;
 };
+
+export const YN_TYPE = {
+  YES: "Y",
+  NO: "N",
+} as const;
+
+export type YnType = (typeof YN_TYPE)[keyof typeof YN_TYPE];

--- a/packages/web/src/layouts/launchpad/components/launchpad-pool-tier-chip/LaunchpadPoolTierChip.tsx
+++ b/packages/web/src/layouts/launchpad/components/launchpad-pool-tier-chip/LaunchpadPoolTierChip.tsx
@@ -1,8 +1,6 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 
-import { TierType } from "@utils/launchpad-get-tier-number";
-import { getTierDuration } from "@utils/launchpad-get-tier-number";
+import { getTierDuration, type TierType } from "@utils/launchpad-get-tier-number";
 
 import { PoolTierChipWrapper } from "./LaunchpadPoolTierChip.styles";
 

--- a/packages/web/src/layouts/leaderboard-layout/containers/leaderboard-list-header-container/LeaderboardListHeaderContainer.tsx
+++ b/packages/web/src/layouts/leaderboard-layout/containers/leaderboard-list-header-container/LeaderboardListHeaderContainer.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { useAddress } from "@hooks/common/use-address";
 import { useGetLeaderboardByAddress, useUpdateLeaderboardHiddenState } from "@query/leaderboard";
 import { DEVICE_TYPE } from "@styles/media";
+import { isLeaderboardHidden } from "@utils/leaderboard-utils";
 
 import IconSearch from "@components/common/icons/IconSearch";
 import SearchInput from "@components/common/search-input/SearchInput";
@@ -35,7 +36,7 @@ const LeaderboardListHeaderContainer = ({
   const { address, connected } = useAddress();
   const { data: leaderboardMyInfo, isLoading: isLoadingLeaderboardMyInfo } = useGetLeaderboardByAddress(address || "");
 
-  const isHidden = leaderboardMyInfo?.hiddenYn === "Y";
+  const isHidden = !!leaderboardMyInfo && isLeaderboardHidden(leaderboardMyInfo.hiddenYn);
 
   const [checked, setChecked] = useState(false);
   const [isOptimisticUpdate, setIsOptimisticUpdate] = useState(false);

--- a/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Trans, useTranslation } from "react-i18next";
 
 import { getDateUtcToLocal } from "@common/utils/date-util";
+import { YN_TYPE } from "@common/types/global-prop-types";
 import { GNS_TOKEN } from "@common/values/token-constant";
 import { PoolMapper } from "@models/pool/mapper/pool-mapper";
 import { ExtendedPoolStakingModel } from "@models/pool/pool-staking";
@@ -96,8 +97,8 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
     return new BigNumber(stakingData.claimableUnvestedAmount || "0").isGreaterThan(0);
   }, [stakingData.claimableUnvestedAmount]);
 
-  const isExternalIncentiveActive = stakingData.activeYn === "Y";
-  const isExternalIncentiveEnded = stakingData.activeYn === "N";
+  const isExternalIncentiveActive = stakingData.activeYn === YN_TYPE.YES;
+  const isExternalIncentiveEnded = stakingData.activeYn === YN_TYPE.NO;
   const hasKnownExternalIncentiveActiveState = isExternalIncentiveActive || isExternalIncentiveEnded;
 
   const isClaimDisabled = !hasClaimableUnvestedAmount || !hasKnownExternalIncentiveActiveState;

--- a/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
@@ -1,3 +1,4 @@
+import BigNumber from "bignumber.js";
 import Link from "next/link";
 import React from "react";
 import { Trans, useTranslation } from "react-i18next";
@@ -32,11 +33,12 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
 
   const { rewardToken, incentiveId } = stakingData;
 
-  const { data: pool = null } = useGetPoolDetailByPath(poolPath, {
-    enabled: !!poolPath,
-  });
+  const { data: pool = null } = useGetPoolDetailByPath(poolPath || null);
 
-  const { removeExternalIncentive } = useRemoveExternalIncentive(poolPath, incentiveId ?? "");
+  const { removeExternalIncentive, collectExternalIncentivePenalty } = useRemoveExternalIncentive(
+    poolPath,
+    incentiveId ?? "",
+  );
   const { getGnotPath } = useGnotToGnot();
 
   const currentPool = React.useMemo(() => {
@@ -89,6 +91,35 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
     const now = new Date();
     return now > endDate;
   }, [stakingData]);
+
+  const hasClaimableUnvestedAmount = React.useMemo(() => {
+    return new BigNumber(stakingData.claimableUnvestedAmount || "0").isGreaterThan(0);
+  }, [stakingData.claimableUnvestedAmount]);
+
+  const isExternalIncentiveActive = stakingData.activeYn === "Y";
+  const isExternalIncentiveEnded = stakingData.activeYn === "N";
+  const hasKnownExternalIncentiveActiveState = isExternalIncentiveActive || isExternalIncentiveEnded;
+
+  const isClaimDisabled = !hasClaimableUnvestedAmount || !hasKnownExternalIncentiveActiveState;
+
+  const handleClaim = React.useCallback(() => {
+    if (isClaimDisabled) {
+      return;
+    }
+
+    if (isExternalIncentiveEnded) {
+      void collectExternalIncentivePenalty({ rpcProvider });
+      return;
+    }
+
+    void removeExternalIncentive({ rpcProvider });
+  }, [
+    collectExternalIncentivePenalty,
+    isClaimDisabled,
+    isExternalIncentiveEnded,
+    removeExternalIncentive,
+    rpcProvider,
+  ]);
 
   const renderDataMapping = () => {
     return (
@@ -230,7 +261,8 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
             <Button
               text={"Claim"}
               style={{ hierarchy: ButtonHierarchy.Primary, fullWidth: true }}
-              onClick={() => removeExternalIncentive({ rpcProvider })}
+              disabled={isClaimDisabled}
+              onClick={handleClaim}
             />
           </div>
         )}

--- a/packages/web/src/models/pool/mapper/pool-staking-mapper.ts
+++ b/packages/web/src/models/pool/mapper/pool-staking-mapper.ts
@@ -13,7 +13,7 @@ export class PoolStakingMapper {
       incentiveId: poolStaking?.incentiveId || null,
       unvestedAmount: poolStaking.unvestedAmount || "0",
       claimableUnvestedAmount: poolStaking.claimableUnvestedAmount || "0",
-      activeYn: poolStaking.activeYn || "",
+      activeYn: poolStaking.activeYn,
       incentiveType: poolStaking.incentiveType as INCENTIVE_TYPE,
     };
   }

--- a/packages/web/src/models/pool/mapper/pool-staking-mapper.ts
+++ b/packages/web/src/models/pool/mapper/pool-staking-mapper.ts
@@ -13,6 +13,7 @@ export class PoolStakingMapper {
       incentiveId: poolStaking?.incentiveId || null,
       unvestedAmount: poolStaking.unvestedAmount || "0",
       claimableUnvestedAmount: poolStaking.claimableUnvestedAmount || "0",
+      activeYn: poolStaking.activeYn || "",
       incentiveType: poolStaking.incentiveType as INCENTIVE_TYPE,
     };
   }

--- a/packages/web/src/models/pool/pool-staking.ts
+++ b/packages/web/src/models/pool/pool-staking.ts
@@ -1,7 +1,6 @@
+import { YnType } from "@common/types/global-prop-types";
 import { INCENTIVE_TYPE } from "@constants/option.constant";
 import { TokenModel } from "@models/token/token-model";
-
-export type PoolStakingActiveYn = "Y" | "N";
 
 export interface PoolStakingModel {
   incentiveId: string | null;
@@ -15,7 +14,7 @@ export interface PoolStakingModel {
   endTimestamp: string;
   unvestedAmount: string;
   claimableUnvestedAmount: string;
-  activeYn: PoolStakingActiveYn;
+  activeYn: YnType;
   createdBlockHeight: string;
 }
 

--- a/packages/web/src/models/pool/pool-staking.ts
+++ b/packages/web/src/models/pool/pool-staking.ts
@@ -13,6 +13,7 @@ export interface PoolStakingModel {
   endTimestamp: string;
   unvestedAmount: string;
   claimableUnvestedAmount: string;
+  activeYn: string;
   createdBlockHeight: string;
 }
 

--- a/packages/web/src/models/pool/pool-staking.ts
+++ b/packages/web/src/models/pool/pool-staking.ts
@@ -1,6 +1,8 @@
 import { INCENTIVE_TYPE } from "@constants/option.constant";
 import { TokenModel } from "@models/token/token-model";
 
+export type PoolStakingActiveYn = "Y" | "N";
+
 export interface PoolStakingModel {
   incentiveId: string | null;
   incentiveType: INCENTIVE_TYPE;
@@ -13,7 +15,7 @@ export interface PoolStakingModel {
   endTimestamp: string;
   unvestedAmount: string;
   claimableUnvestedAmount: string;
-  activeYn: string;
+  activeYn: PoolStakingActiveYn;
   createdBlockHeight: string;
 }
 

--- a/packages/web/src/react-query/pools/use-remove-external-incentive.ts
+++ b/packages/web/src/react-query/pools/use-remove-external-incentive.ts
@@ -8,7 +8,11 @@ import { fetchAllowance } from "@common/clients/wallet-client/transaction-messag
 import { CommonError } from "@common/errors";
 import { useNetworkFee } from "@hooks/common/use-network-fee";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
-import { makeRemoveExternalIncentiveMessageWithApproves } from "@repositories/pool/pool.message";
+import {
+  makeCollectExternalIncentivePenaltyMessageWithApproves,
+  makeRemoveExternalIncentiveMessageWithApproves,
+} from "@repositories/pool/pool.message";
+import { CollectExternalIncentivePenaltyRequest } from "@repositories/pool/request/collect-external-incentive-penalty-request";
 import { RemoveExternalIncentiveRequest } from "@repositories/pool/request/remove-external-incentive-request";
 
 export const useRemoveExternalIncentive = (poolPath: string, incentiveID: string) => {
@@ -16,42 +20,83 @@ export const useRemoveExternalIncentive = (poolPath: string, incentiveID: string
   const { account, walletClient } = useWallet();
   const { estimateNetworkFee } = useNetworkFee(null);
 
-  const buildAdenaWalletRemoveIncentiveAction = async (request: RemoveExternalIncentiveRequest) => {
-    return poolRepository.removeExternalIncentive(request);
-  };
+  const buildAdenaWalletRemoveIncentiveAction = React.useCallback(
+    async (request: RemoveExternalIncentiveRequest) => {
+      return poolRepository.removeExternalIncentive(request);
+    },
+    [poolRepository],
+  );
 
-  const buildSocialWalletRemoveIncentiveAction = async (
-    rpcProvider: GnoProvider | null,
-    request: RemoveExternalIncentiveRequest,
-    caller: string,
-  ) => {
-    if (!rpcProvider) {
-      console.log("RemoveExternalIncentive: ", new CommonError("FAILED_INITIALIZE_GNO_PROVIDER"));
-      return null;
-    }
+  const buildAdenaWalletCollectPenaltyAction = React.useCallback(
+    async (request: CollectExternalIncentivePenaltyRequest) => {
+      return poolRepository.collectExternalIncentivePenalty(request);
+    },
+    [poolRepository],
+  );
 
-    const getAllowance = (packagePath: string, owner: string, spender: string) => {
-      return fetchAllowance(rpcProvider, packagePath, owner, spender);
-    };
+  const buildSocialWalletRemoveIncentiveAction = React.useCallback(
+    async (rpcProvider: GnoProvider | null, request: RemoveExternalIncentiveRequest, caller: string) => {
+      if (!rpcProvider) {
+        console.log("RemoveExternalIncentive: ", new CommonError("FAILED_INITIALIZE_GNO_PROVIDER"));
+        return null;
+      }
 
-    const messageRequests: RemoveExternalIncentiveRequest & { caller: string } = {
-      ...request,
-      caller,
-    };
-    const txMessages = await makeRemoveExternalIncentiveMessageWithApproves(messageRequests, getAllowance);
+      const getAllowance = (packagePath: string, owner: string, spender: string) => {
+        return fetchAllowance(rpcProvider, packagePath, owner, spender);
+      };
 
-    const txDoc = await transactionService.createDocument({ messages: txMessages });
-    await transactionService.createTransaction(txDoc);
+      const messageRequests: RemoveExternalIncentiveRequest & { caller: string } = {
+        ...request,
+        caller,
+      };
+      const txMessages = await makeRemoveExternalIncentiveMessageWithApproves(messageRequests, getAllowance);
 
-    const { currentGasInfo, networkFee } = await estimateNetworkFee(txDoc);
-    const requestWithGasInfo: RemoveExternalIncentiveRequest = {
-      ...request,
-      gasFee: networkFee?.amount,
-      gasUsed: getGasUsed(currentGasInfo).toString(),
-    };
+      const txDoc = await transactionService.createDocument({ messages: txMessages });
+      await transactionService.createTransaction(txDoc);
 
-    return poolRepository.removeExternalIncentive(requestWithGasInfo);
-  };
+      const { currentGasInfo, networkFee } = await estimateNetworkFee(txDoc);
+      const requestWithGasInfo: RemoveExternalIncentiveRequest = {
+        ...request,
+        gasFee: networkFee?.amount,
+        gasUsed: getGasUsed(currentGasInfo).toString(),
+      };
+
+      return poolRepository.removeExternalIncentive(requestWithGasInfo);
+    },
+    [estimateNetworkFee, poolRepository, transactionService],
+  );
+
+  const buildSocialWalletCollectPenaltyAction = React.useCallback(
+    async (rpcProvider: GnoProvider | null, request: CollectExternalIncentivePenaltyRequest, caller: string) => {
+      if (!rpcProvider) {
+        console.log("CollectExternalIncentivePenalty: ", new CommonError("FAILED_INITIALIZE_GNO_PROVIDER"));
+        return null;
+      }
+
+      const getAllowance = (packagePath: string, owner: string, spender: string) => {
+        return fetchAllowance(rpcProvider, packagePath, owner, spender);
+      };
+
+      const messageRequests: CollectExternalIncentivePenaltyRequest & { caller: string } = {
+        ...request,
+        caller,
+      };
+      const txMessages = await makeCollectExternalIncentivePenaltyMessageWithApproves(messageRequests, getAllowance);
+
+      const txDoc = await transactionService.createDocument({ messages: txMessages });
+      await transactionService.createTransaction(txDoc);
+
+      const { currentGasInfo, networkFee } = await estimateNetworkFee(txDoc);
+      const requestWithGasInfo: CollectExternalIncentivePenaltyRequest = {
+        ...request,
+        gasFee: networkFee?.amount,
+        gasUsed: getGasUsed(currentGasInfo).toString(),
+      };
+
+      return poolRepository.collectExternalIncentivePenalty(requestWithGasInfo);
+    },
+    [estimateNetworkFee, poolRepository, transactionService],
+  );
 
   const removeExternalIncentive = React.useCallback(
     async ({ rpcProvider }: { rpcProvider: GnoProvider | null }) => {
@@ -71,8 +116,43 @@ export const useRemoveExternalIncentive = (poolPath: string, incentiveID: string
         ? buildAdenaWalletRemoveIncentiveAction(request)
         : buildSocialWalletRemoveIncentiveAction(rpcProvider, request, address);
     },
-    [walletClient, account?.address, poolRepository, poolPath, incentiveID],
+    [
+      account?.address,
+      buildAdenaWalletRemoveIncentiveAction,
+      buildSocialWalletRemoveIncentiveAction,
+      incentiveID,
+      poolPath,
+      walletClient,
+    ],
   );
 
-  return { removeExternalIncentive };
+  const collectExternalIncentivePenalty = React.useCallback(
+    async ({ rpcProvider }: { rpcProvider: GnoProvider | null }) => {
+      const address = account?.address;
+      if (!address) {
+        return null;
+      }
+
+      const request: CollectExternalIncentivePenaltyRequest = {
+        poolPath,
+        incentiveID,
+      };
+
+      const walletType = walletClient?.getWalletType();
+
+      return walletType === "ADENA"
+        ? buildAdenaWalletCollectPenaltyAction(request)
+        : buildSocialWalletCollectPenaltyAction(rpcProvider, request, address);
+    },
+    [
+      account?.address,
+      buildAdenaWalletCollectPenaltyAction,
+      buildSocialWalletCollectPenaltyAction,
+      incentiveID,
+      poolPath,
+      walletClient,
+    ],
+  );
+
+  return { removeExternalIncentive, collectExternalIncentivePenalty };
 };

--- a/packages/web/src/repositories/leaderboard/response/common/types.ts
+++ b/packages/web/src/repositories/leaderboard/response/common/types.ts
@@ -1,7 +1,11 @@
-export enum LeaderboardVisibilityStatus {
-  HIDDEN = "Y",
-  VISIBLE = "N",
-}
+import { YN_TYPE, YnType } from "@common/types/global-prop-types";
+
+export const LeaderboardVisibilityStatus = {
+  HIDDEN: YN_TYPE.YES,
+  VISIBLE: YN_TYPE.NO,
+} as const satisfies Record<string, YnType>;
+
+export type LeaderboardVisibilityStatus = (typeof LeaderboardVisibilityStatus)[keyof typeof LeaderboardVisibilityStatus];
 
 export interface LeaderboardUser {
   accountAddress: string;

--- a/packages/web/src/repositories/pool/pool-repository-impl.ts
+++ b/packages/web/src/repositories/pool/pool-repository-impl.ts
@@ -28,12 +28,14 @@ import {
 import { generateSendTransactionParams, withTransactionGuard } from "@utils/transaction-utils";
 import { PoolListResponse, PoolPricesResponse, PoolRepository, PoolResponse } from ".";
 import {
+  makeCollectExternalIncentivePenaltyMessageWithApproves,
   makeCreateExternalIncentiveMessageWithApproves,
   makeCreatePoolMessageWithApproves,
   makePositionMintMessageWithApproves,
   makeRemoveExternalIncentiveMessageWithApproves,
 } from "./pool.message";
 import { AddLiquidityRequest } from "./request/add-liquidity-request";
+import { CollectExternalIncentivePenaltyRequest } from "./request/collect-external-incentive-penalty-request";
 import { CreateExternalIncentiveRequest } from "./request/create-external-incentive-request";
 import { CreatePoolRequest } from "./request/create-pool-request";
 import { RemoveExternalIncentiveRequest } from "./request/remove-external-incentive-request";
@@ -58,7 +60,8 @@ export class PoolRepositoryImpl implements PoolRepository {
         throw new CommonError("FAILED_INITIALIZE_ENVIRONMENT");
       }
 
-      const response = await (await this.rpcProvider.getStatus()).sync_info.latest_block_height;
+      const status = await this.rpcProvider.getStatus();
+      const response = status.sync_info.latest_block_height;
 
       return response;
     } catch (error) {
@@ -438,7 +441,45 @@ export class PoolRepositoryImpl implements PoolRepository {
       return this.walletClient!.sendTransaction(updatedSendTransactionParams || sendTransactionParams);
     }).then(response => {
       if (response.code !== 0 || !response.data) {
-        throw new PoolError("FAILED_TO_CREATE_INCENTIVE");
+        throw new PoolError("FAILED_TO_REMOVE_INCENTIVE");
+      }
+      const data = response?.data as SendTransactionSuccessResponse<string[]>;
+      return data?.hash || null;
+    });
+  };
+
+  collectExternalIncentivePenalty = async (request: CollectExternalIncentivePenaltyRequest): Promise<string | null> => {
+    if (!this.rpcProvider) {
+      throw new CommonError("FAILED_INITIALIZE_GNO_PROVIDER");
+    }
+
+    const address = await this.getAddress();
+
+    const { gasFee, gasUsed, ...requests } = request;
+    const makeTxMessageRequests = {
+      caller: address,
+      ...requests,
+    };
+
+    const messages = await makeCollectExternalIncentivePenaltyMessageWithApproves(
+      makeTxMessageRequests,
+      (packagePath, owner, spender) => getGRC20Allowance(this.rpcProvider!, packagePath, owner, spender),
+    );
+
+    const gasWanted = Number(gasUsed) || DEFAULT_GAS_WANTED;
+
+    const sendTransactionParams = generateSendTransactionParams({
+      messages,
+      gasFee: Number(gasFee) || DEFAULT_GAS_FEE,
+      gasWanted: Number(gasWanted.toFixed()),
+      memo: "",
+    });
+
+    return withTransactionGuard(this.walletClient, sendTransactionParams, updatedSendTransactionParams => {
+      return this.walletClient!.sendTransaction(updatedSendTransactionParams || sendTransactionParams);
+    }).then(response => {
+      if (response.code !== 0 || !response.data) {
+        throw new PoolError("FAILED_TO_COLLECT_INCENTIVE");
       }
       const data = response?.data as SendTransactionSuccessResponse<string[]>;
       return data?.hash || null;

--- a/packages/web/src/repositories/pool/pool-repository-mock.ts
+++ b/packages/web/src/repositories/pool/pool-repository-mock.ts
@@ -83,6 +83,10 @@ export class PoolRepositoryMock implements PoolRepository {
     return "hash";
   };
 
+  collectExternalIncentivePenalty = async (): Promise<string> => {
+    return "hash";
+  };
+
   getPoolSqrtPriceX96 = async (poolPath: string): Promise<bigint> => {
     console.log("Mock getPoolSqrtPriceX96:", poolPath);
     return 79228162514264337593543950336n;

--- a/packages/web/src/repositories/pool/pool-repository.ts
+++ b/packages/web/src/repositories/pool/pool-repository.ts
@@ -3,6 +3,7 @@ import { IncentivizePoolModel, PoolModel } from "@models/pool/pool-model";
 import { AddLiquidityRequest } from "./request/add-liquidity-request";
 import { CreatePoolRequest } from "./request/create-pool-request";
 import { CreateExternalIncentiveRequest } from "./request/create-external-incentive-request";
+import { CollectExternalIncentivePenaltyRequest } from "./request/collect-external-incentive-penalty-request";
 import { RemoveExternalIncentiveRequest } from "./request/remove-external-incentive-request";
 import { AddLiquidityFailedResponse, AddLiquiditySuccessResponse } from "./response/add-liquidity-response";
 import { CreatePoolFailedResponse, CreatePoolSuccessResponse } from "./response/create-pool-response";
@@ -44,6 +45,8 @@ export interface PoolRepository {
   ) => Promise<WalletResponse<SendTransactionResponse<string[] | null>> | null>;
 
   removeExternalIncentive: (request: RemoveExternalIncentiveRequest) => Promise<string | null>;
+
+  collectExternalIncentivePenalty: (request: CollectExternalIncentivePenaltyRequest) => Promise<string | null>;
 
   getPoolStakingList: (poolPath: string) => Promise<PoolStakingModel[]>;
 

--- a/packages/web/src/repositories/pool/pool.message.ts
+++ b/packages/web/src/repositories/pool/pool.message.ts
@@ -33,6 +33,7 @@ enum PoolTransactionMessageFunctionType {
   MintAndStake = "MintAndStake",
   CreateExternalIncentive = "CreateExternalIncentive",
   EndExternalIncentive = "EndExternalIncentive",
+  CollectExternalIncentivePenalty = "CollectExternalIncentivePenalty",
 }
 
 export function makeCreatePoolMessageWithApproves(
@@ -271,8 +272,44 @@ export function makeRemoveExternalIncentiveMessageWithApproves(
   const approveMessageInfos: TokenApproveMessageInfo[] = [];
 
   const removeExternalIncentiveMessage = makeRemoveIncentiveMessage(poolPath, incentiveID, caller);
+  const collectExternalIncentivePenaltyMessage = makeCollectExternalIncentivePenaltyMessage(
+    poolPath,
+    incentiveID,
+    caller,
+  );
 
-  return makeTransactionMessagesWithApproves([removeExternalIncentiveMessage], approveMessageInfos, fetchAllowance);
+  return makeTransactionMessagesWithApproves(
+    [removeExternalIncentiveMessage, collectExternalIncentivePenaltyMessage],
+    approveMessageInfos,
+    fetchAllowance,
+  );
+}
+
+export function makeCollectExternalIncentivePenaltyMessageWithApproves(
+  {
+    poolPath,
+    incentiveID,
+    caller,
+  }: {
+    poolPath: string;
+    incentiveID: string;
+    caller: string;
+  },
+  fetchAllowance: (packagePath: string, owner: string, spender: string) => Promise<number>,
+): Promise<TransactionMessage[]> {
+  const approveMessageInfos: TokenApproveMessageInfo[] = [];
+
+  const collectExternalIncentivePenaltyMessage = makeCollectExternalIncentivePenaltyMessage(
+    poolPath,
+    incentiveID,
+    caller,
+  );
+
+  return makeTransactionMessagesWithApproves(
+    [collectExternalIncentivePenaltyMessage],
+    approveMessageInfos,
+    fetchAllowance,
+  );
 }
 
 function makeCreateIncentiveMessage(
@@ -373,6 +410,16 @@ function makeRemoveIncentiveMessage(poolPath: string, incentiveID: string, calle
   return makeTransactionMessage({
     send: "",
     func: PoolTransactionMessageFunctionType.EndExternalIncentive,
+    packagePath: PACKAGE_STAKER_PATH,
+    args: [poolPath, incentiveID, caller],
+    caller,
+  });
+}
+
+function makeCollectExternalIncentivePenaltyMessage(poolPath: string, incentiveID: string, caller: string) {
+  return makeTransactionMessage({
+    send: "",
+    func: PoolTransactionMessageFunctionType.CollectExternalIncentivePenalty,
     packagePath: PACKAGE_STAKER_PATH,
     args: [poolPath, incentiveID, caller],
     caller,

--- a/packages/web/src/repositories/pool/request/collect-external-incentive-penalty-request.ts
+++ b/packages/web/src/repositories/pool/request/collect-external-incentive-penalty-request.ts
@@ -1,0 +1,9 @@
+export interface CollectExternalIncentivePenaltyRequest {
+  poolPath: string;
+
+  incentiveID: string;
+
+  gasFee?: string;
+
+  gasUsed?: string;
+}

--- a/packages/web/src/repositories/pool/response/pool-staking-response.ts
+++ b/packages/web/src/repositories/pool/response/pool-staking-response.ts
@@ -1,3 +1,4 @@
+import { PoolStakingActiveYn } from "@models/pool/pool-staking";
 import { TokenModel } from "@models/token/token-model";
 
 export interface PoolStakingResponse {
@@ -14,6 +15,6 @@ export interface PoolStakingResponse {
   totalPenaltyAmount: string;
   collectedPenaltyAmount: string;
   claimableUnvestedAmount: string;
-  activeYn: string;
+  activeYn: PoolStakingActiveYn;
   createdBlockHeight: string;
 }

--- a/packages/web/src/repositories/pool/response/pool-staking-response.ts
+++ b/packages/web/src/repositories/pool/response/pool-staking-response.ts
@@ -14,5 +14,6 @@ export interface PoolStakingResponse {
   totalPenaltyAmount: string;
   collectedPenaltyAmount: string;
   claimableUnvestedAmount: string;
+  activeYn: string;
   createdBlockHeight: string;
 }

--- a/packages/web/src/repositories/pool/response/pool-staking-response.ts
+++ b/packages/web/src/repositories/pool/response/pool-staking-response.ts
@@ -1,4 +1,4 @@
-import { PoolStakingActiveYn } from "@models/pool/pool-staking";
+import { YnType } from "@common/types/global-prop-types";
 import { TokenModel } from "@models/token/token-model";
 
 export interface PoolStakingResponse {
@@ -15,6 +15,6 @@ export interface PoolStakingResponse {
   totalPenaltyAmount: string;
   collectedPenaltyAmount: string;
   claimableUnvestedAmount: string;
-  activeYn: PoolStakingActiveYn;
+  activeYn: YnType;
   createdBlockHeight: string;
 }


### PR DESCRIPTION
## Summary
- Add `CollectExternalIncentivePenalty` transaction support for external incentives.
- Route claim actions using API `activeYn`: active incentives send End+Collect, ended incentives send Collect-only.
- Disable the Claim button unless `claimableUnvestedAmount` is positive and active state is known.

## Claim Button Behavior
| State | Button visible | Button enabled | Click action |
|---|---:|---:|---|
| Before `endTimestamp` | No | No | - |
| After `endTimestamp` + no claimable amount | Yes | No | - |
| After `endTimestamp` + claimable amount + `activeYn = Y` | Yes | Yes | `EndExternalIncentive` + `CollectExternalIncentivePenalty` |
| After `endTimestamp` + claimable amount + `activeYn = N` | Yes | Yes | `CollectExternalIncentivePenalty` only |
| After `endTimestamp` + claimable amount + unknown `activeYn` | Yes | No | - |


## Verification
- `yarn workspace @gnoswap-labs/web lint` (passes with existing warnings)
- `yarn workspace @gnoswap-labs/web jest --runTestsByPath "src/repositories/pool/pool-repository.spec.ts" --ci`
- `yarn workspace @gnoswap-labs/web test:ci`
- `yarn build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting external incentive penalties from pool incentives.

* **Bug Fixes**
  * Improved incentive claim button logic to correctly handle both active and ended incentive states.
  * Enhanced error handling for incentive collection operations.

* **Chores**
  * Updated pool staking data model to track incentive active status.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/869)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->