### PR TITLE
fix(governance): use backend quorum amount

### DIFF
--- a/packages/web/src/layouts/governance/components/proposals-list/ProposalList.tsx
+++ b/packages/web/src/layouts/governance/components/proposals-list/ProposalList.tsx
@@ -11,6 +11,7 @@ import ProposalHeader from "./proposal-header/ProposalHeader";
 import ViewProposalModal from "./view-proposal-modal/ViewProposalModal";
 
 import { CreateProposalModalOpenOption } from "@hooks/governance/ui/use-create-proposal-modal";
+import { isQuorumReached } from "@utils/governance-utils";
 import { ProposalListWrapper } from "./ProposalList.styles";
 
 export interface ProposalListProps {
@@ -132,8 +133,7 @@ const ProposalList: React.FC<ProposalListProps> = ({
 
   const calculateIsMajorityVoted = (proposalDetail: ProposalItemInfo) => {
     const { votingInfo } = proposalDetail;
-    const totalVoting = votingInfo.yesVotingWeight + votingInfo.noVotingWeight;
-    return totalVoting >= votingInfo.quorumAmount;
+    return isQuorumReached(votingInfo);
   };
 
   return (

--- a/packages/web/src/layouts/governance/components/proposals-list/proposal-card/ProposalCard.tsx
+++ b/packages/web/src/layouts/governance/components/proposals-list/proposal-card/ProposalCard.tsx
@@ -76,7 +76,7 @@ const ProposalCard: React.FC<Props> = ({
     const isCancelled = proposalDetail.status === "CANCELLED";
 
     return {
-      max: safeDisplayAmount(proposalDetail.votingInfo.maxVotingWeight),
+      max: safeDisplayAmount(proposalDetail.votingInfo.quorumAmount),
       yes: isCancelled ? 0 : safeDisplayAmount(proposalDetail.votingInfo.yesVotingWeight),
       no: isCancelled ? 0 : safeDisplayAmount(proposalDetail.votingInfo.noVotingWeight),
     };

--- a/packages/web/src/layouts/governance/components/proposals-list/view-proposal-modal/ViewProposalModal.tsx
+++ b/packages/web/src/layouts/governance/components/proposals-list/view-proposal-modal/ViewProposalModal.tsx
@@ -14,6 +14,7 @@ import { useWindowSize } from "@hooks/common/use-window-size";
 import { nullProposalDetailsInfo, nullUserVotingInfo, PROPOSAL_TYPE } from "@repositories/governance";
 import { DEVICE_TYPE } from "@styles/media";
 import { useGetProposalDetails } from "@query/governance";
+import { isQuorumReached } from "@utils/governance-utils";
 import { rawToDisplayAmount } from "@utils/number-utils";
 
 import StatusBadge from "../../status-badge/StatusBadge";
@@ -106,12 +107,8 @@ const ViewProposalModal: React.FC<ViewProposalModalProps> = ({
   }, [numericVotingInfo]);
 
   const isMajorityVoted = useMemo(() => {
-    const { yesVotingWeight, noVotingWeight, maxVotingWeight } = numericVotingInfo;
-
-    if (maxVotingWeight === 0) return false;
-
-    return yesVotingWeight + noVotingWeight >= maxVotingWeight / 2;
-  }, [numericVotingInfo]);
+    return isQuorumReached(proposalDetail.votingInfo);
+  }, [proposalDetail.votingInfo]);
 
   const { yesVotes, noVotes } = useMemo(() => {
     if (proposalDetail.status === "CANCELLED") {
@@ -250,13 +247,13 @@ const ViewProposalModal: React.FC<ViewProposalModalProps> = ({
                   {rawToDisplayAmount(yesVotes + noVotes, XGNS_TOKEN.decimals).toLocaleString()}
                 </span>
               </Tooltip>
-              /<div>{rawToDisplayAmount(numericVotingInfo.maxVotingWeight, XGNS_TOKEN.decimals).toLocaleString()}</div>
+              /<div>{rawToDisplayAmount(numericVotingInfo.quorumAmount, XGNS_TOKEN.decimals).toLocaleString()}</div>
             </div>
           </div>
           <VotingProgressBar
             yes={numericVotingInfo.yesVotingWeight}
             no={numericVotingInfo.noVotingWeight}
-            max={numericVotingInfo.maxVotingWeight}
+            max={numericVotingInfo.quorumAmount}
             isMajorityVoted={isMajorityVoted}
             hideNumber
           />

--- a/packages/web/src/layouts/governance/components/voting-progress-bar/VotingProgressBar.tsx
+++ b/packages/web/src/layouts/governance/components/voting-progress-bar/VotingProgressBar.tsx
@@ -30,12 +30,19 @@ const VotingProgressBar: React.FC<VotingProgressBarProps> = ({
     return Boolean(yes) || Boolean(no);
   }, [yes, no]);
 
-  const yesRate = (100 * yes) / max;
-  const noRate = (100 * no) / max;
+  const getProgressRate = (value: number) => {
+    if (!max) return 0;
+
+    return Math.min((100 * value) / max, 100);
+  };
+
+  const yesRate = getProgressRate(yes);
+  const noRate = getProgressRate(no);
+  const totalRate = Math.min(yesRate + noRate, 100);
 
   return (
     <ProgressWrapper>
-      <ProgressBar rateWidth={`${yesRate}%`} noOfQuorumWidth={`${Number(yesRate) + Number(noRate)}%`}>
+      <ProgressBar rateWidth={`${yesRate}%`} noOfQuorumWidth={`${totalRate}%`}>
         <FloatingTooltip
           className="float-progress"
           position="top"

--- a/packages/web/src/utils/governance-utils.spec.ts
+++ b/packages/web/src/utils/governance-utils.spec.ts
@@ -1,4 +1,4 @@
-import { makeProposalVariablesQuery } from "./governance-utils";
+import { isQuorumReached, makeProposalVariablesQuery } from "./governance-utils";
 
 describe("make proposal's variable query", () => {
   test("single variable", () => {
@@ -32,5 +32,37 @@ describe("make proposal's variable query", () => {
     const query = makeProposalVariablesQuery(variables);
 
     expect(query).toBe("pkg1*EXE*func1*EXE*arg1,arg2*GOV*pkg2*EXE*func2*EXE*arg1,arg2,arg3");
+  });
+});
+
+describe("isQuorumReached", () => {
+  test("returns true when summed vote weights reach quorum amount", () => {
+    const result = isQuorumReached({
+      yesVotingWeight: "1000000000",
+      noVotingWeight: "578900000",
+      quorumAmount: "1578900000",
+    });
+
+    expect(result).toBe(true);
+  });
+
+  test("adds integer strings numerically instead of concatenating them", () => {
+    const result = isQuorumReached({
+      yesVotingWeight: "1",
+      noVotingWeight: "57",
+      quorumAmount: "58",
+    });
+
+    expect(result).toBe(true);
+  });
+
+  test("returns false when summed vote weights are below quorum amount", () => {
+    const result = isQuorumReached({
+      yesVotingWeight: "1000000000",
+      noVotingWeight: "578899999",
+      quorumAmount: "1578900000",
+    });
+
+    expect(result).toBe(false);
   });
 });

--- a/packages/web/src/utils/governance-utils.ts
+++ b/packages/web/src/utils/governance-utils.ts
@@ -1,7 +1,15 @@
+import BigNumber from "bignumber.js";
+
 interface ProposalVariables {
   pkgPath: string;
   func: string;
   param: string;
+}
+
+interface GovernanceVotingAmounts {
+  yesVotingWeight: string;
+  noVotingWeight: string;
+  quorumAmount: string;
 }
 
 const queryMethodSeparator = "*GOV*";
@@ -23,4 +31,16 @@ export const makeProposalVariablesQuery = (variables: ProposalVariables[]): stri
 
   const methodQueries = variables.map(makeMethodQuery);
   return methodQueries.join(queryMethodSeparator);
+};
+
+export const isQuorumReached = ({ yesVotingWeight, noVotingWeight, quorumAmount }: GovernanceVotingAmounts): boolean => {
+  const yesVotingWeightValue = BigNumber(yesVotingWeight || 0);
+  const noVotingWeightValue = BigNumber(noVotingWeight || 0);
+  const quorumAmountValue = BigNumber(quorumAmount || 0);
+
+  if (yesVotingWeightValue.isNaN() || noVotingWeightValue.isNaN() || quorumAmountValue.isNaN()) {
+    return false;
+  }
+
+  return yesVotingWeightValue.plus(noVotingWeightValue).isGreaterThanOrEqualTo(quorumAmountValue);
 };


### PR DESCRIPTION
## Summary
- Fix governance proposal list/card/modal quorum status to compare vote totals against BE-provided `quorumAmount`.
- Add a BigNumber-based quorum helper to avoid string concatenation and precision issues in raw voting weights.
- Use quorum amount as the displayed progress target and clamp progress widths when vote totals exceed quorum.

## Test Coverage
- `yarn workspace @gnoswap-labs/web test:ci --runTestsByPath src/utils/governance-utils.spec.ts src/layouts/governance/components/proposals-list/ProposalList.spec.tsx src/layouts/governance/components/proposals-list/view-proposal-modal/ViewProposalModal.styles.spec.tsx --coverage=false --modulePathIgnorePatterns='<rootDir>/.next'`
- `yarn workspace @gnoswap-labs/web lint` (passes with existing warnings)
- `yarn build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Voting progress bar percentage calculations now properly clamp to prevent exceeding 100%, improving display accuracy.

* **Refactor**
  * Quorum status determination has been centralized across all governance proposal components.
  * Voting progress bar maximum values updated to use quorum amount instead of max voting weight for consistent calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/879)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->