### PR TITLE
fix: refetch bins on liquidity changes and debounce pool state

### DIFF
--- a/packages/web/src/components/common/my-position-card-list/my-position-card/MyPositionCard.tsx
+++ b/packages/web/src/components/common/my-position-card-list/my-position-card/MyPositionCard.tsx
@@ -55,9 +55,19 @@ const MyPositionCard: React.FC<MyPositionCardProps> = ({
   const [isMouseoverGraph, setIsMouseoverGraph] = useState(false);
   const [shortenInRange, setShortenInRange] = useState(false);
 
-  const { data: bins40, isFetched: isFetchedBins } = useGetPositionBins(position.lpTokenId, 40, {
-    enabled: isMouseoverGraph,
-  });
+  const { data: bins40, isFetched: isFetchedBins } = useGetPositionBins(
+    position.lpTokenId,
+    40,
+    {
+      liquidity: position.liquidity,
+      poolCurrentTick: position.pool?.currentTick,
+      poolTokenABalance: position.pool?.tokenABalance,
+      poolTokenBBalance: position.pool?.tokenBBalance,
+    },
+    {
+      enabled: isMouseoverGraph,
+    },
+  );
 
   const { prefetch } = usePrefetchNavigation({
     pageType: "POOL",

--- a/packages/web/src/hooks/common/use-debounce.tsx
+++ b/packages/web/src/hooks/common/use-debounce.tsx
@@ -3,15 +3,31 @@ import React from "react";
 const useDebounce = <T,>(value: T, delay: number): T => {
   const [debouncedValue, setDebouncedValue] = React.useState<T>(value);
 
+  // Keep the latest `value` in a ref so the debounce effect doesn't have to
+  // depend on `value` by reference. A caller passing a fresh object literal
+  // every render would otherwise re-arm the timer endlessly (timer fires ->
+  // setState -> re-render -> new object -> timer re-arms = a permanent loop).
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+
+  // Drive the effect off a value-based key instead. For primitives this is the
+  // value itself; for objects it's a stable serialization, so structurally
+  // equal inputs across renders don't re-trigger the debounce. The replacer
+  // stringifies `bigint`, which `JSON.stringify` would otherwise throw on.
+  const valueKey =
+    value !== null && typeof value === "object"
+      ? JSON.stringify(value, (_, v) => (typeof v === "bigint" ? v.toString() : v))
+      : value;
+
   React.useEffect(() => {
     const timer = setTimeout(() => {
-      setDebouncedValue(value);
+      setDebouncedValue(valueRef.current);
     }, delay);
 
     return () => {
       clearTimeout(timer);
     };
-  }, [value, delay]);
+  }, [valueKey, delay]);
 
   return debouncedValue;
 };

--- a/packages/web/src/hooks/pool/data/use-select-pool.tsx
+++ b/packages/web/src/hooks/pool/data/use-select-pool.tsx
@@ -153,7 +153,7 @@ export const useSelectPool = ({
 
   const shouldRefetch = ["/earn/pool/add", "/earn/add"].includes(router.pathname);
 
-  const { data: binsResult } = useGetBinsByPath(calculatedPoolPath || "", ZOOL_VALUES[zoomLevel], undefined, {
+  const { data: binsResult } = useGetBinsByPath(calculatedPoolPath || "", ZOOL_VALUES[zoomLevel], null, null, null, {
     enabled: !!calculatedPoolPath && !isCreate,
     queryKey: ["useSelectPool/getBins", calculatedPoolPath, zoomLevel, isCreate],
   });

--- a/packages/web/src/layouts/earn/components/incentivized-pool-card-list/incentivized-pool-card/IncentivizedPoolCard.tsx
+++ b/packages/web/src/layouts/earn/components/incentivized-pool-card-list/incentivized-pool-card/IncentivizedPoolCard.tsx
@@ -1,6 +1,6 @@
+import { cx } from "@emotion/css";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { cx } from "@emotion/css";
 
 import Badge, { BADGE_TYPE } from "@components/common/badge/Badge";
 import DoubleLogo from "@components/common/double-logo/DoubleLogo";
@@ -8,19 +8,19 @@ import IconStar from "@components/common/icons/IconStar";
 import OverlapTokenLogo from "@components/common/overlap-token-logo/OverlapTokenLogo";
 import PoolGraph from "@components/common/pool-graph/PoolGraph";
 import { SwapFeeTierInfoMap } from "@constants/option.constant";
+import { QUERY_PARAMETER } from "@constants/page.constant";
+import { usePrefetchNavigation } from "@hooks/common/use-prefetch-navigation";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
+import { useTokenPriceInfo } from "@hooks/token/data/use-token-price-info";
 import { IncentivizePoolCardInfoWithPriceGrade } from "@models/pool/info/pool-card-info";
+import { useGetBinsByPath } from "@query/pools";
 import { formatRate } from "@utils/new-number-utils";
 import { numberToFormat } from "@utils/string-utils";
-import { useGetBinsByPath } from "@query/pools";
 import { getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
-import { useTokenPriceInfo } from "@hooks/token/data/use-token-price-info";
-import { usePrefetchNavigation } from "@hooks/common/use-prefetch-navigation";
-import { QUERY_PARAMETER } from "@constants/page.constant";
 
-import { PoolCardWrapper, PoolCardWrapperWrapperBorder } from "./IncentivizedPoolCard.styles";
 import LoadingSpinner from "@components/common/loading-spinner/LoadingSpinner";
 import PriceWarning from "@components/common/price-warning/PriceWarning";
+import { PoolCardWrapper, PoolCardWrapperWrapperBorder } from "./IncentivizedPoolCard.styles";
 
 export interface IncentivizedPoolCardProps {
   pool: IncentivizePoolCardInfoWithPriceGrade;
@@ -46,7 +46,9 @@ const IncentivizedPoolCard: React.FC<IncentivizedPoolCardProps> = ({ pool, route
   const { data: bins40Result, isLoading: isLoadingBins40 } = useGetBinsByPath(
     pool.poolPath || "",
     BINS_DATA_DEFAULT_LENGTH,
-    undefined,
+    null,
+    null,
+    null,
     {
       enabled: !!pool.poolPath,
     },

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
@@ -97,7 +97,12 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
   const GRAPH_WIDTH = useMemo(() => Math.min(width - (width > 767 ? 224 : 80), 1216), [width]);
   const [copied, setCopy] = useCopy();
   const [copiedPosition, setCopiedPosition] = useCopy();
-  const { data: bins = [] } = useGetPositionBins(position.lpTokenId, 40);
+  const { data: bins = [] } = useGetPositionBins(position.lpTokenId, 40, {
+    liquidity: position.liquidity,
+    poolCurrentTick: position.pool?.currentTick,
+    poolTokenABalance: position.pool?.tokenABalance,
+    poolTokenBBalance: position.pool?.tokenBBalance,
+  });
 
   const isClosed = position.closed;
 

--- a/packages/web/src/layouts/pool/pool-detail/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
@@ -42,21 +42,30 @@ const PoolPairInformationContainer: React.FC<PoolPairInformationContainerProps> 
     },
   });
 
-  // Gate the bins query on `data?.currentTick` being defined. Bins are server-centered
-  // on the current tick, so firing before pool detail arrives would (1) issue an
-  // initial request without a tick, then (2) immediately invalidate and refetch
-  // once the tick comes in — producing two slightly different payloads on first
-  // mount and a visible re-layout of the graph just after entry.
   const currentTick = data?.currentTick;
+  // Pass only the identifying prefix as `queryKey`; the hook appends the
+  // remaining dependencies (currentTick / token balances) itself so that a
+  // pool detail refetch with changed liquidity also refetches the bins.
+  // The hook debounces those inputs and gates the query on the debounced tick,
+  // so passing the raw values here (and only `!!poolPath` as `enabled`) is fine.
+  // The 60s `refetchInterval` is just a slow safety net for the rare case
+  // where the indexer lags and the pool-detail balances don't update in time.
   const { data: binsResult, isLoading: isLoadingBins } = useGetBinsByPath(
     poolPath as string,
     binCount,
     currentTick,
+    data?.tokenABalance,
+    data?.tokenBBalance,
     {
-      enabled: !!poolPath && currentTick !== undefined,
-      queryKey: [QUERY_KEY.poolPairBins, poolPath, zoomLevel, currentTick ?? null],
+      enabled: !!poolPath,
+      queryKey: [QUERY_KEY.poolPairBins, poolPath, zoomLevel],
+      refetchInterval: 60_000,
     },
   );
+
+  // Read bins and pairedTick from the same query result so they always stay a
+  // matched pair: the graph centers on `pairedTick`, and keepPreviousData swaps
+  // both together on refetch — no skewed layout from a tick/bins mismatch.
   const bins = binsResult?.bins ?? [];
   const pairedTick = binsResult?.pairedTick ?? null;
   const { tokenPrices } = useTokenData();
@@ -79,6 +88,8 @@ const PoolPairInformationContainer: React.FC<PoolPairInformationContainerProps> 
     const tokenB = convertedPool.tokenB;
     return {
       ...convertedPool,
+      // Use the tick paired with the currently displayed bins. Falls back to
+      // the pool-detail tick until the first bins payload arrives.
       currentTick: pairedTick ?? convertedPool.currentTick,
       tokenA: {
         ...tokenA,

--- a/packages/web/src/react-query/pools/use-get-bins-by-path.ts
+++ b/packages/web/src/react-query/pools/use-get-bins-by-path.ts
@@ -1,12 +1,21 @@
 import { UseQueryOptions, useQuery } from "@tanstack/react-query";
 
+import useDebounce from "@hooks/common/use-debounce";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 import { PoolBinModel } from "@models/pool/pool-bin-model";
 
 import { QUERY_KEY } from "../query-keys";
 
+// Delay between a pool-state change (tick / balances) being observed and the
+// bins refetch firing. Gives the server time to (re)build the bins for the
+// new state, so we don't fetch a payload that still reflects the old state.
+const DEFAULT_DEBOUNCE_DELAY = 1_000;
+
 export interface PoolBinsResult {
   bins: PoolBinModel[];
+  // The currentTick captured at fetch time. Bins are server-centered on this
+  // tick, so the graph must render this tick alongside these bins — never the
+  // tick from another source/time, or the graph layout skews.
   pairedTick: number | null;
 }
 
@@ -14,18 +23,60 @@ export const useGetBinsByPath = (
   path: string,
   count?: number,
   currentTick?: number | null,
+  poolDepositedTokenAAmount?: number | null,
+  poolDepositedTokenBAmount?: number | null,
   options?: UseQueryOptions<PoolBinsResult, Error>,
 ) => {
   const { poolRepository } = useGnoswapContext();
+  const { queryKey: extraQueryKey, enabled: callerEnabled, ...restOptions } = options ?? {};
+
+  // Debounce the pool-state inputs so a state change waits `refetchDelay`
+  // before it can drive a refetch. Consecutive changes collapse to the last
+  // value, and the server gets a window to reflect the change in its bins.
+  const {
+    currentTick: debouncedCurrentTick,
+    poolDepositedTokenAAmount: debouncedTokenAAmount,
+    poolDepositedTokenBAmount: debouncedTokenBAmount,
+  } = useDebounce(
+    {
+      currentTick,
+      poolDepositedTokenAAmount,
+      poolDepositedTokenBAmount,
+    },
+    DEFAULT_DEBOUNCE_DELAY,
+  );
+
+  // Gate on the *debounced* tick, not the raw one: the query key is built from
+  // debounced values, so enabling on the raw tick would let the first fetch go
+  // out keyed on a stale (or undefined) tick before the debounce settles.
+  const enabled = (callerEnabled ?? true) && debouncedCurrentTick !== undefined;
+
   return useQuery<PoolBinsResult, Error>({
-    queryKey: [QUERY_KEY.bins, path, currentTick ?? null],
+    // Append the debounced pool-detail dependencies (currentTick / token
+    // balances) to the caller-provided key so changed liquidity is the primary
+    // trigger for a bins refetch — even if the caller overrides `queryKey`.
+    // The pool-detail query already polls every 5s; the heavy bins payload is
+    // only re-fetched when those values actually change (after the debounce),
+    // so unchanged liquidity costs nothing. (Callers may still add a slow
+    // `refetchInterval` as a safety net.)
+    queryKey: [
+      ...(extraQueryKey ?? [QUERY_KEY.bins, path]),
+      count ?? null,
+      debouncedCurrentTick ?? null,
+      debouncedTokenAAmount ?? null,
+      debouncedTokenBAmount ?? null,
+    ],
     queryFn: async () => {
       const bins = await poolRepository.getBinsOfPoolByPath(path, count);
-      return { bins, pairedTick: currentTick ?? null };
+      // Pair the bins with the tick they were fetched for. keepPreviousData
+      // then swaps both atomically, so the graph never mixes new bins with a
+      // stale tick (or vice versa) mid-refetch.
+      return { bins, pairedTick: debouncedCurrentTick ?? null };
     },
     refetchOnMount: true,
     refetchOnReconnect: true,
     keepPreviousData: true,
-    ...options,
+    ...restOptions,
+    enabled,
   });
 };

--- a/packages/web/src/react-query/pools/use-get-bins-by-path.ts
+++ b/packages/web/src/react-query/pools/use-get-bins-by-path.ts
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import { UseQueryOptions, useQuery } from "@tanstack/react-query";
 
 import useDebounce from "@hooks/common/use-debounce";
@@ -30,6 +32,21 @@ export const useGetBinsByPath = (
   const { poolRepository } = useGnoswapContext();
   const { queryKey: extraQueryKey, enabled: callerEnabled, ...restOptions } = options ?? {};
 
+  // Memoize the pool-state input object before handing it to `useDebounce`.
+  // `useDebounce` compares its `value` by reference, so a fresh object literal
+  // on every render would make the debounce timer re-arm endlessly: the timer
+  // fires -> setState -> re-render -> new object -> timer re-arms (a permanent
+  // 1s render loop). Keying the memo on the primitives keeps the reference
+  // stable until one of the values actually changes.
+  const poolStateInput = useMemo(
+    () => ({
+      currentTick,
+      poolDepositedTokenAAmount,
+      poolDepositedTokenBAmount,
+    }),
+    [currentTick, poolDepositedTokenAAmount, poolDepositedTokenBAmount],
+  );
+
   // Debounce the pool-state inputs so a state change waits `refetchDelay`
   // before it can drive a refetch. Consecutive changes collapse to the last
   // value, and the server gets a window to reflect the change in its bins.
@@ -37,14 +54,7 @@ export const useGetBinsByPath = (
     currentTick: debouncedCurrentTick,
     poolDepositedTokenAAmount: debouncedTokenAAmount,
     poolDepositedTokenBAmount: debouncedTokenBAmount,
-  } = useDebounce(
-    {
-      currentTick,
-      poolDepositedTokenAAmount,
-      poolDepositedTokenBAmount,
-    },
-    DEFAULT_DEBOUNCE_DELAY,
-  );
+  } = useDebounce(poolStateInput, DEFAULT_DEBOUNCE_DELAY);
 
   // Gate on the *debounced* tick, not the raw one: the query key is built from
   // debounced values, so enabling on the raw tick would let the first fetch go

--- a/packages/web/src/react-query/positions/use-get-position-bins.ts
+++ b/packages/web/src/react-query/positions/use-get-position-bins.ts
@@ -1,19 +1,80 @@
+import { useMemo } from "react";
+
 import { UseQueryOptions, useQuery } from "@tanstack/react-query";
 
+import useDebounce from "@hooks/common/use-debounce";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 
 import { QUERY_KEY } from "../query-keys";
 import { PositionBinModel } from "@models/position/position-bin-model";
 
+// Delay between a pool-state change (tick / balances / liquidity) being
+// observed and the bins refetch firing. Gives the server time to (re)build the
+// bins for the new state, so we don't fetch a payload that still reflects the
+// old state. Mirrors `useGetBinsByPath`.
+const DEFAULT_DEBOUNCE_DELAY = 1_000;
+
+// Pool-state inputs that the server-built position bins depend on. A
+// `PositionBinModel` carries `poolLiquidity` / `poolReserveToken*` and each bin
+// is drawn as the position's share of the pool, so the bins go stale whenever
+// the *pool* changes — not just when this position's own liquidity does. Any
+// liquidity event in the pool (even from another address) shifts these values.
+interface PoolStateInput {
+  // This position's own liquidity — changes on add / remove / reposition.
+  liquidity?: bigint | null;
+  // Pool-wide state, read from `position.pool`. The pool-detail / positions
+  // queries poll, so these update on their own and drive the refetch.
+  poolCurrentTick?: number | null;
+  poolTokenABalance?: number | null;
+  poolTokenBBalance?: number | null;
+}
+
 export const useGetPositionBins = (
   lpTokenId: string,
   count: 20 | 40,
+  poolState?: PoolStateInput,
   options?: UseQueryOptions<PositionBinModel[], Error>,
 ) => {
   const { positionRepository } = useGnoswapContext();
 
+  const { liquidity, poolCurrentTick, poolTokenABalance, poolTokenBBalance } = poolState ?? {};
+
+  // Memoize the pool-state input object before handing it to `useDebounce`.
+  // `useDebounce` would otherwise re-arm its timer on every render for a fresh
+  // object literal. Key the memo on the primitives (`liquidity` stringified,
+  // since bigint isn't a stable dep otherwise).
+  const poolStateInput = useMemo(
+    () => ({
+      liquidity: liquidity?.toString() ?? null,
+      poolCurrentTick: poolCurrentTick ?? null,
+      poolTokenABalance: poolTokenABalance ?? null,
+      poolTokenBBalance: poolTokenBBalance ?? null,
+    }),
+    [liquidity, poolCurrentTick, poolTokenABalance, poolTokenBBalance],
+  );
+
+  // Debounce the pool-state inputs so consecutive changes collapse to the last
+  // value and the server gets a window to reflect the change in its bins.
+  const {
+    liquidity: debouncedLiquidity,
+    poolCurrentTick: debouncedTick,
+    poolTokenABalance: debouncedTokenABalance,
+    poolTokenBBalance: debouncedTokenBBalance,
+  } = useDebounce(poolStateInput, DEFAULT_DEBOUNCE_DELAY);
+
   return useQuery<PositionBinModel[], Error>({
-    queryKey: [QUERY_KEY.positionBins, lpTokenId, count],
+    // Append the debounced pool-state dependencies to the key so changed
+    // liquidity — this position's or anyone else's in the pool — is the trigger
+    // for a bins refetch. Mirrors how `useGetBinsByPath` keys pool bins.
+    queryKey: [
+      QUERY_KEY.positionBins,
+      lpTokenId,
+      count,
+      debouncedLiquidity,
+      debouncedTick,
+      debouncedTokenABalance,
+      debouncedTokenBBalance,
+    ],
     queryFn: async () => {
       const data = await positionRepository.getPositionBins(lpTokenId, count);
       return data;


### PR DESCRIPTION
## Description

### Summary

Improves how pool liquidity bins are fetched and keyed so the pool detail graph stays consistent when liquidity or the current tick changes. Adds debounced pool-state inputs to `useGetBinsByPath`, extends the query key with deposited token amounts, and wires those values from `PoolPairInformationContainer` so bins refetch when on-chain pool balances update—not only when the tick changes.

### Problem

- Bins are centered on a **server tick** at fetch time; mixing **bins** from one response with **currentTick** from another source or moment skews the chart.
- After liquidity changes, pool detail can refetch with new balances while bins were still keyed mainly on path/tick, so the UI could lag or double-fetch awkwardly on first paint.

### Solution

1. **`useGetBinsByPath`**
   - Accepts optional `poolDepositedTokenAAmount` and `poolDepositedTokenBAmount`.
   - Debounces `{ currentTick, token A/B balances }` (default **1000 ms**) so refetches wait for the indexer to settle after state changes.
   - Builds `queryKey` from caller prefix + **debounced** tick and balances so liquidity changes invalidate and refetch bins.
   - Enables the query only when **`debouncedCurrentTick` is defined**, avoiding a fetch keyed on stale/undefined tick before debounce settles.
   - Returns **`pairedTick`** aligned with the tick used for that bins payload (works with `keepPreviousData` so tick and bins update together).

2. **`PoolPairInformationContainer`**
   - Passes `data?.tokenABalance` / `data?.tokenBBalance` into the hook.
   - Uses a shorter `queryKey` prefix; the hook appends debounced dependencies.
   - `enabled` is `!!poolPath` only; gating uses debounced tick inside the hook.
   - Adds a **60s** `refetchInterval` as a slow fallback if balances lag.
   - Pool object passed downstream uses **`pairedTick ?? pool currentTick`** so the displayed tick always matches the bins being shown.

3. **Call sites**
   - `useSelectPool` and `IncentivizedPoolCard` pass explicit `null` for the new balance args where bins do not depend on pool-detail liquidity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Debounced pool/position inputs to reduce unnecessary data refetches and stabilize graphs.
  * Query keys and enablement logic refined to align refetches with relevant pool-detail changes.

* **Breaking Changes**
  * Several hooks now accept optional pool/position state inputs (debounced) which affect when bins data is requested; callers should pass context where applicable.

* **Style**
  * Minor import and call-site argument reorderings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/880)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->