### PR TITLE
chore: update refetch intervals to 5 seconds in pool and position hooksg

### DIFF
--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -48,20 +48,16 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   const { breakpoint } = useWindowSize();
   const { connected: connectedWallet, isSwitchNetwork, account, currentChainId } = useWallet();
   const [currentIndex, setCurrentIndex] = useState(1);
-  const [positionPage, setPositionPage] = useState(1);
   const [positionLimit, setPositionLimit] = useState(DEFAULT_POSITION_LIMIT);
-  const [loadedPositions, setLoadedPositions] = useState<PoolPositionModel[]>([]);
   const poolPath = router.getPoolPath();
   const normalizedAddress = useMemo(() => (address || "").toLowerCase(), [address]);
 
   const positionScopeId = useMemo(() => {
-    return ["my-liquidity", address || "", poolPath || "", positionLimit, positionPage].join("-");
-  }, [address, poolPath, positionLimit, positionPage]);
+    return ["my-liquidity", address || "", poolPath || "", positionLimit].join("-");
+  }, [address, poolPath, positionLimit]);
 
   useEffect(() => {
-    setPositionPage(1);
     setPositionLimit(DEFAULT_POSITION_LIMIT);
-    setLoadedPositions([]);
   }, [address, poolPath]);
 
   const {
@@ -72,7 +68,7 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   } = usePositionData({
     address,
     poolPath,
-    page: positionPage,
+    page: 1,
     limit: positionLimit,
     scopeId: positionScopeId,
     queryOption: {
@@ -80,29 +76,14 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     },
   });
 
-  useEffect(() => {
-    if (!address || !poolPath || positions.length === 0) {
-      return;
+  const loadedPositions = useMemo<PoolPositionModel[]>(() => {
+    if (!address || !poolPath) {
+      return [];
     }
 
-    const currentPagePositions = positions.filter(
+    return positions.filter(
       position => position.poolPath === poolPath && position.owner.toLowerCase() === normalizedAddress,
     );
-
-    if (currentPagePositions.length === 0) {
-      return;
-    }
-
-    setLoadedPositions(prev => {
-      const loadedPositionIds = new Set(prev.map(position => position.id));
-      const nextPositions = currentPagePositions.filter(position => !loadedPositionIds.has(position.id));
-
-      if (nextPositions.length === 0) {
-        return prev;
-      }
-
-      return [...prev, ...nextPositions];
-    });
   }, [address, poolPath, positions, normalizedAddress]);
 
   const { invalidateQueryKey } = useInvalidateQueries();
@@ -328,7 +309,6 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
       return;
     }
 
-    setPositionPage(1);
     setPositionLimit(Math.max(totalPositionCount, DEFAULT_POSITION_LIMIT));
   }, [accountPositions.length, totalPositionCount]);
 

--- a/packages/web/src/react-query/pools/use-get-pool-detail-by-path.ts
+++ b/packages/web/src/react-query/pools/use-get-pool-detail-by-path.ts
@@ -1,14 +1,14 @@
 import { UseQueryOptions, useQuery } from "@tanstack/react-query";
 
-import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
-import { PoolDetailModel } from "@models/pool/pool-detail-model";
 import { PoolError } from "@common/errors/pool";
 import useCustomRouter from "@hooks/common/use-custom-router";
+import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
+import { PoolDetailModel } from "@models/pool/pool-detail-model";
 
-import { QUERY_KEY } from "../query-keys";
 import { useForceRefetchQuery } from "@hooks/common/useForceRefetchQuery";
+import { QUERY_KEY } from "../query-keys";
 
-const REFETCH_INTERVAL = 60_000;
+const REFETCH_INTERVAL = 5_000;
 
 export const useGetPoolDetailByPath = (path: string | null, options?: UseQueryOptions<PoolDetailModel, Error>) => {
   const { poolRepository } = useGnoswapContext();

--- a/packages/web/src/react-query/pools/use-get-pool-list.ts
+++ b/packages/web/src/react-query/pools/use-get-pool-list.ts
@@ -5,7 +5,7 @@ import { PoolModel } from "@models/pool/pool-model";
 
 import { QUERY_KEY } from "../query-keys";
 
-const REFETCH_INTERVAL = 60_000;
+const REFETCH_INTERVAL = 5_000;
 
 export const useGetPoolList = (options?: UseQueryOptions<PoolModel[], Error>) => {
   const { poolRepository } = useGnoswapContext();

--- a/packages/web/src/react-query/positions/use-get-positions-by-address.ts
+++ b/packages/web/src/react-query/positions/use-get-positions-by-address.ts
@@ -7,7 +7,7 @@ import { GetPositionsByAddressResult } from "@repositories/position/response";
 
 import { QUERY_KEY } from "../query-keys";
 
-const REFETCH_INTERVAL = 60_000;
+const REFETCH_INTERVAL = 5_000;
 
 interface UseGetPositionsByAddressProps {
   address?: string;


### PR DESCRIPTION
## Summary
- Added a dedicated Stake Position flow in Earn with an updated page structure and layout.
- Introduced a new **Available Staking Pools** section to improve discovery of stakeable pools.
- Improved staking UX by refining selection/result interactions in stake-related containers and modal flow.
- Updated pool/position data integration to support the new flow (query hooks, mappers, and repository contract updates).
- Applied supporting updates across navigation/footer integration, related container wiring, Storybook usage, and locale resources.

## Why
Staking entry points were fragmented and not intuitive enough for users to quickly find eligible pools and proceed with staking.  
This change improves discoverability and end-to-end usability by unifying the staking path under a clearer page flow backed by aligned data handling.

## Scope
- `earn/pool/stake` page entry and layout updates
- New `AvailableStakingPools` UI + container implementation
- Stake position selection and result interaction improvements
- Pool/position query and model/repository layer adjustments
- Supporting localization and integration changes