### PR TITLE
fix(pool): count positions by closed filter

### DIFF
--- a/packages/web/src/layouts/earn/containers/earn-my-position-container/EarnMyPositionContainer.tsx
+++ b/packages/web/src/layouts/earn/containers/earn-my-position-container/EarnMyPositionContainer.tsx
@@ -12,6 +12,7 @@ import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { useConnectWalletModal } from "@hooks/wallet/ui/use-connect-wallet-modal";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { useGetUsernameByAddress } from "@query/address";
+import { useGetPositionsByAddress } from "@query/positions";
 import { EarnState, ThemeState } from "@states/index";
 
 import { PositionConverter } from "@services/converters/position";
@@ -64,7 +65,15 @@ const EarnMyPositionContainer: React.FC<EarnMyPositionContainerProps> = ({
     address,
     page,
     limit,
+    withClosed: isClosed,
     scopeId: "EarnMyPositionContainer",
+  });
+
+  const { data: oppositePositionData } = useGetPositionsByAddress({
+    address,
+    page: 1,
+    limit: 1,
+    withClosed: !isClosed,
   });
 
   const [mappedData, setMappedData] = useState<PoolPositionModel[]>([]);
@@ -246,13 +255,16 @@ const EarnMyPositionContainer: React.FC<EarnMyPositionContainerProps> = ({
   }, []);
 
   const visiblePositions = useMemo(() => {
-    const noClosedPosition = closedPosition.length <= 0;
+    const oppositeTotalPositionCount = oppositePositionData?.totalCount ?? 0;
+    const openedTotalPositionCount = isClosed ? oppositeTotalPositionCount : totalPositionCount;
+    const allTotalPositionCount = isClosed ? totalPositionCount : oppositeTotalPositionCount;
 
-    if ((!connected && !address) || noClosedPosition) {
+    if (!connected && !address) {
       return false;
     }
-    return true;
-  }, [address, closedPosition.length, connected]);
+
+    return allTotalPositionCount > openedTotalPositionCount;
+  }, [address, connected, isClosed, oppositePositionData?.totalCount, totalPositionCount]);
 
   const getMappedData = (): PoolPositionModel[] => {
     if (isViewMorePositions) {

--- a/packages/web/src/layouts/earn/containers/earn-my-position-container/EarnMyPositionContainer.tsx
+++ b/packages/web/src/layouts/earn/containers/earn-my-position-container/EarnMyPositionContainer.tsx
@@ -12,7 +12,6 @@ import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { useConnectWalletModal } from "@hooks/wallet/ui/use-connect-wallet-modal";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { useGetUsernameByAddress } from "@query/address";
-import { useGetPositionsByAddress } from "@query/positions";
 import { EarnState, ThemeState } from "@states/index";
 
 import { PositionConverter } from "@services/converters/position";
@@ -68,18 +67,6 @@ const EarnMyPositionContainer: React.FC<EarnMyPositionContainerProps> = ({
     withClosed: isClosed,
     scopeId: "EarnMyPositionContainer",
   });
-
-  const { data: allPositionData } = useGetPositionsByAddress(
-    {
-      address,
-      page: 1,
-      limit: 1,
-      withClosed: true,
-    },
-    {
-      enabled: !isClosed,
-    },
-  );
 
   const [mappedData, setMappedData] = useState<PoolPositionModel[]>([]);
   const [isDataMappingLoading, setIsDataMappingLoading] = useState(true);
@@ -260,18 +247,8 @@ const EarnMyPositionContainer: React.FC<EarnMyPositionContainerProps> = ({
   }, []);
 
   const visiblePositions = useMemo(() => {
-    if (!connected && !address) {
-      return false;
-    }
-
-    if (isClosed) {
-      return true;
-    }
-
-    const allTotalPositionCount = allPositionData?.totalCount ?? totalPositionCount;
-
-    return allTotalPositionCount > totalPositionCount;
-  }, [address, allPositionData?.totalCount, connected, isClosed, totalPositionCount]);
+    return connected || !!address;
+  }, [address, connected]);
 
   const getMappedData = (): PoolPositionModel[] => {
     if (isViewMorePositions) {

--- a/packages/web/src/layouts/earn/containers/earn-my-position-container/EarnMyPositionContainer.tsx
+++ b/packages/web/src/layouts/earn/containers/earn-my-position-container/EarnMyPositionContainer.tsx
@@ -69,12 +69,17 @@ const EarnMyPositionContainer: React.FC<EarnMyPositionContainerProps> = ({
     scopeId: "EarnMyPositionContainer",
   });
 
-  const { data: oppositePositionData } = useGetPositionsByAddress({
-    address,
-    page: 1,
-    limit: 1,
-    withClosed: !isClosed,
-  });
+  const { data: allPositionData } = useGetPositionsByAddress(
+    {
+      address,
+      page: 1,
+      limit: 1,
+      withClosed: true,
+    },
+    {
+      enabled: !isClosed,
+    },
+  );
 
   const [mappedData, setMappedData] = useState<PoolPositionModel[]>([]);
   const [isDataMappingLoading, setIsDataMappingLoading] = useState(true);
@@ -255,16 +260,18 @@ const EarnMyPositionContainer: React.FC<EarnMyPositionContainerProps> = ({
   }, []);
 
   const visiblePositions = useMemo(() => {
-    const oppositeTotalPositionCount = oppositePositionData?.totalCount ?? 0;
-    const openedTotalPositionCount = isClosed ? oppositeTotalPositionCount : totalPositionCount;
-    const allTotalPositionCount = isClosed ? totalPositionCount : oppositeTotalPositionCount;
-
     if (!connected && !address) {
       return false;
     }
 
-    return allTotalPositionCount > openedTotalPositionCount;
-  }, [address, connected, isClosed, oppositePositionData?.totalCount, totalPositionCount]);
+    if (isClosed) {
+      return true;
+    }
+
+    const allTotalPositionCount = allPositionData?.totalCount ?? totalPositionCount;
+
+    return allTotalPositionCount > totalPositionCount;
+  }, [address, allPositionData?.totalCount, connected, isClosed, totalPositionCount]);
 
   const getMappedData = (): PoolPositionModel[] => {
     if (isViewMorePositions) {

--- a/packages/web/src/layouts/pool/pool-detail/PoolDetail.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/PoolDetail.tsx
@@ -56,6 +56,7 @@ const PoolDetail: React.FC = () => {
   const { isFetchedPosition, loading, positions } = usePositionData({
     address: urlAddress ?? connectAddress,
     poolPath,
+    withClosed: false,
     queryOption: {
       enabled: !!poolPath,
     },

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/MyLiquidity.tsx
@@ -33,6 +33,7 @@ interface MyLiquidityProps {
   isStakable: boolean;
   isShowRemovePositionButton: boolean;
   loading: boolean;
+  isHeaderLoading: boolean;
   loadingTransactionClaim: boolean;
   isShowClosePosition: boolean;
   handleSetIsClosePosition: () => void;
@@ -63,6 +64,7 @@ const MyLiquidity: React.FC<MyLiquidityProps> = ({
   isStakable,
   isShowRemovePositionButton,
   loading,
+  isHeaderLoading,
   loadingTransactionClaim,
   isShowClosePosition,
   handleSetIsClosePosition,
@@ -99,7 +101,7 @@ const MyLiquidity: React.FC<MyLiquidityProps> = ({
           handleSetIsClosePosition={handleSetIsClosePosition}
           isHiddenAddPosition={isHiddenAddPosition}
           showClosePositionButton={showClosePositionButton}
-          isLoadingPositionsById={loading}
+          isLoadingPositionsById={isHeaderLoading}
         />
         <MyLiquidityContent
           connected={connected}

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -53,6 +53,7 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   const poolPath = router.getPoolPath();
   const normalizedAddress = useMemo(() => (address || "").toLowerCase(), [address]);
   const [isShowClosePosition, setIsShowClosedPosition] = useState(false);
+  const [hasLoadedPositionOnce, setHasLoadedPositionOnce] = useState(false);
 
   const positionScopeId = useMemo(() => {
     return ["my-liquidity", address || "", poolPath || "", positionLimit].join("-");
@@ -60,6 +61,7 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
 
   useEffect(() => {
     setPositionLimit(DEFAULT_POSITION_LIMIT);
+    setHasLoadedPositionOnce(false);
   }, [address, poolPath]);
 
   const {
@@ -114,6 +116,16 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
       position => position.poolPath === poolPath && position.owner.toLowerCase() === normalizedAddress,
     );
   }, [address, poolPath, positions, normalizedAddress]);
+
+  useEffect(() => {
+    if (!isLoadingPosition) {
+      setHasLoadedPositionOnce(true);
+    }
+  }, [isLoadingPosition]);
+
+  const isHeaderLoading = useMemo(() => {
+    return isLoadingPosition && !hasLoadedPositionOnce;
+  }, [hasLoadedPositionOnce, isLoadingPosition]);
 
   const { invalidateQueryKey } = useInvalidateQueries();
 
@@ -371,6 +383,7 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
       isStakable={isStakable}
       isShowRemovePositionButton={isShowRemovePositionButton}
       loading={isLoadingPosition}
+      isHeaderLoading={isHeaderLoading}
       loadingTransactionClaim={loadingTransactionClaim}
       isShowClosePosition={isShowClosePosition}
       handleSetIsClosePosition={handleSetIsClosePosition}

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -12,6 +12,7 @@ import { usePositionData } from "@hooks/pool/data/use-position-data";
 import { useTokenData } from "@hooks/token/data/use-token-data";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { useGetUsernameByAddress } from "@query/address";
+import { useGetPositionsByAddress } from "@query/positions";
 import { QUERY_KEY } from "@query/query-keys";
 import { DexEvent } from "@repositories/common";
 import { delay } from "@utils/common";
@@ -77,6 +78,20 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
       enabled: !!poolPath,
     },
   });
+
+  const { data: closedPositionCheck, isFetched: isFetchedClosedPositionCheck } = useGetPositionsByAddress(
+    {
+      address,
+      poolPath,
+      page: 1,
+      limit: 1,
+      isClosed: true,
+      withClosed: true,
+    },
+    {
+      enabled: !!address && !!poolPath,
+    },
+  );
 
   const loadedPositions = useMemo<PoolPositionModel[]>(() => {
     if (!address || !poolPath) {
@@ -274,6 +289,16 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     setIsShowClosedPosition(!isShowClosePosition);
   };
 
+  const haveClosedPosition = useMemo(() => {
+    return (closedPositionCheck?.totalCount ?? 0) > 0;
+  }, [closedPositionCheck?.totalCount]);
+
+  useEffect(() => {
+    if (isFetchedClosedPositionCheck && !haveClosedPosition && isShowClosePosition) {
+      setIsShowClosedPosition(false);
+    }
+  }, [haveClosedPosition, isFetchedClosedPositionCheck, isShowClosePosition]);
+
   const closedPosition = useMemo(() => {
     return (
       accountPositions
@@ -290,8 +315,8 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     if (!connectedWallet || isSwitchNetwork) {
       return false;
     }
-    return !!address;
-  }, [address, connectedWallet, isSwitchNetwork]);
+    return isFetchedClosedPositionCheck && haveClosedPosition;
+  }, [connectedWallet, haveClosedPosition, isFetchedClosedPositionCheck, isSwitchNetwork]);
 
   const isShowRemovePositionButton = useMemo(() => {
     if (!connectedWallet || isSwitchNetwork) {

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -51,6 +51,7 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   const [positionLimit, setPositionLimit] = useState(DEFAULT_POSITION_LIMIT);
   const poolPath = router.getPoolPath();
   const normalizedAddress = useMemo(() => (address || "").toLowerCase(), [address]);
+  const [isShowClosePosition, setIsShowClosedPosition] = useState(false);
 
   const positionScopeId = useMemo(() => {
     return ["my-liquidity", address || "", poolPath || "", positionLimit].join("-");
@@ -70,6 +71,7 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     poolPath,
     page: 1,
     limit: positionLimit,
+    withClosed: isShowClosePosition,
     scopeId: positionScopeId,
     queryOption: {
       enabled: !!poolPath,
@@ -98,7 +100,6 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
 
   const { claimAll, claim } = usePosition(loadedPositions.filter(item => !item.closed));
   const [loadingTransactionClaim, setLoadingTransactionClaim] = useState(false);
-  const [isShowClosePosition, setIsShowClosedPosition] = useState(false);
   const { openModal } = useTransactionConfirmModal();
   const { tokenPrices, updateBalances, refetchGrc20Balances } = useTokenData();
 
@@ -283,15 +284,14 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     );
   }, [accountPositions]);
 
-  const haveClosedPosition = useMemo(() => closedPosition.length > 0, [closedPosition.length]);
   const haveNotClosedPosition = useMemo(() => openedPosition.length > 0, [openedPosition.length]);
 
   const showClosePositionButton = useMemo(() => {
     if (!connectedWallet || isSwitchNetwork) {
       return false;
     }
-    return haveClosedPosition;
-  }, [connectedWallet, haveClosedPosition, isSwitchNetwork]);
+    return !!address;
+  }, [address, connectedWallet, isSwitchNetwork]);
 
   const isShowRemovePositionButton = useMemo(() => {
     if (!connectedWallet || isSwitchNetwork) {

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -79,13 +79,25 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     },
   });
 
-  const { data: closedPositionCheck, isFetched: isFetchedClosedPositionCheck } = useGetPositionsByAddress(
+  const { data: openPositionCountData, isFetched: isFetchedOpenPositionCount } = useGetPositionsByAddress(
     {
       address,
       poolPath,
       page: 1,
       limit: 1,
-      isClosed: true,
+      withClosed: false,
+    },
+    {
+      enabled: !!address && !!poolPath,
+    },
+  );
+
+  const { data: allPositionCountData, isFetched: isFetchedAllPositionCount } = useGetPositionsByAddress(
+    {
+      address,
+      poolPath,
+      page: 1,
+      limit: 1,
       withClosed: true,
     },
     {
@@ -289,15 +301,15 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     setIsShowClosedPosition(!isShowClosePosition);
   };
 
-  const haveClosedPosition = useMemo(() => {
-    return (closedPositionCheck?.totalCount ?? 0) > 0;
-  }, [closedPositionCheck?.totalCount]);
+  const hasMeaningfulClosedToggle = useMemo(() => {
+    return (allPositionCountData?.totalCount ?? 0) > (openPositionCountData?.totalCount ?? 0);
+  }, [allPositionCountData?.totalCount, openPositionCountData?.totalCount]);
 
   useEffect(() => {
-    if (isFetchedClosedPositionCheck && !haveClosedPosition && isShowClosePosition) {
+    if (isFetchedAllPositionCount && isFetchedOpenPositionCount && !hasMeaningfulClosedToggle && isShowClosePosition) {
       setIsShowClosedPosition(false);
     }
-  }, [haveClosedPosition, isFetchedClosedPositionCheck, isShowClosePosition]);
+  }, [hasMeaningfulClosedToggle, isFetchedAllPositionCount, isFetchedOpenPositionCount, isShowClosePosition]);
 
   const closedPosition = useMemo(() => {
     return (
@@ -315,8 +327,8 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     if (!connectedWallet || isSwitchNetwork) {
       return false;
     }
-    return isFetchedClosedPositionCheck && haveClosedPosition;
-  }, [connectedWallet, haveClosedPosition, isFetchedClosedPositionCheck, isSwitchNetwork]);
+    return isFetchedAllPositionCount && isFetchedOpenPositionCount && hasMeaningfulClosedToggle;
+  }, [connectedWallet, hasMeaningfulClosedToggle, isFetchedAllPositionCount, isFetchedOpenPositionCount, isSwitchNetwork]);
 
   const isShowRemovePositionButton = useMemo(() => {
     if (!connectedWallet || isSwitchNetwork) {

--- a/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/my-liquidity-container/MyLiquidityContainer.tsx
@@ -12,7 +12,6 @@ import { usePositionData } from "@hooks/pool/data/use-position-data";
 import { useTokenData } from "@hooks/token/data/use-token-data";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { useGetUsernameByAddress } from "@query/address";
-import { useGetPositionsByAddress } from "@query/positions";
 import { QUERY_KEY } from "@query/query-keys";
 import { DexEvent } from "@repositories/common";
 import { delay } from "@utils/common";
@@ -55,7 +54,7 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   const [isShowClosePosition, setIsShowClosedPosition] = useState(false);
   const [hasLoadedPositionOnce, setHasLoadedPositionOnce] = useState(false);
 
-  const positionScopeId = useMemo(() => {
+  const positionScopeIdPrefix = useMemo(() => {
     return ["my-liquidity", address || "", poolPath || "", positionLimit].join("-");
   }, [address, poolPath, positionLimit]);
 
@@ -64,48 +63,37 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     setHasLoadedPositionOnce(false);
   }, [address, poolPath]);
 
-  const {
-    positions: positions,
-    loading: isLoadingPosition,
-    refetch: refetchPositions,
-    totalPositionCount,
-  } = usePositionData({
+  const openPositionData = usePositionData({
     address,
     poolPath,
     page: 1,
     limit: positionLimit,
-    withClosed: isShowClosePosition,
-    scopeId: positionScopeId,
+    withClosed: false,
+    scopeId: `${positionScopeIdPrefix}-open`,
     queryOption: {
       enabled: !!poolPath,
     },
   });
 
-  const { data: openPositionCountData, isFetched: isFetchedOpenPositionCount } = useGetPositionsByAddress(
-    {
-      address,
-      poolPath,
-      page: 1,
-      limit: 1,
-      withClosed: false,
+  const allPositionData = usePositionData({
+    address,
+    poolPath,
+    page: 1,
+    limit: positionLimit,
+    withClosed: true,
+    scopeId: `${positionScopeIdPrefix}-all`,
+    queryOption: {
+      enabled: !!poolPath,
     },
-    {
-      enabled: !!address && !!poolPath,
-    },
-  );
+  });
 
-  const { data: allPositionCountData, isFetched: isFetchedAllPositionCount } = useGetPositionsByAddress(
-    {
-      address,
-      poolPath,
-      page: 1,
-      limit: 1,
-      withClosed: true,
-    },
-    {
-      enabled: !!address && !!poolPath,
-    },
-  );
+  const activePositionData = isShowClosePosition ? allPositionData : openPositionData;
+  const {
+    positions,
+    loading: isLoadingPosition,
+    refetch: refetchPositions,
+    totalPositionCount,
+  } = activePositionData;
 
   const loadedPositions = useMemo<PoolPositionModel[]>(() => {
     if (!address || !poolPath) {
@@ -314,14 +302,24 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
   };
 
   const hasMeaningfulClosedToggle = useMemo(() => {
-    return (allPositionCountData?.totalCount ?? 0) > (openPositionCountData?.totalCount ?? 0);
-  }, [allPositionCountData?.totalCount, openPositionCountData?.totalCount]);
+    return allPositionData.totalPositionCount > openPositionData.totalPositionCount;
+  }, [allPositionData.totalPositionCount, openPositionData.totalPositionCount]);
 
   useEffect(() => {
-    if (isFetchedAllPositionCount && isFetchedOpenPositionCount && !hasMeaningfulClosedToggle && isShowClosePosition) {
+    if (
+      allPositionData.isFetchedPosition &&
+      openPositionData.isFetchedPosition &&
+      !hasMeaningfulClosedToggle &&
+      isShowClosePosition
+    ) {
       setIsShowClosedPosition(false);
     }
-  }, [hasMeaningfulClosedToggle, isFetchedAllPositionCount, isFetchedOpenPositionCount, isShowClosePosition]);
+  }, [
+    allPositionData.isFetchedPosition,
+    hasMeaningfulClosedToggle,
+    isShowClosePosition,
+    openPositionData.isFetchedPosition,
+  ]);
 
   const closedPosition = useMemo(() => {
     return (
@@ -339,8 +337,14 @@ const MyLiquidityContainer: React.FC<MyLiquidityContainerProps> = ({ isStakable,
     if (!connectedWallet || isSwitchNetwork) {
       return false;
     }
-    return isFetchedAllPositionCount && isFetchedOpenPositionCount && hasMeaningfulClosedToggle;
-  }, [connectedWallet, hasMeaningfulClosedToggle, isFetchedAllPositionCount, isFetchedOpenPositionCount, isSwitchNetwork]);
+    return allPositionData.isFetchedPosition && openPositionData.isFetchedPosition && hasMeaningfulClosedToggle;
+  }, [
+    allPositionData.isFetchedPosition,
+    connectedWallet,
+    hasMeaningfulClosedToggle,
+    isSwitchNetwork,
+    openPositionData.isFetchedPosition,
+  ]);
 
   const isShowRemovePositionButton = useMemo(() => {
     if (!connectedWallet || isSwitchNetwork) {

--- a/packages/web/src/layouts/pool/pool-detail/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
@@ -37,6 +37,7 @@ const PoolPairInformationContainer: React.FC<PoolPairInformationContainerProps> 
   const { loading: loadingPosition } = usePositionData({
     address,
     poolPath,
+    withClosed: false,
     queryOption: {
       enabled: !!poolPath,
     },

--- a/packages/web/src/layouts/pool/pool-detail/containers/staking-container/StakingContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/staking-container/StakingContainer.tsx
@@ -47,6 +47,7 @@ const StakingContainer: React.FC<StakingContainerProps> = ({ hasPoolStaking, onO
   const { positions: allPositions, loading: isLoadingPosition } = usePositionData({
     address,
     poolPath,
+    withClosed: false,
     queryOption: {
       enabled: !!poolPath,
     },

--- a/packages/web/src/react-query/positions/use-get-positions-by-address.ts
+++ b/packages/web/src/react-query/positions/use-get-positions-by-address.ts
@@ -21,7 +21,10 @@ interface UseGetPositionsByAddressProps {
 
 export const useGetPositionsByAddress = (
   props?: UseGetPositionsByAddressProps,
-  options?: UseQueryOptions<GetPositionsByAddressResult, Error>,
+  options?: Omit<
+    UseQueryOptions<GetPositionsByAddressResult, Error, GetPositionsByAddressResult>,
+    "queryKey" | "queryFn"
+  >,
 ) => {
   const { positionRepository } = useGnoswapContext();
   const { account, currentChainId, availNetwork } = useWallet();
@@ -34,8 +37,8 @@ export const useGetPositionsByAddress = (
     return props?.poolPath || "";
   }, [props?.poolPath]);
 
-  return useQuery<GetPositionsByAddressResult, Error>({
-    queryKey: [
+  return useQuery<GetPositionsByAddressResult, Error, GetPositionsByAddressResult>(
+    [
       QUERY_KEY.positions,
       currentChainId,
       address,
@@ -46,7 +49,7 @@ export const useGetPositionsByAddress = (
       props?.isClosed,
       props?.withAvailableStake,
     ],
-    queryFn: async () => {
+    async () => {
       if (!availNetwork || !address) {
         return { positions: [], totalCount: 0 };
       }
@@ -65,19 +68,21 @@ export const useGetPositionsByAddress = (
           return { positions: [], totalCount: 0 };
         });
     },
-    select: data => {
-      if (props?.isClosed === undefined) {
-        return data;
-      }
-      return {
-        positions: data.positions.filter(p => p.closed === props.isClosed),
-        totalCount: data.totalCount,
-      };
+    {
+      select: data => {
+        if (props?.isClosed === undefined) {
+          return data;
+        }
+        return {
+          positions: data.positions.filter(p => p.closed === props.isClosed),
+          totalCount: data.totalCount,
+        };
+      },
+      keepPreviousData: true,
+      refetchInterval: REFETCH_INTERVAL,
+      refetchOnMount: true,
+      refetchOnReconnect: true,
+      ...options,
     },
-    keepPreviousData: true,
-    refetchInterval: REFETCH_INTERVAL,
-    refetchOnMount: true,
-    refetchOnReconnect: true,
-    ...options,
-  });
+  );
 };

--- a/packages/web/src/react-query/positions/use-make-pool-positions.ts
+++ b/packages/web/src/react-query/positions/use-make-pool-positions.ts
@@ -17,7 +17,12 @@ export const useMakePoolPositions = (
   options?: UseQueryOptions<PoolPositionModel[], Error>,
 ) => {
   const query = useQuery<PoolPositionModel[], Error>({
-    queryKey: [QUERY_KEY.poolPositions, scopeId],
+    queryKey: [
+      QUERY_KEY.poolPositions,
+      scopeId,
+      positions?.map(position => `${position.id}:${position.closed}`).join(",") ?? "",
+      pools.map(pool => pool.poolPath).join(","),
+    ],
     queryFn: async () => {
       return new Promise(resolve => {
         const poolPositions: PoolPositionModel[] = [];


### PR DESCRIPTION
## Summary
- Pass the Show Closed state through the existing `withClosed` position request parameter.
- Use API `totalCount` semantics for My Positions count: open-only when Show Closed is off, all positions when it is on.
- Keep the Show Closed toggle visible only when closed positions exist, without adding a new API response field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of position display when toggling between closed and open positions to better reflect available positions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/887)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->