### PR TITLE
style(snackbar): update link styles and class names

### DIFF
--- a/packages/web/src/providers/snackbar-provider/snackbar/contents/FailContent.tsx
+++ b/packages/web/src/providers/snackbar-provider/snackbar/contents/FailContent.tsx
@@ -32,7 +32,7 @@ const FailContent: React.FC<{ content?: SnackbarContent }> = ({ content }: { con
       <div>
         <h5>{t("Modal:toast.failed.title")}</h5>
         <p>{t("Modal:toast.failed.desc")}</p>
-        <a href={getGnoscanUrl(GnoscanDataType.Transactions)} target="_blank">
+        <a className="link" href={getGnoscanUrl(GnoscanDataType.Transactions)} target="_blank">
           {t("Modal:toast.failed.viewTx")} <IconNewTab />
         </a>
       </div>

--- a/packages/web/src/providers/snackbar-provider/snackbar/contents/PendingContent.tsx
+++ b/packages/web/src/providers/snackbar-provider/snackbar/contents/PendingContent.tsx
@@ -29,7 +29,7 @@ const PendingContent: React.FC<{ content?: SnackbarContent }> = ({ content }: { 
       <div>
         <h5>{t("Modal:toast.pending.title")}</h5>
         <p className="waiting-confirmation">{t("Modal:toast.pending.desc")}</p>
-        <a href={getGnoscanUrl(GnoscanDataType.Transactions)} target="_blank">
+        <a className="link" href={getGnoscanUrl(GnoscanDataType.Transactions)} target="_blank">
           {t("Modal:toast.pending.viewTx")} <IconNewTab />
         </a>
       </div>

--- a/packages/web/src/providers/snackbar-provider/snackbar/contents/ReceiveWugnotContent.tsx
+++ b/packages/web/src/providers/snackbar-provider/snackbar/contents/ReceiveWugnotContent.tsx
@@ -39,7 +39,7 @@ const ReceiveWugnotContent: React.FC<{ content?: SnackbarContent; onClick: () =>
             __html: sanitizeHtml(content?.description || t("Modal:toast.receive-wugnot.desc")),
           }}
         />
-        <a href={getUnwrapUrl()} target="_blank" rel="noopener noreferrer" onClick={onClickLink}>
+        <a className="link" href={getUnwrapUrl()} target="_blank" rel="noopener noreferrer" onClick={onClickLink}>
           {t("Modal:toast.receive-wugnot.link")} <IconArrowRight />
         </a>
       </div>

--- a/packages/web/src/providers/snackbar-provider/snackbar/contents/StakePositionContent.tsx
+++ b/packages/web/src/providers/snackbar-provider/snackbar/contents/StakePositionContent.tsx
@@ -38,7 +38,7 @@ const StakePositionContent: React.FC<{ content?: SnackbarContent; onClick: () =>
               __html: sanitizeHtml(content?.description || t("Modal:toast.stake-position.desc")),
             }}
           />
-          <a onClick={onClickLink}>
+          <a className="link" onClick={onClickLink}>
             {t("Modal:toast.stake-position.link")} <IconArrowRightLine />
           </a>
         </div>

--- a/packages/web/src/providers/snackbar-provider/snackbar/contents/SuccessContent.tsx
+++ b/packages/web/src/providers/snackbar-provider/snackbar/contents/SuccessContent.tsx
@@ -32,7 +32,7 @@ const SuccessContent: React.FC<{ content?: SnackbarContent }> = ({ content }) =>
       <div>
         <h5>{t("Modal:toast.success.title")}</h5>
         <p>{t("Modal:toast.success.defaultDesc")}</p>
-        <a href={getGnoscanUrl(GnoscanDataType.Transactions)} target="_blank">
+        <a className="link" href={getGnoscanUrl(GnoscanDataType.Transactions)} target="_blank">
           {t("Modal:toast.success.viewTx")} <IconNewTab />
         </a>
       </div>

--- a/packages/web/src/providers/snackbar-provider/snackbar/contents/UpdatingContent.tsx
+++ b/packages/web/src/providers/snackbar-provider/snackbar/contents/UpdatingContent.tsx
@@ -29,7 +29,7 @@ const UpdatingContent: React.FC<{ content?: SnackbarContent }> = ({ content }: {
       <div>
         <h5>{t("Modal:toast.updating.title")}</h5>
         <p className="waiting-confirmation">{t("Modal:toast.updating.desc")}</p>
-        <a href={getGnoscanUrl(GnoscanDataType.Transactions)} target="_blank">
+        <a className="link" href={getGnoscanUrl(GnoscanDataType.Transactions)} target="_blank">
           {t("Modal:toast.pending.viewTx")} <IconNewTab />
         </a>
       </div>

--- a/packages/web/src/providers/snackbar-provider/snackbar/contents/UpdatingDoneContent.tsx
+++ b/packages/web/src/providers/snackbar-provider/snackbar/contents/UpdatingDoneContent.tsx
@@ -29,7 +29,7 @@ const UpdatingDoneContent: React.FC<{ content?: SnackbarContent }> = ({ content 
       <div>
         <h5>{t("Modal:toast.updating.title")}</h5>
         <p className="waiting-confirmation">{t("Modal:toast.updating.desc")}</p>
-        <a href={getGnoscanUrl(GnoscanDataType.Transactions)} target="_blank">
+        <a className="link" href={getGnoscanUrl(GnoscanDataType.Transactions)} target="_blank">
           {t("Modal:toast.pending.viewTx")} <IconNewTab />
         </a>
       </div>

--- a/packages/web/src/providers/snackbar-provider/snackbar/snackbar.styles.ts
+++ b/packages/web/src/providers/snackbar-provider/snackbar/snackbar.styles.ts
@@ -122,12 +122,14 @@ export const SnackbarWrapper = styled.div`
           ${fonts.p2}
         }
       }
-      a {
-        width: 100%;
+      a,.link {
         ${mixins.flexbox("row", "center", "flex-start")};
         ${fonts.body11}
+        width: fit-content;
         color: ${({ theme }) => theme.color.text04};
         gap: 4px;
+        cursor: pointer;
+
         ${media.mobile} {
           ${fonts.p2}
         }


### PR DESCRIPTION
## Summary

- **Snackbar / toast UX**: Remove the pointer cursor from non-link areas of toast bodies (`ReceiveWugnotContent`, `StakePositionContent`) and scope link styling to a dedicated `.link` class so only actionable links show `cursor: pointer` with `width: fit-content`.

## Changes

### Snackbar
- Drop `clickable` class from `notice-body` in receive-wUGNOT and stake-position toasts.
- Add `className="link"` to all snackbar anchor elements (success, fail, pending, updating, etc.).
- Update `snackbar.styles.ts`: style `a` → `.link` with `width: fit-content` and explicit `cursor: pointer`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual styling for transaction links and action links displayed in notification messages. Links now render with consistent styling, appropriate sizing, and enhanced cursor interaction feedback for better usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/886)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->