### PR TITLE
refactir(pool): use refunded incentive flag

### DIFF
--- a/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
@@ -97,18 +97,18 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
     return new BigNumber(stakingData.claimableUnvestedAmount || "0").isGreaterThan(0);
   }, [stakingData.claimableUnvestedAmount]);
 
-  const isExternalIncentiveActive = stakingData.activeYn === YN_TYPE.YES;
-  const isExternalIncentiveEnded = stakingData.activeYn === YN_TYPE.NO;
-  const hasKnownExternalIncentiveActiveState = isExternalIncentiveActive || isExternalIncentiveEnded;
+  const isExternalIncentiveRefunded = stakingData.isRefunded === YN_TYPE.YES;
+  const isExternalIncentiveNotRefunded = stakingData.isRefunded === YN_TYPE.NO;
+  const hasKnownExternalIncentiveRefundState = isExternalIncentiveRefunded || isExternalIncentiveNotRefunded;
 
-  const isClaimDisabled = !hasClaimableUnvestedAmount || !hasKnownExternalIncentiveActiveState;
+  const isClaimDisabled = !hasClaimableUnvestedAmount || !hasKnownExternalIncentiveRefundState;
 
   const handleClaim = React.useCallback(() => {
     if (isClaimDisabled) {
       return;
     }
 
-    if (isExternalIncentiveEnded) {
+    if (isExternalIncentiveRefunded) {
       void collectExternalIncentivePenalty({ rpcProvider });
       return;
     }
@@ -117,7 +117,7 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
   }, [
     collectExternalIncentivePenalty,
     isClaimDisabled,
-    isExternalIncentiveEnded,
+    isExternalIncentiveRefunded,
     removeExternalIncentive,
     rpcProvider,
   ]);

--- a/packages/web/src/models/pool/mapper/pool-staking-mapper.ts
+++ b/packages/web/src/models/pool/mapper/pool-staking-mapper.ts
@@ -13,7 +13,7 @@ export class PoolStakingMapper {
       incentiveId: poolStaking?.incentiveId || null,
       unvestedAmount: poolStaking.unvestedAmount || "0",
       claimableUnvestedAmount: poolStaking.claimableUnvestedAmount || "0",
-      activeYn: poolStaking.activeYn,
+      isRefunded: poolStaking.isRefunded,
       incentiveType: poolStaking.incentiveType as INCENTIVE_TYPE,
     };
   }

--- a/packages/web/src/models/pool/pool-staking.ts
+++ b/packages/web/src/models/pool/pool-staking.ts
@@ -14,7 +14,7 @@ export interface PoolStakingModel {
   endTimestamp: string;
   unvestedAmount: string;
   claimableUnvestedAmount: string;
-  activeYn: YnType;
+  isRefunded: YnType;
   createdBlockHeight: string;
 }
 

--- a/packages/web/src/repositories/pool/response/pool-staking-response.ts
+++ b/packages/web/src/repositories/pool/response/pool-staking-response.ts
@@ -15,6 +15,6 @@ export interface PoolStakingResponse {
   totalPenaltyAmount: string;
   collectedPenaltyAmount: string;
   claimableUnvestedAmount: string;
-  activeYn: YnType;
+  isRefunded: YnType;
   createdBlockHeight: string;
 }


### PR DESCRIPTION
## Summary
- Update incentive DTO/model mapping from `activeYn` to `isRefunded` to match the API response rename.
- Keep the incentivization history claim flow aligned with the new semantics: `isRefunded = N` removes/refunds the incentive, `isRefunded = Y` only collects remaining penalty.

## Tests
- `yarn install`
- `yarn workspace @gnoswap-labs/web lint` (passes with existing warnings)
- `yarn build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pool incentive claim logic to properly distinguish between active and refunded incentives, improving claim availability checks and penalty collection handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->