### PR TITLE
fix(launchpad): apply condition decimals

### DIFF
--- a/packages/web/src/components/common/launchpad-tooltip/deposit-conditions-tooltip/DepositConditionsTooltip.tsx
+++ b/packages/web/src/components/common/launchpad-tooltip/deposit-conditions-tooltip/DepositConditionsTooltip.tsx
@@ -3,7 +3,9 @@ import { useAtomValue } from "jotai";
 import { Placement } from "@floating-ui/react";
 
 import { XGNS_TOKEN_PATH } from "@constants/environment.constant";
+import { useGetTokens } from "@query/token";
 import { LaunchpadState } from "@states/index";
+import { formatLaunchpadConditionAmount, getLaunchpadConditionSymbol } from "@utils/launchpad-condition-utils";
 
 import IconWarning from "@components/common/icons/IconWarning";
 import Tooltip from "@components/common/tooltip/Tooltip";
@@ -18,20 +20,22 @@ const DepositConditionsTooltip = ({ placement }: DepositConditionsTooltipProps) 
   const { t } = useTranslation();
 
   const depositConditions = useAtomValue(LaunchpadState.depositConditions);
+  const { data: { tokens = [] } = {} } = useGetTokens();
 
   const renderConditions = () => {
     return depositConditions.map(condition => {
-      const { tokenPath, leastTokenAmount } = condition;
-      const tokenSymbol = tokenPath.split("/").pop();
+      const { tokenPath } = condition;
+      const tokenSymbol = getLaunchpadConditionSymbol(condition, tokens);
+      const displayAmount = formatLaunchpadConditionAmount(condition, tokens);
 
       return (
-        <>
+        <React.Fragment key={tokenPath}>
           {tokenPath === XGNS_TOKEN_PATH ? (
             <li>
               <Trans
                 ns="Launchpad"
                 i18nKey={"common.tooltip.conditions.xGNS"}
-                values={{ amount: leastTokenAmount.toLocaleString() }}
+                values={{ amount: displayAmount }}
                 components={{ br: <br /> }}
               />
             </li>
@@ -41,14 +45,14 @@ const DepositConditionsTooltip = ({ placement }: DepositConditionsTooltipProps) 
                 ns="Launchpad"
                 i18nKey={"common.tooltip.conditions.token"}
                 values={{
-                  amount: leastTokenAmount.toLocaleString(),
-                  symbol: tokenSymbol?.toUpperCase(),
+                  amount: displayAmount,
+                  symbol: tokenSymbol,
                 }}
                 components={{ br: <br /> }}
               />
             </li>
           )}
-        </>
+        </React.Fragment>
       );
     });
   };

--- a/packages/web/src/hooks/launchpad/data/use-launchpad-handler.ts
+++ b/packages/web/src/hooks/launchpad/data/use-launchpad-handler.ts
@@ -4,7 +4,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { XGNS_TOKEN_PATH } from "@constants/environment.constant";
-import { GNS_TOKEN } from "@common/values/token-constant";
+import { GNS_TOKEN, XGNS_TOKEN } from "@common/values/token-constant";
 import { useBroadcastHandler } from "@hooks/common/use-broadcast-handler";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 import { usePreventScroll } from "@hooks/common/use-prevent-scroll";
@@ -21,6 +21,7 @@ import { makeRawTokenAmount } from "@utils/token-utils";
 import { useReferral } from "@hooks/common/use-referral";
 import { useTokenAmountInput } from "@hooks/token/data/use-token-amount-input";
 import { isLaunchpadPoolEnded } from "@utils/launchpad-get-claimable";
+import { getLaunchpadConditionDisplayAmount, getLaunchpadConditionToken } from "@utils/launchpad-condition-utils";
 
 type DepositButtonStateType =
   | "WALLET_LOGIN"
@@ -58,7 +59,7 @@ export const useLaunchpadHandler = () => {
   const selectPoolId = useAtomValue(LaunchpadState.selectLaunchpadPool);
 
   const { connected: connectedWallet, account, isSwitchNetwork, switchNetwork } = useWallet();
-  const { displayBalanceMap } = useTokenData();
+  const { displayBalanceMap, tokens } = useTokenData();
 
   const { launchpadRepository } = useGnoswapContext();
   const { data: tokenPriceMap } = useGetAllTokenPrices();
@@ -88,11 +89,16 @@ export const useLaunchpadHandler = () => {
 
   // Variables to determine if conditions are met to make a deposit
   const isDepositAllowed = depositConditions.every(condition => {
+    const conditionAmount = getLaunchpadConditionDisplayAmount(condition, tokens);
+
     if (condition.tokenPath === XGNS_TOKEN_PATH) {
-      return Number(xGnsBalance) >= condition.leastTokenAmount;
+      const displayXGnsBalance = BigNumber(xGnsBalance || 0).shiftedBy(-XGNS_TOKEN.decimals);
+      return displayXGnsBalance.isGreaterThanOrEqualTo(conditionAmount);
     } else {
-      const balance = displayBalanceMap[condition.tokenPath] || 0;
-      return balance >= condition.leastTokenAmount;
+      const token = getLaunchpadConditionToken(condition, tokens);
+      const balance =
+        displayBalanceMap[token?.priceID ?? condition.tokenPath] ?? displayBalanceMap[condition.tokenPath] ?? 0;
+      return BigNumber(balance).isGreaterThanOrEqualTo(conditionAmount);
     }
   });
 

--- a/packages/web/src/utils/launchpad-condition-utils.spec.ts
+++ b/packages/web/src/utils/launchpad-condition-utils.spec.ts
@@ -1,0 +1,50 @@
+import { XGNS_TOKEN } from "@common/values/token-constant";
+import { LaunchpadProjectConditionModel } from "@models/launchpad";
+import { TokenModel } from "@models/token/token-model";
+
+import {
+  formatLaunchpadConditionAmount,
+  getLaunchpadConditionDisplayAmount,
+  getLaunchpadConditionSymbol,
+  getLaunchpadConditionToken,
+} from "./launchpad-condition-utils";
+
+const fooToken: TokenModel = {
+  path: "gno.land/r/gnoswap/test_token/foo",
+  type: "GRC20",
+  chainId: "dev.gnoswap",
+  name: "Foo Token",
+  symbol: "FOO",
+  decimals: 6,
+  logoURI: "",
+  createdAt: "2026-05-13T00:00:00Z",
+  priceID: "gno.land/r/gnoswap/test_token/foo",
+};
+
+const condition: LaunchpadProjectConditionModel = {
+  tokenPath: fooToken.path,
+  leastTokenAmount: 1000000,
+};
+
+describe("launchpad condition utils", () => {
+  it("converts raw condition amounts using token decimals", () => {
+    expect(getLaunchpadConditionDisplayAmount(condition, [fooToken]).toString()).toBe("1");
+    expect(formatLaunchpadConditionAmount(condition, [fooToken])).toBe("1");
+  });
+
+  it("uses xGNS decimals for xGNS conditions", () => {
+    const xGnsCondition: LaunchpadProjectConditionModel = {
+      tokenPath: XGNS_TOKEN.path,
+      leastTokenAmount: 2500000,
+    };
+
+    expect(getLaunchpadConditionToken(xGnsCondition, [])).toEqual(XGNS_TOKEN);
+    expect(getLaunchpadConditionDisplayAmount(xGnsCondition, []).toString()).toBe("2.5");
+    expect(getLaunchpadConditionSymbol(xGnsCondition, [])).toBe("xGNS");
+  });
+
+  it("falls back to raw amount and path suffix when token metadata is missing", () => {
+    expect(getLaunchpadConditionDisplayAmount(condition, []).toString()).toBe("1000000");
+    expect(getLaunchpadConditionSymbol(condition, [])).toBe("FOO");
+  });
+});

--- a/packages/web/src/utils/launchpad-condition-utils.ts
+++ b/packages/web/src/utils/launchpad-condition-utils.ts
@@ -1,0 +1,48 @@
+import BigNumber from "bignumber.js";
+
+import { XGNS_TOKEN } from "@common/values/token-constant";
+import { XGNS_TOKEN_PATH } from "@constants/environment.constant";
+import { LaunchpadProjectConditionModel } from "@models/launchpad";
+import { TokenModel } from "@models/token/token-model";
+
+export function getLaunchpadConditionToken(
+  condition: LaunchpadProjectConditionModel,
+  tokens: TokenModel[],
+): TokenModel | null {
+  if (condition.tokenPath === XGNS_TOKEN_PATH) {
+    return XGNS_TOKEN;
+  }
+
+  return tokens.find(token => token.path === condition.tokenPath) ?? null;
+}
+
+export function getLaunchpadConditionDisplayAmount(
+  condition: LaunchpadProjectConditionModel,
+  tokens: TokenModel[],
+): BigNumber {
+  const token = getLaunchpadConditionToken(condition, tokens);
+  const amount = BigNumber(condition.leastTokenAmount || 0);
+
+  if (!token) {
+    return amount;
+  }
+
+  return amount.shiftedBy(-(token.decimals || 0));
+}
+
+export function formatLaunchpadConditionAmount(
+  condition: LaunchpadProjectConditionModel,
+  tokens: TokenModel[],
+): string {
+  return getLaunchpadConditionDisplayAmount(condition, tokens).toFormat();
+}
+
+export function getLaunchpadConditionSymbol(condition: LaunchpadProjectConditionModel, tokens: TokenModel[]): string {
+  const token = getLaunchpadConditionToken(condition, tokens);
+
+  if (token) {
+    return token.symbol;
+  }
+
+  return condition.tokenPath.split("/").pop()?.toUpperCase() ?? "";
+}


### PR DESCRIPTION
## Summary
- Convert launchpad condition `leastTokenAmount` from raw units to display units using condition token decimals.
- Apply the converted amount to both the deposit eligibility check and the deposit conditions tooltip.
- Add a focused utility test covering GRC20, xGNS, and missing-token fallback behavior.

## Test
- `corepack yarn workspace @gnoswap-labs/web jest --runTestsByPath src/utils/launchpad-condition-utils.spec.ts --runInBand`
- `corepack yarn workspace @gnoswap-labs/web lint` (passes with existing repository warnings)
- `corepack yarn workspace @gnoswap-labs/web build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deposit conditions tooltip to correctly display token symbols and amounts based on token metadata.
  * Fixed deposit eligibility checks to properly verify token balances and calculate required amounts.

* **Tests**
  * Added comprehensive test coverage for launchpad condition utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/877)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->