### PR TITLE
fix(snackbar): fit badge images

### DIFF
--- a/packages/web/src/providers/snackbar-provider/snackbar-provider.styles.ts
+++ b/packages/web/src/providers/snackbar-provider/snackbar-provider.styles.ts
@@ -17,7 +17,7 @@ export const SnackbarList = styled.div`
   }
   ${media.mobile} {
     width: 328px;
-    top: 0px;
+    top: calc(env(safe-area-inset-top, 0px) + 56px);
     left: 50%;
     transform: translateX(-50%);
     right: auto;

--- a/packages/web/src/providers/snackbar-provider/snackbar/contents/StakePositionContent.tsx
+++ b/packages/web/src/providers/snackbar-provider/snackbar/contents/StakePositionContent.tsx
@@ -26,8 +26,8 @@ const StakePositionContent: React.FC<{ content?: SnackbarContent; onClick: () =>
 
   return (
     <div className="notice-body" onClick={onClick}>
-      <div className="icon-wrap-wrapper">
-        <Image mobileWidth={24} width={36} src={content?.logoUrl || ""} alt="logo" />
+      <div className="icon-wrap-wrapper nft-image-wrapper">
+        <Image className="nft-image" mobileWidth={20} width={32} src={content?.logoUrl || ""} alt="logo" />
       </div>
       <div>
         <div>

--- a/packages/web/src/providers/snackbar-provider/snackbar/snackbar.styles.ts
+++ b/packages/web/src/providers/snackbar-provider/snackbar/snackbar.styles.ts
@@ -190,9 +190,9 @@ export const SnackbarWrapper = styled.div`
       }
 
       ${media.mobile} {
-        width: 16px;
-        height: 16px;
-        flex-basis: 16px;
+        width: 20px;
+        height: 20px;
+        flex-basis: 20px;
       }
     }
   }

--- a/packages/web/src/providers/snackbar-provider/snackbar/snackbar.styles.ts
+++ b/packages/web/src/providers/snackbar-provider/snackbar/snackbar.styles.ts
@@ -94,7 +94,7 @@ export const SnackbarWrapper = styled.div`
         }
       }
     }
-    > div {
+    > div:not(.icon-wrap-wrapper) {
       ${mixins.flexbox("column", "flex-start", "flex-start")};
 
       gap: 8px;

--- a/packages/web/src/providers/snackbar-provider/snackbar/snackbar.styles.ts
+++ b/packages/web/src/providers/snackbar-provider/snackbar/snackbar.styles.ts
@@ -157,18 +157,43 @@ export const SnackbarWrapper = styled.div`
       display: flex;
       width: 36px;
       height: 36px;
+      min-width: 36px;
+      flex: 0 0 36px;
       background-color: ${({ theme }) => theme.color.point};
       border-radius: 50%;
       justify-content: center;
       align-items: center;
+
+      &.nft-image-wrapper {
+        background-color: transparent;
+        border-radius: 0;
+
+        .nft-image {
+          object-fit: contain;
+        }
+      }
+
+      ${media.mobile} {
+        width: 24px;
+        height: 24px;
+        min-width: 24px;
+        flex-basis: 24px;
+      }
     }
 
     .icon-wrap {
       display: flex;
       width: 24px;
       height: 24px;
+      flex: 0 0 24px;
       * {
         fill: ${({ theme }) => theme.color.background06};
+      }
+
+      ${media.mobile} {
+        width: 16px;
+        height: 16px;
+        flex-basis: 16px;
       }
     }
   }

--- a/packages/web/src/providers/snackbar-provider/snackbar/snackbar.styles.ts
+++ b/packages/web/src/providers/snackbar-provider/snackbar/snackbar.styles.ts
@@ -40,7 +40,6 @@ export const SnackbarWrapper = styled.div`
   }
   ${media.mobile} {
     width: 100%;
-    top: 16px;
     height: fit-content;
     padding: 15px;
   }


### PR DESCRIPTION
## Summary
- Fix snackbar badge image sizing for stake-position NFT and receive-wUGNOT unwrap notices around the 768px breakpoint.
- Remove the blue circular background behind the stake-position NFT image.
- Keep badge wrappers fixed in flex layout so images do not overflow or shrink unpredictably.

## Verification
- LSP diagnostics: no diagnostics for modified files
- yarn workspace @gnoswap-labs/web lint
- yarn build

## Jira
- https://onbloc.atlassian.net/browse/GSW-2693

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined visual presentation of stake position notifications in snackbar messages.
  * Improved mobile responsiveness with optimized image sizing and layout adjustments.
  * Enhanced spacing and alignment for better display consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->