### PR TITLE
fix(wallet): handle locked Adena login

### DIFF
--- a/packages/web/src/containers/connect-wallet-container/ConnectWalletContainer.tsx
+++ b/packages/web/src/containers/connect-wallet-container/ConnectWalletContainer.tsx
@@ -2,13 +2,12 @@ import ConnectWalletModal from "@components/common/connect-wallet-modal/ConnectW
 import { useClearModal } from "@hooks/common/use-clear-modal";
 import { useConnectWalletStatusModal } from "@hooks/wallet/ui/use-connect-status-wallet-modal";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
-import React, { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import useRouter from "@hooks/common/use-custom-router";
 
 const ConnectWalletContainer = () => {
   const clearModal = useClearModal();
   const { connectAdenaClient, loadingConnect, connectAccount, walletClient } = useWallet();
-  const [connectWallet, setConnectWallet] = useState(false);
   const router = useRouter();
 
   const { openModal } = useConnectWalletStatusModal();
@@ -31,19 +30,12 @@ const ConnectWalletContainer = () => {
   const connect = useCallback(() => {
     if (walletClient) {
       connectAdenaClient();
-      connectAccount();
+      connectAccount(walletClient);
     } else {
-      connectAdenaClient();
-      setConnectWallet(true);
+      const adena = connectAdenaClient();
+      connectAccount(adena);
     }
-  }, [connectAdenaClient, close]);
-
-  useEffect(() => {
-    if (connectWallet && walletClient) {
-      connectAccount();
-      setConnectWallet(false);
-    }
-  }, [connectWallet, String(walletClient)]);
+  }, [connectAdenaClient, connectAccount, walletClient]);
 
   return <ConnectWalletModal close={close} connect={connect} loadingConnect={loadingConnect} />;
 };

--- a/packages/web/src/containers/connect-wallet-container/ConnectWalletContainer.tsx
+++ b/packages/web/src/containers/connect-wallet-container/ConnectWalletContainer.tsx
@@ -29,11 +29,12 @@ const ConnectWalletContainer = () => {
 
   const connect = useCallback(() => {
     if (walletClient) {
-      connectAdenaClient();
       connectAccount(walletClient);
     } else {
       const adena = connectAdenaClient();
-      connectAccount(adena);
+      if (adena !== null) {
+        connectAccount(adena);
+      }
     }
   }, [connectAdenaClient, connectAccount, walletClient]);
 

--- a/packages/web/src/hooks/wallet/data/use-wallet.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.ts
@@ -1,11 +1,11 @@
 import { WalletClient } from "@common/clients/wallet-client";
 import { AdenaClient } from "@common/clients/wallet-client/adena";
-import { AdenaError, ERROR_VALUE } from "@common/errors/adena";
 import { NetworkData } from "@constants/chains.constant";
 import { DEFAULT_CHAIN_ID, SUPPORT_CHAIN_IDS } from "@constants/environment.constant";
 import { AUTH_STORE_KEY } from "@hooks/common/use-auto-disconnect";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 import { useSocialWalletContext } from "@hooks/common/use-social-wallet-context";
+import { AccountMapper } from "@models/account/mapper/account-mapper";
 import { useGetTokenBalancesFromChain } from "@query/address";
 import {
   ACCOUNT_SESSION_INFO_KEY,
@@ -21,17 +21,10 @@ import { useAtom } from "jotai";
 import { useCallback, useEffect, useMemo } from "react";
 import { AdenaSdkConnectionState, SocialLoginType, WalletType } from "src/types/wallet.types";
 import * as uuid from "uuid";
+import { isConnectedAccountResponse, isWalletLockedError, isWalletLockedResponse } from "./use-wallet.util";
 
 const balanceQueryKey = ["token-balance", "ugnot"];
 const defaultGnoswapMemo = "Executed through gnoswap.io";
-
-const isWalletLockedResponse = (response: { code: number; type: string } | null) => {
-  return response?.code === ERROR_VALUE.WALLET_LOCKED.status && response.type === ERROR_VALUE.WALLET_LOCKED.type;
-};
-
-const isWalletLockedError = (error: unknown) => {
-  return error instanceof AdenaError && error.getType() === ERROR_VALUE.WALLET_LOCKED.type;
-};
 
 export const useWallet = () => {
   const { accountRepository } = useGnoswapContext();
@@ -209,6 +202,27 @@ export const useWallet = () => {
       if (walletClient === null) {
         const adena = AdenaClient.createAdenaClient(defaultGnoswapMemo);
         setWalletClient(adena);
+        return;
+      }
+
+      const accountResponse = await walletClient.getAccount().catch(() => null);
+
+      if (isWalletLockedResponse(accountResponse)) {
+        setLoadingConnect("initial");
+        return;
+      }
+
+      if (isConnectedAccountResponse(accountResponse)) {
+        const account = AccountMapper.fromResponse(accountResponse);
+        sessionStorage.setItem(ACCOUNT_SESSION_INFO_KEY, JSON.stringify(account));
+        sessionStorage.setItem(GNOSWAP_WALLET_TYPE_KEY, "ADENA");
+        const availNetwork = SUPPORT_CHAIN_IDS.includes(account.chainId);
+        if (!availNetwork) {
+          switchNetwork();
+        }
+        setWalletAccount(account);
+        accountRepository.setConnectedWallet(true);
+        setLoadingConnect("done");
         return;
       }
 

--- a/packages/web/src/hooks/wallet/data/use-wallet.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.ts
@@ -25,6 +25,7 @@ import { isConnectedAccountResponse, isWalletLockedError, isWalletLockedResponse
 
 const balanceQueryKey = ["token-balance", "ugnot"];
 const defaultGnoswapMemo = "Executed through gnoswap.io";
+let connectingAdenaAccount = false;
 
 export const useWallet = () => {
   const { accountRepository } = useGnoswapContext();
@@ -197,6 +198,12 @@ export const useWallet = () => {
   }, [sessionId, loadingConnect]);
 
   const connectAccount = async (targetWalletClient?: WalletClient | null) => {
+    if (connectingAdenaAccount) {
+      return;
+    }
+
+    connectingAdenaAccount = true;
+
     try {
       setLoadingConnect("loading");
 
@@ -270,6 +277,8 @@ export const useWallet = () => {
 
       setLoadingConnect("error");
       console.error(error);
+    } finally {
+      connectingAdenaAccount = false;
     }
   };
 

--- a/packages/web/src/hooks/wallet/data/use-wallet.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.ts
@@ -5,6 +5,7 @@ import { DEFAULT_CHAIN_ID, SUPPORT_CHAIN_IDS } from "@constants/environment.cons
 import { AUTH_STORE_KEY } from "@hooks/common/use-auto-disconnect";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 import { useSocialWalletContext } from "@hooks/common/use-social-wallet-context";
+import { AccountMapper } from "@models/account/mapper/account-mapper";
 import { useGetTokenBalancesFromChain } from "@query/address";
 import {
   ACCOUNT_SESSION_INFO_KEY,
@@ -150,10 +151,10 @@ export const useWallet = () => {
     }
   }
 
-  const switchNetwork = async () => {
+  const switchNetwork = async (targetWalletClient?: WalletClient | null) => {
     try {
       setLoadingConnect("loading");
-      const adena = AdenaClient.createAdenaClient(defaultGnoswapMemo);
+      const adena = targetWalletClient ?? AdenaClient.createAdenaClient(defaultGnoswapMemo);
       if (!adena) {
         setLoadingConnect("error");
         return;
@@ -162,7 +163,8 @@ export const useWallet = () => {
       const res = await adena?.switchNetwork(DEFAULT_CHAIN_ID);
 
       if (res.code === 0) {
-        const account = await accountRepository.getAccount();
+        const accountResponse = await adena.getAccount();
+        const account = AccountMapper.fromResponse(accountResponse);
         setWalletAccount(account);
         accountRepository.setConnectedWallet(true);
       }
@@ -230,12 +232,13 @@ export const useWallet = () => {
       }
 
       if (established.code === 0 || established.code === 4001) {
-        const account = await accountRepository.getAccount();
+        const accountResponse = await currentWalletClient.getAccount();
+        const account = AccountMapper.fromResponse(accountResponse);
         sessionStorage.setItem(ACCOUNT_SESSION_INFO_KEY, JSON.stringify(account));
         sessionStorage.setItem(GNOSWAP_WALLET_TYPE_KEY, "ADENA");
         const availNetwork = SUPPORT_CHAIN_IDS.includes(account.chainId);
         if (!availNetwork) {
-          switchNetwork();
+          await switchNetwork(currentWalletClient);
         }
         setWalletAccount(account);
         accountRepository.setConnectedWallet(true);

--- a/packages/web/src/hooks/wallet/data/use-wallet.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.ts
@@ -193,19 +193,27 @@ export const useWallet = () => {
       window.open("https://adena.app/", "", "noopener,noreferrer");
     }
     setWalletClient(adena);
+    return adena;
   }, [sessionId, loadingConnect]);
 
-  const connectAccount = async () => {
+  const connectAccount = async (targetWalletClient?: WalletClient | null) => {
     try {
       setLoadingConnect("loading");
 
-      if (walletClient === null) {
+      const currentWalletClient = targetWalletClient ?? walletClient;
+
+      if (currentWalletClient === null) {
         const adena = AdenaClient.createAdenaClient(defaultGnoswapMemo);
         setWalletClient(adena);
         return;
       }
 
-      const accountResponse = await walletClient.getAccount().catch(() => null);
+      const accountResponse = await currentWalletClient.getAccount().catch(() => null);
+
+      if (accountResponse === null) {
+        setLoadingConnect("initial");
+        return;
+      }
 
       if (isWalletLockedResponse(accountResponse)) {
         setLoadingConnect("initial");
@@ -226,7 +234,7 @@ export const useWallet = () => {
         return;
       }
 
-      const established = await accountRepository.addEstablishedSite().catch(() => null);
+      const established = await currentWalletClient.addEstablishedSite("Gnoswap").catch(() => null);
 
       if (established === null) {
         return;

--- a/packages/web/src/hooks/wallet/data/use-wallet.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.ts
@@ -1,5 +1,6 @@
 import { WalletClient } from "@common/clients/wallet-client";
 import { AdenaClient } from "@common/clients/wallet-client/adena";
+import { AdenaError, ERROR_VALUE } from "@common/errors/adena";
 import { NetworkData } from "@constants/chains.constant";
 import { DEFAULT_CHAIN_ID, SUPPORT_CHAIN_IDS } from "@constants/environment.constant";
 import { AUTH_STORE_KEY } from "@hooks/common/use-auto-disconnect";
@@ -23,6 +24,14 @@ import * as uuid from "uuid";
 
 const balanceQueryKey = ["token-balance", "ugnot"];
 const defaultGnoswapMemo = "Executed through gnoswap.io";
+
+const isWalletLockedResponse = (response: { code: number; type: string } | null) => {
+  return response?.code === ERROR_VALUE.WALLET_LOCKED.status && response.type === ERROR_VALUE.WALLET_LOCKED.type;
+};
+
+const isWalletLockedError = (error: unknown) => {
+  return error instanceof AdenaError && error.getType() === ERROR_VALUE.WALLET_LOCKED.type;
+};
 
 export const useWallet = () => {
   const { accountRepository } = useGnoswapContext();
@@ -208,6 +217,10 @@ export const useWallet = () => {
       if (established === null) {
         return;
       }
+      if (isWalletLockedResponse(established)) {
+        setLoadingConnect("initial");
+        return;
+      }
       if (established.code === 4000) {
         return;
       }
@@ -228,6 +241,12 @@ export const useWallet = () => {
         setLoadingConnect("error");
       }
     } catch (error) {
+      if (isWalletLockedError(error)) {
+        setLoadingConnect("initial");
+        return;
+      }
+
+      setLoadingConnect("error");
       console.error(error);
     }
   };

--- a/packages/web/src/hooks/wallet/data/use-wallet.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.ts
@@ -5,6 +5,7 @@ import { DEFAULT_CHAIN_ID, SUPPORT_CHAIN_IDS } from "@constants/environment.cons
 import { AUTH_STORE_KEY } from "@hooks/common/use-auto-disconnect";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 import { useSocialWalletContext } from "@hooks/common/use-social-wallet-context";
+import { AdenaError } from "@common/errors/adena";
 import { AccountMapper } from "@models/account/mapper/account-mapper";
 import { useGetTokenBalancesFromChain } from "@query/address";
 import {
@@ -164,7 +165,10 @@ export const useWallet = () => {
 
       if (res.code === 0) {
         const accountResponse = await adena.getAccount();
+        AdenaError.validate(accountResponse);
         const account = AccountMapper.fromResponse(accountResponse);
+        sessionStorage.setItem(ACCOUNT_SESSION_INFO_KEY, JSON.stringify(account));
+        sessionStorage.setItem(GNOSWAP_WALLET_TYPE_KEY, "ADENA");
         setWalletAccount(account);
         accountRepository.setConnectedWallet(true);
       }
@@ -213,15 +217,12 @@ export const useWallet = () => {
       if (currentWalletClient === null) {
         const adena = AdenaClient.createAdenaClient(defaultGnoswapMemo);
         setWalletClient(adena);
-        return;
-      }
-
-      const established = await currentWalletClient.addEstablishedSite("Gnoswap").catch(() => null);
-
-      if (established === null) {
         setLoadingConnect("initial");
         return;
       }
+
+      const established = await currentWalletClient.addEstablishedSite("Gnoswap");
+
       if (isWalletLockedResponse(established)) {
         setLoadingConnect("initial");
         return;
@@ -233,13 +234,15 @@ export const useWallet = () => {
 
       if (established.code === 0 || established.code === 4001) {
         const accountResponse = await currentWalletClient.getAccount();
+        AdenaError.validate(accountResponse);
         const account = AccountMapper.fromResponse(accountResponse);
-        sessionStorage.setItem(ACCOUNT_SESSION_INFO_KEY, JSON.stringify(account));
-        sessionStorage.setItem(GNOSWAP_WALLET_TYPE_KEY, "ADENA");
         const availNetwork = SUPPORT_CHAIN_IDS.includes(account.chainId);
         if (!availNetwork) {
           await switchNetwork(currentWalletClient);
+          return;
         }
+        sessionStorage.setItem(ACCOUNT_SESSION_INFO_KEY, JSON.stringify(account));
+        sessionStorage.setItem(GNOSWAP_WALLET_TYPE_KEY, "ADENA");
         setWalletAccount(account);
         accountRepository.setConnectedWallet(true);
         setLoadingConnect("done");

--- a/packages/web/src/hooks/wallet/data/use-wallet.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.ts
@@ -5,7 +5,6 @@ import { DEFAULT_CHAIN_ID, SUPPORT_CHAIN_IDS } from "@constants/environment.cons
 import { AUTH_STORE_KEY } from "@hooks/common/use-auto-disconnect";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 import { useSocialWalletContext } from "@hooks/common/use-social-wallet-context";
-import { AccountMapper } from "@models/account/mapper/account-mapper";
 import { useGetTokenBalancesFromChain } from "@query/address";
 import {
   ACCOUNT_SESSION_INFO_KEY,
@@ -21,7 +20,7 @@ import { useAtom } from "jotai";
 import { useCallback, useEffect, useMemo } from "react";
 import { AdenaSdkConnectionState, SocialLoginType, WalletType } from "src/types/wallet.types";
 import * as uuid from "uuid";
-import { isConnectedAccountResponse, isWalletLockedError, isWalletLockedResponse } from "./use-wallet.util";
+import { isWalletLockedError, isWalletLockedResponse } from "./use-wallet.util";
 
 const balanceQueryKey = ["token-balance", "ugnot"];
 const defaultGnoswapMemo = "Executed through gnoswap.io";
@@ -215,35 +214,10 @@ export const useWallet = () => {
         return;
       }
 
-      const accountResponse = await currentWalletClient.getAccount().catch(() => null);
-
-      if (accountResponse === null) {
-        setLoadingConnect("initial");
-        return;
-      }
-
-      if (isWalletLockedResponse(accountResponse)) {
-        setLoadingConnect("initial");
-        return;
-      }
-
-      if (isConnectedAccountResponse(accountResponse)) {
-        const account = AccountMapper.fromResponse(accountResponse);
-        sessionStorage.setItem(ACCOUNT_SESSION_INFO_KEY, JSON.stringify(account));
-        sessionStorage.setItem(GNOSWAP_WALLET_TYPE_KEY, "ADENA");
-        const availNetwork = SUPPORT_CHAIN_IDS.includes(account.chainId);
-        if (!availNetwork) {
-          switchNetwork();
-        }
-        setWalletAccount(account);
-        accountRepository.setConnectedWallet(true);
-        setLoadingConnect("done");
-        return;
-      }
-
       const established = await currentWalletClient.addEstablishedSite("Gnoswap").catch(() => null);
 
       if (established === null) {
+        setLoadingConnect("initial");
         return;
       }
       if (isWalletLockedResponse(established)) {
@@ -251,6 +225,7 @@ export const useWallet = () => {
         return;
       }
       if (established.code === 4000) {
+        setLoadingConnect("initial");
         return;
       }
 

--- a/packages/web/src/hooks/wallet/data/use-wallet.util.spec.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.util.spec.ts
@@ -1,0 +1,45 @@
+import { WalletResponse } from "@common/clients/wallet-client/protocols";
+import { AdenaError, ERROR_VALUE } from "@common/errors/adena";
+import { isConnectedAccountResponse, isWalletLockedError, isWalletLockedResponse } from "./use-wallet.util";
+
+describe("wallet login response helpers", () => {
+  it("detects locked Adena responses before establish requests", () => {
+    const response: WalletResponse<null> = {
+      code: ERROR_VALUE.WALLET_LOCKED.status,
+      status: "failure",
+      type: ERROR_VALUE.WALLET_LOCKED.type,
+      message: "Adena is locked.",
+      data: null,
+    };
+
+    expect(isWalletLockedResponse(response)).toBe(true);
+  });
+
+  it("does not treat other wallet failures as locked responses", () => {
+    const response: WalletResponse<null> = {
+      code: ERROR_VALUE.NOT_CONNECTED.status,
+      status: "failure",
+      type: ERROR_VALUE.NOT_CONNECTED.type,
+      message: "A connection has not been established.",
+      data: null,
+    };
+
+    expect(isWalletLockedResponse(response)).toBe(false);
+  });
+
+  it("detects locked Adena errors from validated account responses", () => {
+    expect(isWalletLockedError(new AdenaError("WALLET_LOCKED"))).toBe(true);
+  });
+
+  it("recognizes successful account preflight responses", () => {
+    const response: WalletResponse = {
+      code: 0,
+      status: "success",
+      type: "GET_ACCOUNT",
+      message: "Get account.",
+      data: {},
+    };
+
+    expect(isConnectedAccountResponse(response)).toBe(true);
+  });
+});

--- a/packages/web/src/hooks/wallet/data/use-wallet.util.spec.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.util.spec.ts
@@ -1,6 +1,6 @@
 import { WalletResponse } from "@common/clients/wallet-client/protocols";
 import { AdenaError, ERROR_VALUE } from "@common/errors/adena";
-import { isConnectedAccountResponse, isWalletLockedError, isWalletLockedResponse } from "./use-wallet.util";
+import { isWalletLockedError, isWalletLockedResponse } from "./use-wallet.util";
 
 describe("wallet login response helpers", () => {
   it("detects locked Adena responses before establish requests", () => {
@@ -29,17 +29,5 @@ describe("wallet login response helpers", () => {
 
   it("detects locked Adena errors from validated account responses", () => {
     expect(isWalletLockedError(new AdenaError("WALLET_LOCKED"))).toBe(true);
-  });
-
-  it("recognizes successful account preflight responses", () => {
-    const response: WalletResponse = {
-      code: 0,
-      status: "success",
-      type: "GET_ACCOUNT",
-      message: "Get account.",
-      data: {},
-    };
-
-    expect(isConnectedAccountResponse(response)).toBe(true);
   });
 });

--- a/packages/web/src/hooks/wallet/data/use-wallet.util.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.util.ts
@@ -8,7 +8,3 @@ export const isWalletLockedResponse = (response: Pick<WalletResponse, "code" | "
 export const isWalletLockedError = (error: unknown) => {
   return error instanceof AdenaError && error.getType() === ERROR_VALUE.WALLET_LOCKED.type;
 };
-
-export const isConnectedAccountResponse = <T>(response: WalletResponse<T> | null): response is WalletResponse<T> => {
-  return response?.code === 0 && response.type === "GET_ACCOUNT";
-};

--- a/packages/web/src/hooks/wallet/data/use-wallet.util.ts
+++ b/packages/web/src/hooks/wallet/data/use-wallet.util.ts
@@ -1,0 +1,14 @@
+import { WalletResponse } from "@common/clients/wallet-client/protocols";
+import { AdenaError, ERROR_VALUE } from "@common/errors/adena";
+
+export const isWalletLockedResponse = (response: Pick<WalletResponse, "code" | "type"> | null) => {
+  return response?.code === ERROR_VALUE.WALLET_LOCKED.status && response.type === ERROR_VALUE.WALLET_LOCKED.type;
+};
+
+export const isWalletLockedError = (error: unknown) => {
+  return error instanceof AdenaError && error.getType() === ERROR_VALUE.WALLET_LOCKED.type;
+};
+
+export const isConnectedAccountResponse = <T>(response: WalletResponse<T> | null): response is WalletResponse<T> => {
+  return response?.code === 0 && response.type === "GET_ACCOUNT";
+};


### PR DESCRIPTION
## Summary
- Treat Adena `WALLET_LOCKED` responses as a user-action-required state instead of a generic connection failure.
- Prevent the Gnoswap connection failure modal from opening on top of Adena's locked-wallet prompt.

## Changes
- Added explicit locked-wallet checks for both `addEstablishedSite()` responses and `getAccount()` errors.
- Reset `loadingConnect` to `initial` for locked Adena flows so the login UI returns to idle without showing an extra failure modal.
- Preserve the existing failure modal behavior for non-lock wallet connection errors.

## Test Coverage
- LSP diagnostics on `packages/web/src/hooks/wallet/data/use-wallet.ts`: passed
- `yarn workspace @gnoswap-labs/web lint`: passed with existing warnings
- `yarn workspace @gnoswap-labs/web build`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevents concurrent wallet connection attempts for more reliable connects.
  * Allows targeting a specific wallet client when switching networks or connecting.

* **Bug Fixes**
  * Improved detection and handling of locked wallets to avoid unnecessary errors and reset connection UI state.
  * Ensures account data is retrieved and persisted after successful connection.

* **Tests**
  * Added unit tests covering locked-wallet detection logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/876)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->