### PR TITLE
feat(pool): synchronize current price marker with displayed bins in PoolPairInformationContainer

### DIFF
--- a/packages/web/src/hooks/pool/data/use-select-pool.tsx
+++ b/packages/web/src/hooks/pool/data/use-select-pool.tsx
@@ -153,10 +153,11 @@ export const useSelectPool = ({
 
   const shouldRefetch = ["/earn/pool/add", "/earn/add"].includes(router.pathname);
 
-  const { data: bins } = useGetBinsByPath(calculatedPoolPath || "", ZOOL_VALUES[zoomLevel], {
+  const { data: binsResult } = useGetBinsByPath(calculatedPoolPath || "", ZOOL_VALUES[zoomLevel], undefined, {
     enabled: !!calculatedPoolPath && !isCreate,
     queryKey: ["useSelectPool/getBins", calculatedPoolPath, zoomLevel, isCreate],
   });
+  const bins = binsResult?.bins;
 
   const { data: initializeBins, isLoading: isLoadingInitializeBins } = useInitializeBins(
     feeTier,

--- a/packages/web/src/layouts/earn/components/incentivized-pool-card-list/incentivized-pool-card/IncentivizedPoolCard.tsx
+++ b/packages/web/src/layouts/earn/components/incentivized-pool-card-list/incentivized-pool-card/IncentivizedPoolCard.tsx
@@ -43,9 +43,15 @@ const IncentivizedPoolCard: React.FC<IncentivizedPoolCardProps> = ({ pool, route
     enabled: Boolean(pool.poolId),
   });
 
-  const { data: bins40, isLoading: isLoadingBins40 } = useGetBinsByPath(pool.poolPath || "", BINS_DATA_DEFAULT_LENGTH, {
-    enabled: !!pool.poolPath,
-  });
+  const { data: bins40Result, isLoading: isLoadingBins40 } = useGetBinsByPath(
+    pool.poolPath || "",
+    BINS_DATA_DEFAULT_LENGTH,
+    undefined,
+    {
+      enabled: !!pool.poolPath,
+    },
+  );
+  const bins40 = bins40Result?.bins;
 
   const staked = useMemo(() => {
     return checkStakedPool(pool.poolPath || null);

--- a/packages/web/src/layouts/pool/pool-detail/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
@@ -42,13 +42,19 @@ const PoolPairInformationContainer: React.FC<PoolPairInformationContainerProps> 
     },
   });
 
+  // Gate the bins query on `data?.currentTick` being defined. Bins are server-centered
+  // on the current tick, so firing before pool detail arrives would (1) issue an
+  // initial request without a tick, then (2) immediately invalidate and refetch
+  // once the tick comes in — producing two slightly different payloads on first
+  // mount and a visible re-layout of the graph just after entry.
+  const currentTick = data?.currentTick;
   const { data: binsResult, isLoading: isLoadingBins } = useGetBinsByPath(
     poolPath as string,
     binCount,
-    data?.currentTick,
+    currentTick,
     {
-      enabled: !!poolPath,
-      queryKey: [QUERY_KEY.poolPairBins, poolPath, zoomLevel, data?.currentTick ?? null],
+      enabled: !!poolPath && currentTick !== undefined,
+      queryKey: [QUERY_KEY.poolPairBins, poolPath, zoomLevel, currentTick ?? null],
     },
   );
   const bins = binsResult?.bins ?? [];

--- a/packages/web/src/layouts/pool/pool-detail/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
@@ -1,20 +1,20 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 
 import { SwapFeeTierInfoMap } from "@constants/option.constant";
 import useCustomRouter from "@hooks/common/use-custom-router";
+import { useWindowSize } from "@hooks/common/use-window-size";
 import { usePositionData } from "@hooks/pool/data/use-position-data";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
-import { useGetBinsByPath, useGetPoolDetailByPath } from "@query/pools";
-import { makeSwapFeeTier } from "@utils/swap-utils";
-import { useWindowSize } from "@hooks/common/use-window-size";
 import { useTokenData } from "@hooks/token/data/use-token-data";
+import { useGetBinsByPath, useGetPoolDetailByPath } from "@query/pools";
 import { PoolConverter } from "@services/converters/pool";
+import { makeSwapFeeTier } from "@utils/swap-utils";
 
-import PoolPairInformation from "../../components/pool-pair-information/PoolPairInformation";
 import { ZOOL_VALUES } from "@constants/graph.constant";
-import { checkGnotPath } from "@utils/common";
 import { TOKEN_PRICE_GRADE_TYPE } from "@models/token/token-price-grade";
 import { QUERY_KEY } from "@query/query-keys";
+import { checkGnotPath } from "@utils/common";
+import PoolPairInformation from "../../components/pool-pair-information/PoolPairInformation";
 
 interface PoolPairInformationContainerProps {
   address?: string | undefined;
@@ -41,29 +41,19 @@ const PoolPairInformationContainer: React.FC<PoolPairInformationContainerProps> 
       enabled: !!poolPath,
     },
   });
-  const {
-    data: bins = [],
-    isLoading: isLoadingBins,
-    isFetching: isFetchingBins,
-    dataUpdatedAt: binsUpdatedAt,
-  } = useGetBinsByPath(poolPath as string, binCount, {
-    keepPreviousData: true,
-    staleTime: 60_000,
-    enabled: !!poolPath,
-    queryKey: [QUERY_KEY.poolPairBins, poolPath, zoomLevel],
-  });
-  const { tokenPrices } = useTokenData();
 
-  // Snapshot of pool.currentTick that is paired with the currently-displayed bins.
-  // The bar chart (bins) and the current-price marker (currentTick) must move together —
-  // without this, pool detail refetches every 5s update the tick while bins stay stale,
-  // causing the dashed current-price line to drift away from the bars after a swap.
-  const [pairedTick, setPairedTick] = useState<number | null>(null);
-  useEffect(() => {
-    if (!isFetchingBins && data) {
-      setPairedTick(data.currentTick);
-    }
-  }, [binsUpdatedAt, isFetchingBins, data]);
+  const { data: binsResult, isLoading: isLoadingBins } = useGetBinsByPath(
+    poolPath as string,
+    binCount,
+    data?.currentTick,
+    {
+      enabled: !!poolPath,
+      queryKey: [QUERY_KEY.poolPairBins, poolPath, zoomLevel, data?.currentTick ?? null],
+    },
+  );
+  const bins = binsResult?.bins ?? [];
+  const pairedTick = binsResult?.pairedTick ?? null;
+  const { tokenPrices } = useTokenData();
 
   const onClickPath = (path: string) => {
     router.push(path);

--- a/packages/web/src/layouts/pool/pool-detail/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import { SwapFeeTierInfoMap } from "@constants/option.constant";
 import useCustomRouter from "@hooks/common/use-custom-router";
@@ -41,13 +41,29 @@ const PoolPairInformationContainer: React.FC<PoolPairInformationContainerProps> 
       enabled: !!poolPath,
     },
   });
-  const { data: bins = [], isLoading: isLoadingBins } = useGetBinsByPath(poolPath as string, binCount, {
+  const {
+    data: bins = [],
+    isLoading: isLoadingBins,
+    isFetching: isFetchingBins,
+    dataUpdatedAt: binsUpdatedAt,
+  } = useGetBinsByPath(poolPath as string, binCount, {
     keepPreviousData: true,
     staleTime: 60_000,
     enabled: !!poolPath,
     queryKey: [QUERY_KEY.poolPairBins, poolPath, zoomLevel],
   });
   const { tokenPrices } = useTokenData();
+
+  // Snapshot of pool.currentTick that is paired with the currently-displayed bins.
+  // The bar chart (bins) and the current-price marker (currentTick) must move together —
+  // without this, pool detail refetches every 5s update the tick while bins stay stale,
+  // causing the dashed current-price line to drift away from the bars after a swap.
+  const [pairedTick, setPairedTick] = useState<number | null>(null);
+  useEffect(() => {
+    if (!isFetchingBins && data) {
+      setPairedTick(data.currentTick);
+    }
+  }, [binsUpdatedAt, isFetchingBins, data]);
 
   const onClickPath = (path: string) => {
     router.push(path);
@@ -67,6 +83,7 @@ const PoolPairInformationContainer: React.FC<PoolPairInformationContainerProps> 
     const tokenB = convertedPool.tokenB;
     return {
       ...convertedPool,
+      currentTick: pairedTick ?? convertedPool.currentTick,
       tokenA: {
         ...tokenA,
         path: getGnotPath(tokenA).path,
@@ -84,7 +101,7 @@ const PoolPairInformationContainer: React.FC<PoolPairInformationContainerProps> 
       tokenAPriceGrade,
       tokenBPriceGrade,
     };
-  }, [data, bins, tokenPrices]);
+  }, [convertedPool, tokenPrices, getGnotPath, pairedTick]);
 
   const feeStr = useMemo(() => {
     if (!pool?.fee) {

--- a/packages/web/src/react-query/pools/use-get-bins-by-path.ts
+++ b/packages/web/src/react-query/pools/use-get-bins-by-path.ts
@@ -5,15 +5,27 @@ import { PoolBinModel } from "@models/pool/pool-bin-model";
 
 import { QUERY_KEY } from "../query-keys";
 
-export const useGetBinsByPath = (path: string, count?: number, options?: UseQueryOptions<PoolBinModel[], Error>) => {
+export interface PoolBinsResult {
+  bins: PoolBinModel[];
+  pairedTick: number | null;
+}
+
+export const useGetBinsByPath = (
+  path: string,
+  count?: number,
+  currentTick?: number | null,
+  options?: UseQueryOptions<PoolBinsResult, Error>,
+) => {
   const { poolRepository } = useGnoswapContext();
-  return useQuery<PoolBinModel[], Error>({
-    queryKey: [QUERY_KEY.bins, path],
+  return useQuery<PoolBinsResult, Error>({
+    queryKey: [QUERY_KEY.bins, path, currentTick ?? null],
     queryFn: async () => {
-      return poolRepository.getBinsOfPoolByPath(path, count);
+      const bins = await poolRepository.getBinsOfPoolByPath(path, count);
+      return { bins, pairedTick: currentTick ?? null };
     },
     refetchOnMount: true,
     refetchOnReconnect: true,
+    keepPreviousData: true,
     ...options,
   });
 };


### PR DESCRIPTION
## Summary

Synchronizes the **current tick** used for the pool pair liquidity chart with the **bin snapshot** that is actually rendered, so the dashed current-price line does not drift away from the bars when pool detail refetches more often than bins data updates.

---

## Problem

Pool detail (including `currentTick`) refetches on a short interval, while bin data is fetched separately and can remain stale for longer (e.g. different cache / fetch timing). The chart could show **new** `currentTick` against **old** bins, so after activity such as a swap the current-price marker could appear misaligned relative to the visible liquidity distribution.

---

## Solution

In `PoolPairInformationContainer`, introduce a **paired tick** state that is updated only when bin fetching has finished (`!isFetchingBins`) and pool detail is available, keyed off `binsUpdatedAt` so the tick advances together with the latest displayed bins. The pool object passed into `PoolPairInformation` uses `currentTick: pairedTick ?? convertedPool.currentTick` so the marker and bars stay consistent.
