### PR TITLE
style: adjust padding for available staking pools rows

### DIFF
--- a/packages/web/src/layouts/pool/pool-stake/components/available-staking-pools/AvailableStakingPools.styles.ts
+++ b/packages/web/src/layouts/pool/pool-stake/components/available-staking-pools/AvailableStakingPools.styles.ts
@@ -20,6 +20,12 @@ export const wrapper = (theme: Theme) => css`
     ${fonts.body9}
     color: ${theme.color.text02};
     margin-bottom: 8px;
+    
+    padding: 0 24px;
+
+    ${media.mobile} {
+      padding: 0 11px;
+    }
   }
 
   .pools-card {
@@ -28,11 +34,11 @@ export const wrapper = (theme: Theme) => css`
     background-color: ${theme.color.background20};
     border: 1px solid ${theme.color.border02};
     border-radius: 8px;
-    padding: 24px;
     gap: 4px;
+    padding: 24px 0;
 
     ${media.mobile} {
-      padding: 11px;
+      padding: 11px 0;
     }
   }
 
@@ -51,6 +57,12 @@ export const wrapper = (theme: Theme) => css`
     height: 36px;
     color: ${theme.color.text02};
     ${fonts.body12};
+    
+    padding: 0 24px;
+
+    ${media.mobile} {
+      padding: 0 11px;
+    }
   }
 
   .pools-table .pools-row {


### PR DESCRIPTION
## Summary

- Refactor horizontal padding on the **Available Staking Pools** section so row hover backgrounds span the full width of the pools card.
- Move horizontal inset from `.pools-card` to `.section-title` and `.pools-row`, keeping vertical spacing on the card (`24px 0` desktop, `11px 0` mobile).
- Apply responsive horizontal padding (`24px` desktop, `11px` mobile) on section title and table rows so content alignment stays the same while hover states look correct.

## Context

Previously, uniform padding on `.pools-card` clipped row hover backgrounds at the card’s inner edge. Padding is now applied per row (and on the section title), so interactive rows can use the full card width for `:hover` while text and columns remain aligned.

## Changes

| Area | Before | After |
|------|--------|-------|
| `.pools-card` | `padding: 24px` / `11px` (mobile) | `padding: 24px 0` / `11px 0` (mobile) |
| `.section-title`, `.pools-row` | — | `padding: 0 24px` / `0 11px` (mobile) |

**Files changed:** `packages/web/src/layouts/pool/pool-stake/components/available-staking-pools/AvailableStakingPools.styles.ts`
