### PR TITLE
style(snackbar): remove clickable cursor from notice body

### DIFF
--- a/packages/web/src/providers/snackbar-provider/snackbar/contents/ReceiveWugnotContent.tsx
+++ b/packages/web/src/providers/snackbar-provider/snackbar/contents/ReceiveWugnotContent.tsx
@@ -27,7 +27,7 @@ const ReceiveWugnotContent: React.FC<{ content?: SnackbarContent; onClick: () =>
   };
 
   return (
-    <div className="notice-body clickable" onClick={onClick}>
+    <div className="notice-body" onClick={onClick}>
       <div className="icon-wrap-wrapper">
         <IconWrap className="icon-wrap" />
       </div>

--- a/packages/web/src/providers/snackbar-provider/snackbar/contents/StakePositionContent.tsx
+++ b/packages/web/src/providers/snackbar-provider/snackbar/contents/StakePositionContent.tsx
@@ -25,7 +25,7 @@ const StakePositionContent: React.FC<{ content?: SnackbarContent; onClick: () =>
   };
 
   return (
-    <div className="notice-body clickable" onClick={onClick}>
+    <div className="notice-body" onClick={onClick}>
       <div className="icon-wrap-wrapper">
         <Image mobileWidth={24} width={36} src={content?.logoUrl || ""} alt="logo" />
       </div>


### PR DESCRIPTION
## Summary

Removes the `clickable` class from the notice body wrapper in two snackbar content components so the toast no longer shows a **pointer (clickable) cursor** over the entire body area.

## Motivation

The notice body still handles `onClick`, but styling it as globally “clickable” suggested the whole surface was an explicit link-style control. Dropping the `clickable` class aligns the cursor with the intended UX: avoid implying the full notice region is a primary click target.

## Changes

- **`ReceiveWugnotContent.tsx`**: `notice-body clickable` → `notice-body`
- **`StakePositionContent.tsx`**: same