### PR TITLE
fix: enable token approve reset

### DIFF
--- a/packages/web/src/common/clients/wallet-client/transaction-messages/common.spec.ts
+++ b/packages/web/src/common/clients/wallet-client/transaction-messages/common.spec.ts
@@ -1,0 +1,149 @@
+import {
+  makeTransactionMessage,
+  makeTransactionMessagesWithApproves,
+  TokenApproveMessageInfo,
+  TransactionMessage,
+} from "./common";
+
+describe("makeTransactionMessagesWithApproves", () => {
+  const caller = "caller";
+  const targetAddress = "target";
+  const tokenPath = "token_path";
+
+  const transactionMessage: TransactionMessage = makeTransactionMessage({
+    caller,
+    send: "",
+    packagePath: "contract_path",
+    func: "Execute",
+    args: ["argument"],
+  });
+
+  const approveInfos: TokenApproveMessageInfo[] = [
+    {
+      tokenPath,
+      targetAddress,
+      amount: "100",
+      caller,
+    },
+  ];
+
+  it("adds approve reset messages after transactions by default", async () => {
+    const fetchAllowance = jest.fn(async () => 0);
+
+    const messages = await makeTransactionMessagesWithApproves([transactionMessage], approveInfos, fetchAllowance);
+
+    expect(messages).toEqual([
+      {
+        caller,
+        send: "",
+        pkg_path: tokenPath,
+        func: "Approve",
+        args: [targetAddress, "100"],
+        gasFee: undefined,
+      },
+      transactionMessage,
+      {
+        caller,
+        send: "",
+        pkg_path: tokenPath,
+        func: "Approve",
+        args: [targetAddress, "0"],
+        gasFee: undefined,
+      },
+    ]);
+  });
+
+  it("resets existing allowances even when a new approve message is skipped", async () => {
+    const fetchAllowance = jest.fn(async () => 2);
+
+    const messages = await makeTransactionMessagesWithApproves([transactionMessage], approveInfos, fetchAllowance, 1);
+
+    expect(messages).toEqual([
+      transactionMessage,
+      {
+        caller,
+        send: "",
+        pkg_path: tokenPath,
+        func: "Approve",
+        args: [targetAddress, "0"],
+        gasFee: undefined,
+      },
+    ]);
+  });
+
+  it("resets all required allowances when only some need a new approve message", async () => {
+    const skippedTargetAddress = "skipped_target";
+    const approveInfosWithMixedAllowances: TokenApproveMessageInfo[] = [
+      ...approveInfos,
+      {
+        tokenPath,
+        targetAddress: skippedTargetAddress,
+        amount: "200",
+        caller,
+      },
+    ];
+    const fetchAllowance = jest.fn(async (...args: [string, string, string]) => {
+      const spender = args[2];
+      return spender === skippedTargetAddress ? 2 : 0;
+    });
+
+    const messages = await makeTransactionMessagesWithApproves(
+      [transactionMessage],
+      approveInfosWithMixedAllowances,
+      fetchAllowance,
+      1,
+    );
+
+    expect(messages).toEqual([
+      {
+        caller,
+        send: "",
+        pkg_path: tokenPath,
+        func: "Approve",
+        args: [targetAddress, "100"],
+        gasFee: undefined,
+      },
+      transactionMessage,
+      {
+        caller,
+        send: "",
+        pkg_path: tokenPath,
+        func: "Approve",
+        args: [targetAddress, "0"],
+        gasFee: undefined,
+      },
+      {
+        caller,
+        send: "",
+        pkg_path: tokenPath,
+        func: "Approve",
+        args: [skippedTargetAddress, "0"],
+        gasFee: undefined,
+      },
+    ]);
+  });
+
+  it("keeps reset messages disabled when explicitly requested", async () => {
+    const fetchAllowance = jest.fn(async () => 0);
+
+    const messages = await makeTransactionMessagesWithApproves(
+      [transactionMessage],
+      approveInfos,
+      fetchAllowance,
+      1,
+      false,
+    );
+
+    expect(messages).toEqual([
+      {
+        caller,
+        send: "",
+        pkg_path: tokenPath,
+        func: "Approve",
+        args: [targetAddress, "100"],
+        gasFee: undefined,
+      },
+      transactionMessage,
+    ]);
+  });
+});

--- a/packages/web/src/common/clients/wallet-client/transaction-messages/common.ts
+++ b/packages/web/src/common/clients/wallet-client/transaction-messages/common.ts
@@ -123,7 +123,7 @@ export async function makeTransactionMessagesWithApproves(
   approveInfos: TokenApproveMessageInfo[],
   fetchAllowance: (packagePath: string, owner: string, spender: string) => Promise<number>,
   allowanceLimit: number = DEFAULT_ALLOWANCE_LIMIT,
-  withReset: boolean = false,
+  withReset: boolean = true,
 ): Promise<TransactionMessage[]> {
   if (!Array.isArray(transactionMessages)) {
     throw new TransactionMessageError("FAILED_PARSE_APPROVE_MESSAGE", transactionMessages);

--- a/packages/web/src/repositories/position/position.message.spec.ts
+++ b/packages/web/src/repositories/position/position.message.spec.ts
@@ -4,6 +4,7 @@ import type { PoolPositionModel } from "@models/position/pool-position-model";
 import type { PositionModel } from "@models/position/position-model";
 import type { RewardModel } from "@models/position/reward-model";
 import type { TokenModel } from "@models/token/token-model";
+import type { TransactionMessage } from "@common/clients/wallet-client/transaction-messages/common";
 import { MAX_INT64_STR } from "@utils/math.utils";
 import BigNumber from "bignumber.js";
 
@@ -108,10 +109,39 @@ const createPosition = (lpTokenId: string, rewards: RewardModel[]): PositionMode
 
 const createPoolPosition = (lpTokenId: string, rewards: RewardModel[]): PoolPositionModel => {
   return {
-    ...((createPosition(lpTokenId, rewards) as unknown) as PositionModel),
+    ...(createPosition(lpTokenId, rewards) as unknown as PositionModel),
     feeTier: "NONE",
-    pool: ({} as unknown) as PoolPositionModel["pool"],
+    pool: {} as unknown as PoolPositionModel["pool"],
   };
+};
+
+const splitMessagesByApproveReset = (
+  messages: TransactionMessage[],
+  approveCount: number,
+  resetCount: number = approveCount,
+) => {
+  return {
+    approveMessages: messages.slice(0, approveCount),
+    txMessages: messages.slice(approveCount, messages.length - resetCount),
+    resetMessages: resetCount > 0 ? messages.slice(messages.length - resetCount) : [],
+  };
+};
+
+const toResetApproveMessage = (message: TransactionMessage): TransactionMessage => {
+  const targetAddress = message.args?.[0];
+
+  if (message.func !== "Approve" || !targetAddress) {
+    throw new Error("Approve message must include a target address");
+  }
+
+  return {
+    ...message,
+    args: [targetAddress, "0"],
+  };
+};
+
+const expectResetMessages = (resetMessages: TransactionMessage[], approveMessages: TransactionMessage[]) => {
+  expect(resetMessages).toEqual(approveMessages.map(toResetApproveMessage));
 };
 
 describe("position.message.ts", () => {
@@ -186,8 +216,7 @@ describe("position.message.ts", () => {
       const fetchAllowance = jest.fn(async () => 0);
       const messages = await makeClaimMessageWithApproves({ position, caller }, fetchAllowance);
 
-      const approveMessages = messages.filter(m => m.func === "Approve");
-      const txMessages = messages.slice(approveMessages.length);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 3);
 
       expect(approveMessages).toEqual(
         expect.arrayContaining([
@@ -236,6 +265,7 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
+      expectResetMessages(resetMessages, approveMessages);
     });
 
     it("filters out approve messages when allowance is above the limit", async () => {
@@ -246,14 +276,33 @@ describe("position.message.ts", () => {
 
       const fetchAllowance = jest.fn(async () => DEFAULT_ALLOWANCE_LIMIT * 2);
       const messages = await makeClaimMessageWithApproves({ position, caller }, fetchAllowance);
+      const { txMessages, resetMessages } = splitMessagesByApproveReset(messages, 0, 2);
 
-      expect(messages).toEqual([
+      expect(txMessages).toEqual([
         {
           caller,
           send: "",
           pkg_path: "position_path",
           func: "CollectFee",
           args: ["lp1"],
+          gasFee: undefined,
+        },
+      ]);
+      expect(resetMessages).toEqual([
+        {
+          caller,
+          send: "",
+          pkg_path: "fee_token",
+          func: "Approve",
+          args: ["pool_address", "0"],
+          gasFee: undefined,
+        },
+        {
+          caller,
+          send: "",
+          pkg_path: "fee_token",
+          func: "Approve",
+          args: ["position_address", "0"],
           gasFee: undefined,
         },
       ]);
@@ -273,8 +322,7 @@ describe("position.message.ts", () => {
       const fetchAllowance = jest.fn(async () => 0);
       const messages = await makeClaimAllMessageWithApproves({ positions, caller }, fetchAllowance);
 
-      const approveMessages = messages.filter(m => m.func === "Approve");
-      const txMessages = messages.slice(approveMessages.length);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 1);
 
       expect(approveMessages).toEqual(
         expect.arrayContaining([
@@ -300,6 +348,7 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
+      expectResetMessages(resetMessages, approveMessages);
     });
 
     it("merges duplicate approveInfos across multiple positions (fee)", async () => {
@@ -317,8 +366,7 @@ describe("position.message.ts", () => {
       const fetchAllowance = jest.fn(async () => 0);
       const messages = await makeClaimAllMessageWithApproves({ positions, caller }, fetchAllowance);
 
-      const approveMessages = messages.filter(m => m.func === "Approve");
-      const txMessages = messages.slice(approveMessages.length);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 2);
 
       // Expect exactly 2 approve messages for fee_token: pool + position_address.
       expect(approveMessages).toEqual(
@@ -361,6 +409,7 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
+      expectResetMessages(resetMessages, approveMessages);
     });
   });
 
@@ -380,8 +429,7 @@ describe("position.message.ts", () => {
       const fetchAllowance = jest.fn(async () => 0);
       const messages = await makeUnStakePositionsMessagesWithApproves({ positions, caller }, fetchAllowance);
 
-      const approveMessages = messages.filter(m => m.func === "Approve");
-      const txMessages = messages.slice(approveMessages.length);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 2);
 
       expect(approveMessages).toEqual(
         expect.arrayContaining([
@@ -423,6 +471,7 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
+      expectResetMessages(resetMessages, approveMessages);
     });
   });
 
@@ -450,8 +499,7 @@ describe("position.message.ts", () => {
         fetchAllowance,
       );
 
-      const approveMessages = messages.filter(m => m.func === "Approve");
-      const txMessages = messages.slice(approveMessages.length);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 2);
 
       expect(approveMessages).toHaveLength(2);
       expect(approveMessages).toEqual(
@@ -493,6 +541,7 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
+      expectResetMessages(resetMessages, approveMessages);
     });
   });
 
@@ -521,8 +570,7 @@ describe("position.message.ts", () => {
         fetchAllowance,
       );
 
-      const approveMessages = messages.filter(m => m.func === "Approve");
-      const txMessages = messages.slice(approveMessages.length);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 2);
 
       // Base pool approves (wugnot + tokenB) + extra gnot approve should merge into a single wugnot->pool approve.
       expect(approveMessages).toHaveLength(2);
@@ -557,6 +605,7 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
+      expectResetMessages(resetMessages, approveMessages);
     });
   });
 
@@ -586,8 +635,7 @@ describe("position.message.ts", () => {
         fetchAllowance,
       );
 
-      const approveMessages = messages.filter(m => m.func === "Approve");
-      const txMessages = messages.slice(approveMessages.length);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 2);
 
       expect(approveMessages).toHaveLength(2);
       expect(approveMessages).toEqual(
@@ -629,6 +677,7 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
+      expectResetMessages(resetMessages, approveMessages);
     });
   });
 
@@ -657,8 +706,7 @@ describe("position.message.ts", () => {
         fetchAllowance,
       );
 
-      const approveMessages = messages.filter(m => m.func === "Approve");
-      const txMessages = messages.slice(approveMessages.length);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 3);
 
       // wugnot->pool, tokenB->pool, wugnot->position_address
       expect(approveMessages).toHaveLength(3);
@@ -709,6 +757,7 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
+      expectResetMessages(resetMessages, approveMessages);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Enable approve reset by default for token approval transaction messages.
- Add coverage for default resets, skipped-approve resets, mixed allowance reset behavior, explicit reset opt-out, and position message ordering.

## Test Plan
- yarn workspace @gnoswap-labs/web jest --runInBand src/common/clients/wallet-client/transaction-messages/common.spec.ts src/repositories/position/position.message.spec.ts
- yarn prettier --check packages/web/src/common/clients/wallet-client/transaction-messages/common.ts packages/web/src/common/clients/wallet-client/transaction-messages/common.spec.ts packages/web/src/repositories/position/position.message.spec.ts
- yarn workspace @gnoswap-labs/web lint
- yarn workspace @gnoswap-labs/web build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approval reset is now enabled by default, automatically appending post-transaction allowance resets for improved security.

* **Tests**
  * Added tests covering approval-message sequencing, conditional approval emission, and optional reset behavior.
  * Updated existing transaction tests to assert the new trailing reset-approve messages and partitioning logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/875)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->