### PR TITLE
feat(pool): fetch incentive deposit amount

### DIFF
--- a/packages/web/src/layouts/pool/pool-incentivize/components/pool-incentivize/incentive-creation-deposit/IncentiveCreationDeposit.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/pool-incentivize/incentive-creation-deposit/IncentiveCreationDeposit.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@emotion/react";
 
+import { GNS_TOKEN } from "@common/values/token-constant";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import { GNS_TOKEN_PATH } from "@constants/environment.constant";
 import { useTokenData } from "@hooks/token/data/use-token-data";
+import { DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT, useGetIncentiveCreationDeposit } from "@query/pools";
+import { makeDisplayTokenAmount } from "@utils/token-utils";
 
 import {
   IncentiveCreationDepositTooltipContent,
@@ -13,14 +16,14 @@ import {
 import Tooltip from "@components/common/tooltip/Tooltip";
 import IconInfo from "@components/common/icons/IconInfo";
 
-export const GNS_DEPOSIT_AMOUNT = 1_000;
-
 const IncentiveCreationDeposit: React.FC = () => {
   const { t } = useTranslation();
   const { tokens } = useTokenData();
   const theme = useTheme();
+  const { data: depositGnsAmount = DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } = useGetIncentiveCreationDeposit();
 
   const gnsInfo = tokens.find(item => item.path === GNS_TOKEN_PATH);
+  const displayDepositAmount = makeDisplayTokenAmount(GNS_TOKEN, depositGnsAmount) || 0;
 
   return (
     <IncentiveCreationDepositWrapper>
@@ -39,7 +42,7 @@ const IncentiveCreationDeposit: React.FC = () => {
       </h5>
       <div className="deposit">
         <MissingLogo symbol={gnsInfo?.symbol || ""} url={gnsInfo?.logoURI} width={24} mobileWidth={24} />
-        {GNS_DEPOSIT_AMOUNT.toLocaleString("en")}
+        {displayDepositAmount.toLocaleString("en")}
       </div>
     </IncentiveCreationDepositWrapper>
   );

--- a/packages/web/src/layouts/pool/pool-incentivize/containers/pool-add-incentivize-container/PoolAddIncentivizeContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/containers/pool-add-incentivize-container/PoolAddIncentivizeContainer.tsx
@@ -2,6 +2,7 @@ import { useAtom } from "jotai";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { GNS_TOKEN } from "@common/values/token-constant";
 import { GNS_TOKEN_PATH } from "@constants/environment.constant";
 import useCustomRouter from "@hooks/common/use-custom-router";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
@@ -11,11 +12,16 @@ import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { PoolDetailModel } from "@models/pool/pool-detail-model";
 import { TokenBalanceInfo } from "@models/token/token-balance-info";
 import { TokenModel } from "@models/token/token-model";
-import { useGetPoolDetailByPath, useGetPoolList } from "@query/pools";
+import {
+  DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT,
+  useGetIncentiveCreationDeposit,
+  useGetPoolDetailByPath,
+  useGetPoolList,
+} from "@query/pools";
 import PoolDetailData from "@repositories/pool/mock/pool-detail.json";
 import { EarnState } from "@states/index";
+import { makeDisplayTokenAmount } from "@utils/token-utils";
 
-import { GNS_DEPOSIT_AMOUNT } from "../../components/pool-incentivize/incentive-creation-deposit/IncentiveCreationDeposit";
 import PoolIncentivize from "../../components/pool-incentivize/PoolIncentivize";
 import { useIncentivizePoolModal } from "@hooks/pool/ui/use-incentivize-pool-modal";
 
@@ -40,6 +46,7 @@ const PoolAddIncentivizeContainer: React.FC = () => {
   const tokenAmountInput = useTokenAmountInput(token);
   const { updateTokenPrices, balances } = useTokenData();
   const { data: pools = [] } = useGetPoolList();
+  const { data: depositGnsAmount = DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } = useGetIncentiveCreationDeposit();
   const [currentPool, setCurrentPool] = useState(pools[0]);
   const { data: poolDetal } = useGetPoolDetailByPath(poolPath, {
     enabled: !!poolPath,
@@ -127,6 +134,9 @@ const PoolAddIncentivizeContainer: React.FC = () => {
   }, [connected, connectAdenaClient, openModal]);
 
   const btnStatus: { text: string; disabled: boolean } = useMemo(() => {
+    const depositDisplayAmount = makeDisplayTokenAmount(GNS_TOKEN, depositGnsAmount) || 0;
+    const depositRawAmount = Number(depositGnsAmount);
+
     if (!connected) {
       return {
         text: t("common:btn.walletLogin"),
@@ -165,8 +175,8 @@ const PoolAddIncentivizeContainer: React.FC = () => {
     }
     if (
       (token?.path === GNS_TOKEN_PATH &&
-        Number(tokenAmountInput.amount) + 1000 > Number(tokenAmountInput.balance.replace(/,/g, ""))) ||
-      (token?.path !== GNS_TOKEN_PATH && GNS_DEPOSIT_AMOUNT * 1_000_000 > (balances[GNS_TOKEN_PATH] || 0))
+        Number(tokenAmountInput.amount) + depositDisplayAmount > Number(tokenAmountInput.balance.replace(/,/g, ""))) ||
+      (token?.path !== GNS_TOKEN_PATH && depositRawAmount > (balances[GNS_TOKEN_PATH] || 0))
     )
       return {
         text: t("IncentivizePool:submitBtn.insuffiDep"),
@@ -184,6 +194,7 @@ const PoolAddIncentivizeContainer: React.FC = () => {
     tokenAmountInput.balance,
     token?.path,
     balances,
+    depositGnsAmount,
     t,
   ]);
 

--- a/packages/web/src/layouts/pool/pool-incentivize/containers/pool-incentivize-container/PoolIncentivizeContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/containers/pool-incentivize-container/PoolIncentivizeContainer.tsx
@@ -2,6 +2,7 @@ import { useAtom } from "jotai";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { GNS_TOKEN } from "@common/values/token-constant";
 import { GNS_TOKEN_PATH } from "@constants/environment.constant";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { useTokenAmountInput } from "@hooks/token/data/use-token-amount-input";
@@ -11,11 +12,11 @@ import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { PoolDetailModel } from "@models/pool/pool-detail-model";
 import { TokenBalanceInfo } from "@models/token/token-balance-info";
 import { TokenModel } from "@models/token/token-model";
-import { useGetPoolList } from "@query/pools";
+import { DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT, useGetIncentiveCreationDeposit, useGetPoolList } from "@query/pools";
 import PoolDetailData from "@repositories/pool/mock/pool-detail.json";
 import { EarnState } from "@states/index";
+import { makeDisplayTokenAmount } from "@utils/token-utils";
 
-import { GNS_DEPOSIT_AMOUNT } from "../../components/pool-incentivize/incentive-creation-deposit/IncentiveCreationDeposit";
 import PoolIncentivize from "../../components/pool-incentivize/PoolIncentivize";
 import { useIncentivizePoolModal } from "@hooks/pool/ui/use-incentivize-pool-modal";
 
@@ -38,6 +39,7 @@ const PoolIncentivizeContainer: React.FC = () => {
   const tokenAmountInput = useTokenAmountInput(token);
   const { updateTokenPrices, balances } = useTokenData();
   const { data: pools = [] } = useGetPoolList({ enabled: false });
+  const { data: depositGnsAmount = DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } = useGetIncentiveCreationDeposit();
   const { getGnotPath } = useGnotToGnot();
 
   const { openModal: openConnectWalletModal } = useConnectWalletModal();
@@ -106,6 +108,9 @@ const PoolIncentivizeContainer: React.FC = () => {
   }, [connected, openConnectWalletModal, openModal]);
 
   const btnStatus: { text: string; disabled: boolean } = useMemo(() => {
+    const depositDisplayAmount = makeDisplayTokenAmount(GNS_TOKEN, depositGnsAmount) || 0;
+    const depositRawAmount = Number(depositGnsAmount);
+
     if (!connected) {
       return {
         text: t("common:btn.walletLogin"),
@@ -144,8 +149,8 @@ const PoolIncentivizeContainer: React.FC = () => {
     }
     if (
       (token?.path === GNS_TOKEN_PATH &&
-        Number(tokenAmountInput.amount) + 1000 > Number(tokenAmountInput.balance.replace(/,/g, ""))) ||
-      (token?.path !== GNS_TOKEN_PATH && GNS_DEPOSIT_AMOUNT * 1_000_000 > (balances[GNS_TOKEN_PATH] || 0))
+        Number(tokenAmountInput.amount) + depositDisplayAmount > Number(tokenAmountInput.balance.replace(/,/g, ""))) ||
+      (token?.path !== GNS_TOKEN_PATH && depositRawAmount > (balances[GNS_TOKEN_PATH] || 0))
     )
       return {
         text: t("IncentivizePool:submitBtn.insuffiDep"),
@@ -163,6 +168,7 @@ const PoolIncentivizeContainer: React.FC = () => {
     tokenAmountInput.balance,
     token?.path,
     balances,
+    depositGnsAmount,
     t,
   ]);
 

--- a/packages/web/src/react-query/pools/index.ts
+++ b/packages/web/src/react-query/pools/index.ts
@@ -1,5 +1,6 @@
 export * from "./use-get-bins-by-path";
 export * from "./use-get-incentivize-pool-list";
+export * from "./use-get-incentive-creation-deposit";
 export * from "./use-get-lasted-block-height";
 export * from "./use-get-pool-creation-fee";
 export * from "./use-get-pool-detail-by-path";

--- a/packages/web/src/react-query/pools/use-get-incentive-creation-deposit.ts
+++ b/packages/web/src/react-query/pools/use-get-incentive-creation-deposit.ts
@@ -1,0 +1,23 @@
+import { UseQueryOptions, useQuery } from "@tanstack/react-query";
+
+import { GNS_DEPOSIT_AMOUNT } from "@common/values";
+import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
+
+import { QUERY_KEY } from "../query-keys";
+
+export const DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT = String(GNS_DEPOSIT_AMOUNT);
+
+export const useGetIncentiveCreationDeposit = (options?: UseQueryOptions<string, Error>) => {
+  const { poolRepository } = useGnoswapContext();
+
+  return useQuery<string, Error>({
+    queryKey: [QUERY_KEY.incentiveCreationDeposit],
+    queryFn: async () => {
+      const res = await poolRepository.getIncentiveCreationDeposit();
+
+      return res;
+    },
+    placeholderData: DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT,
+    ...options,
+  });
+};

--- a/packages/web/src/react-query/query-keys.ts
+++ b/packages/web/src/react-query/query-keys.ts
@@ -36,6 +36,7 @@ export enum QUERY_KEY {
   pools = "pools",
   rpcPools = "rpcPools",
   poolCreationFee = "poolCreationFee",
+  incentiveCreationDeposit = "incentiveCreationDeposit",
   poolDetail = "pool_details",
   bins = "bins",
   poolPairBins = "poolPairBins",

--- a/packages/web/src/repositories/pool/pool-repository-impl.ts
+++ b/packages/web/src/repositories/pool/pool-repository-impl.ts
@@ -1,14 +1,10 @@
 import { getGRC20Allowance } from "@common/clients/gno-provider";
 import { NetworkClient } from "@common/clients/network-client";
 import { WalletClient } from "@common/clients/wallet-client";
-import {
-  SendTransactionResponse,
-  SendTransactionSuccessResponse,
-  WalletResponse,
-} from "@common/clients/wallet-client/protocols";
+import { SendTransactionResponse, SendTransactionSuccessResponse, WalletResponse } from "@common/clients/wallet-client/protocols";
 import { CommonError } from "@common/errors";
 import { PoolError } from "@common/errors/pool";
-import { DEFAULT_GAS_FEE, DEFAULT_GAS_WANTED } from "@common/values";
+import { DEFAULT_GAS_FEE, DEFAULT_GAS_WANTED, GNS_DEPOSIT_AMOUNT } from "@common/values";
 import { PACKAGE_POOL_PATH, PACKAGE_STAKER_PATH } from "@constants/environment.constant";
 import { CHART_DAY_SCOPE_TYPE } from "@constants/option.constant";
 import { GnoProvider } from "@gnolang/gno-js-client";
@@ -83,6 +79,27 @@ export class PoolRepositoryImpl implements PoolRepository {
     } catch (error) {
       console.error(error);
       return 0;
+    }
+  };
+
+  getIncentiveCreationDeposit = async (): Promise<string> => {
+    const defaultDepositGnsAmount = String(GNS_DEPOSIT_AMOUNT);
+
+    if (!this.networkClient) {
+      return defaultDepositGnsAmount;
+    }
+
+    try {
+      const response = await this.networkClient.get<{
+        data: { depositGnsAmount: string };
+      }>({
+        url: "/incentivize/deposit",
+      });
+
+      return response?.data?.data?.depositGnsAmount || defaultDepositGnsAmount;
+    } catch (error) {
+      console.error(error);
+      return defaultDepositGnsAmount;
     }
   };
 

--- a/packages/web/src/repositories/pool/pool-repository-mock.ts
+++ b/packages/web/src/repositories/pool/pool-repository-mock.ts
@@ -1,6 +1,7 @@
 import { PoolPricesResponse, PoolRepository } from ".";
 
 import { SendTransactionResponse, WalletResponse } from "@common/clients/wallet-client/protocols";
+import { GNS_DEPOSIT_AMOUNT } from "@common/values";
 import { PoolRPCMapper } from "@models/pool/mapper/pool-rpc-mapper";
 import { PoolBinModel } from "@models/pool/pool-bin-model";
 import { PoolDetailModel } from "@models/pool/pool-detail-model";
@@ -47,6 +48,10 @@ export class PoolRepositoryMock implements PoolRepository {
 
   getCreationFee = async (): Promise<number> => {
     return 0;
+  };
+
+  getIncentiveCreationDeposit = async (): Promise<string> => {
+    return String(GNS_DEPOSIT_AMOUNT);
   };
 
   getPoolDetailByPoolPath = async (): Promise<PoolDetailModel> => {

--- a/packages/web/src/repositories/pool/pool-repository.ts
+++ b/packages/web/src/repositories/pool/pool-repository.ts
@@ -18,6 +18,8 @@ export interface PoolRepository {
 
   getCreationFee: () => Promise<number>;
 
+  getIncentiveCreationDeposit: () => Promise<string>;
+
   getWithdrawalFee: () => Promise<number>;
 
   getUnstakingFee: () => Promise<number>;


### PR DESCRIPTION
## Summary
- Fetch the incentive creation deposit amount from the new API instead of using hardcoded 1,000 GNS UI/validation values.
- Add a React Query hook and repository method with the existing default amount as a safe fallback.
- Update incentive creation display and balance validation to use the fetched raw amount.

## Validation
- yarn build
- yarn workspace @gnoswap-labs/web lint (completed with existing repo-wide warnings)

## Related
- GSW-2676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Incentive deposit amounts are now dynamically retrieved from the backend instead of using hardcoded values.

* **Refactor**
  * Updated incentive creation components to use server-provided deposit values for validation and display logic, replacing static constants with configurable amounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->