### PR TITLE
fix(launchpad): align claim threshold units

### DIFF
--- a/packages/web/src/components/common/launchpad-modal/launchpad-deposit-modal/LaunchpadDepositModal.tsx
+++ b/packages/web/src/components/common/launchpad-modal/launchpad-deposit-modal/LaunchpadDepositModal.tsx
@@ -18,6 +18,7 @@ import LaunchpadPoolTierChip from "@layouts/launchpad/components/launchpad-pool-
 import { getDateUtcToLocal } from "@common/utils/date-util";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import { EXT_URL } from "@constants/external-url.contant";
+import { getClaimableTime } from "@utils/launchpad-get-claimable";
 
 type LaunchpadPoolModelWithoutClaimableTime = Omit<LaunchpadPoolModel, "claimableTime">;
 
@@ -51,10 +52,7 @@ const LaunchpadDepositModal = ({
 
   const Modal = React.useMemo(() => withLocalModal(LaunchpadDepositModalWrapper, setIsOpen), [setIsOpen]);
 
-  const now = new Date();
-  const claimableTime = poolInfo?.claimableThreshold
-    ? new Date(now.getTime() + Number(poolInfo.claimableThreshold) * 1000)
-    : null;
+  const claimableTime = getClaimableTime(poolInfo?.claimableThreshold);
 
   const poolDuration = getTierNumber(poolInfo?.poolTier);
 

--- a/packages/web/src/models/launchpad/launchpad-pool-model.ts
+++ b/packages/web/src/models/launchpad/launchpad-pool-model.ts
@@ -31,5 +31,6 @@ export interface LaunchpadPoolModel {
 
   endBlockHeight: number;
 
+  /** Seconds after deposit before rewards become claimable. */
   claimableThreshold: number;
 }

--- a/packages/web/src/repositories/launchpad/response/get-launchpad-active-projects-response.ts
+++ b/packages/web/src/repositories/launchpad/response/get-launchpad-active-projects-response.ts
@@ -4,6 +4,7 @@ export interface LaunchpadActiveProjectPool extends LaunchpadPoolModel {
   createBlockHeight: number;
   startBlockHeight: number;
   endBlockHeight: number;
+  /** Seconds after deposit before rewards become claimable. */
   claimableThreshold: number;
   apr: number;
   status: "UPCOMING" | "ONGOING" | "ENDED";

--- a/packages/web/src/repositories/position/position-repository-impl.ts
+++ b/packages/web/src/repositories/position/position-repository-impl.ts
@@ -76,7 +76,7 @@ export class PositionRepositoryImpl implements PositionRepository {
     const response = await this.networkClient.get<{
       data: PositionBinResponse[];
     }>({
-      url: "/positions/" + lpTokenId + `/bins?bins=${count}`,
+      url: "/positions/" + lpTokenId + `/bins?binSize=${count}`,
     });
     return PositionBinMapper.fromList(response.data.data);
   };

--- a/packages/web/src/repositories/position/position-repository.spec.ts
+++ b/packages/web/src/repositories/position/position-repository.spec.ts
@@ -1,0 +1,68 @@
+import { NetworkClient } from "@common/clients/network-client";
+import {
+  HttpDeleteRequestParam,
+  HttpGetRequestParam,
+  HttpPostRequestParam,
+  HttpPutRequestParam,
+  HttpResponse,
+} from "@common/clients/network-client/protocols";
+import { PositionRepositoryImpl } from "./position-repository-impl";
+
+class MockNetworkClient implements NetworkClient {
+  public getCalls: HttpGetRequestParam[] = [];
+
+  public async get<R>(params: HttpGetRequestParam): Promise<HttpResponse<R>> {
+    this.getCalls.push(params);
+
+    return {
+      status: 200,
+      message: "Success",
+      data: { data: [] } as R,
+    };
+  }
+
+  public async post<T, R>(params: HttpPostRequestParam<T>): Promise<HttpResponse<R>> {
+    void params;
+
+    return {
+      status: 200,
+      message: "Success",
+      data: {} as R,
+    };
+  }
+
+  public async put<T, R>(params: HttpPutRequestParam<T>): Promise<HttpResponse<R>> {
+    void params;
+
+    return {
+      status: 200,
+      message: "Success",
+      data: {} as R,
+    };
+  }
+
+  public async delete<T, R>(params: HttpDeleteRequestParam<T>): Promise<HttpResponse<R>> {
+    void params;
+
+    return {
+      status: 200,
+      message: "Success",
+      data: {} as R,
+    };
+  }
+}
+
+describe("PositionRepositoryImpl", () => {
+  it("uses binSize query parameter for position bins", async () => {
+    const networkClient = new MockNetworkClient();
+    const repository = new PositionRepositoryImpl(networkClient, null, null);
+
+    await repository.getPositionBins("123", 40);
+
+    expect(networkClient.getCalls).toEqual([
+      {
+        url: "/positions/123/bins?binSize=40",
+      },
+    ]);
+  });
+});

--- a/packages/web/src/utils/launchpad-get-claimable.spec.ts
+++ b/packages/web/src/utils/launchpad-get-claimable.spec.ts
@@ -1,0 +1,21 @@
+import { getClaimableTime } from "./launchpad-get-claimable";
+
+describe("getClaimableTime", () => {
+  const now = new Date("2026-05-13T00:00:00.000Z").getTime();
+
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(now);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("treats claimableThreshold as seconds", () => {
+    expect(getClaimableTime(86_400)?.toISOString()).toBe("2026-05-14T00:00:00.000Z");
+  });
+
+  it("returns undefined when threshold is missing", () => {
+    expect(getClaimableTime()).toBeUndefined();
+  });
+});

--- a/packages/web/src/utils/launchpad-get-claimable.ts
+++ b/packages/web/src/utils/launchpad-get-claimable.ts
@@ -1,10 +1,12 @@
 import { CLAIMABLE_DAYS } from "@common/values";
 import { safeParseTime } from "./time.utils";
 
-export const getClaimableTime = (threshold?: number) => {
-  if (threshold == null) return;
+const MILLISECONDS_PER_SECOND = 1000;
 
-  return new Date(Date.now() + threshold);
+export const getClaimableTime = (claimableThresholdSeconds?: number) => {
+  if (claimableThresholdSeconds == null) return;
+
+  return new Date(Date.now() + claimableThresholdSeconds * MILLISECONDS_PER_SECOND);
 };
 
 export const getClaimableDays = (poolTier: string): number => {


### PR DESCRIPTION
## Summary
- Treat Launchpad `claimableThreshold` as seconds when calculating claimable times.
- Reuse the shared claimable-time helper in the deposit confirmation modal.
- Align the position bins request query parameter with the backend `binSize` contract.

## Changes
- Convert `claimableThreshold` from seconds to milliseconds inside `getClaimableTime`.
- Add unit coverage for seconds-based claimable time calculation.
- Document the `claimableThreshold` unit in Launchpad pool response/model types.
- Change position bins requests from `?bins=` to `?binSize=` and add repository coverage for the generated URL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected claimable time calculation to properly interpret thresholds in seconds.
  * Fixed position bin request parameter handling for accurate data retrieval.

* **Documentation**
  * Added clarification that claimable threshold represents seconds after deposit before rewards become available.

* **Tests**
  * Added test coverage for position bin request parameters.
  * Added test coverage for claimable time calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/878)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->