### PR TITLE
fix: tighten approval injection messages

### DIFF
--- a/packages/web/src/common/values/data-constant.ts
+++ b/packages/web/src/common/values/data-constant.ts
@@ -30,5 +30,4 @@ export const GAS_WANTED_BUFFER_MULTIPLIER = 1.1 as const;
 export const GAS_WANTED_BUFFER_SAFE_MARGIN = 1.2 as const;
 
 export const MINIMUM_GNOT_SWAP_AMOUNT = 0.001;
-
-export const GNS_DEPOSIT_AMOUNT = 1_000_000_000 as const;
+export const DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT = "1000000000" as const;

--- a/packages/web/src/layouts/pool/pool-incentivize/components/pool-incentivize/incentive-creation-deposit/IncentiveCreationDeposit.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/pool-incentivize/incentive-creation-deposit/IncentiveCreationDeposit.tsx
@@ -2,11 +2,12 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@emotion/react";
 
+import { DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } from "@common/values";
 import { GNS_TOKEN } from "@common/values/token-constant";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import { GNS_TOKEN_PATH } from "@constants/environment.constant";
 import { useTokenData } from "@hooks/token/data/use-token-data";
-import { DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT, useGetIncentiveCreationDeposit } from "@query/pools";
+import { useGetIncentiveCreationDeposit } from "@query/pools";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
 
 import {

--- a/packages/web/src/layouts/pool/pool-incentivize/containers/incentivize-pool-modal-container/IncentivizePoolModalContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/containers/incentivize-pool-modal-container/IncentivizePoolModalContainer.tsx
@@ -3,6 +3,7 @@ import { useAtom } from "jotai";
 import { useCallback } from "react";
 
 import { ERROR_VALUE } from "@common/errors/adena";
+import { DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } from "@common/values";
 import { useAddress } from "@hooks/common/use-address";
 import { useBroadcastHandler } from "@hooks/common/use-broadcast-handler";
 import { useClearModal } from "@hooks/common/use-clear-modal";
@@ -12,7 +13,12 @@ import { useMessage } from "@hooks/common/use-message";
 import { usePositionData } from "@hooks/pool/data/use-position-data";
 import { useTransactionConfirmModal } from "@hooks/common/use-transaction-confirm-modal";
 import { useTransactionEventStore } from "@hooks/common/use-transaction-event-store";
-import { useGetIncentivizePoolList, useGetPoolList, useRefetchGetPoolDetailByPath } from "@query/pools";
+import {
+  useGetIncentiveCreationDeposit,
+  useGetIncentivizePoolList,
+  useGetPoolList,
+  useRefetchGetPoolDetailByPath,
+} from "@query/pools";
 import { useGetPoolStakingListByAddress } from "@query/pools/use-get-pool-staking-list-by-address";
 import { DexEvent } from "@repositories/common";
 import { EarnState } from "@states/index";
@@ -59,6 +65,8 @@ const IncentivizePoolModalContainer: React.FC<IncentivizePoolModalContainerProps
   const { refetch: refetchIncentivizePools } = useGetIncentivizePoolList();
   const { refetch: refetchPoolDetails } = useRefetchGetPoolDetailByPath(poolPath);
   const { refetch: refetchStakingList } = useGetPoolStakingListByAddress(address || "");
+  const { data: incentiveCreationDepositGnsAmount = DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } =
+    useGetIncentiveCreationDeposit();
 
   const { getMessage } = useMessage();
 
@@ -133,6 +141,7 @@ const IncentivizePoolModalContainer: React.FC<IncentivizePoolModalContainerProps
         poolPath: pool.poolPath,
         rewardToken: dataModal.token,
         rewardAmount: dataModal.amount || "0",
+        incentiveCreationDepositGnsAmount,
         startTime,
         endTime,
       };
@@ -203,7 +212,18 @@ const IncentivizePoolModalContainer: React.FC<IncentivizePoolModalContainerProps
       }
       return result;
     },
-    [address, poolRepository, dataModal, period, pool, router, startDate.date, startDate.month, startDate.year],
+    [
+      address,
+      poolRepository,
+      dataModal,
+      incentiveCreationDepositGnsAmount,
+      period,
+      pool,
+      router,
+      startDate.date,
+      startDate.month,
+      startDate.year,
+    ],
   );
 
   return (

--- a/packages/web/src/layouts/pool/pool-incentivize/containers/pool-add-incentivize-container/PoolAddIncentivizeContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/containers/pool-add-incentivize-container/PoolAddIncentivizeContainer.tsx
@@ -2,6 +2,7 @@ import { useAtom } from "jotai";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } from "@common/values";
 import { GNS_TOKEN } from "@common/values/token-constant";
 import { GNS_TOKEN_PATH } from "@constants/environment.constant";
 import useCustomRouter from "@hooks/common/use-custom-router";
@@ -12,12 +13,7 @@ import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { PoolDetailModel } from "@models/pool/pool-detail-model";
 import { TokenBalanceInfo } from "@models/token/token-balance-info";
 import { TokenModel } from "@models/token/token-model";
-import {
-  DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT,
-  useGetIncentiveCreationDeposit,
-  useGetPoolDetailByPath,
-  useGetPoolList,
-} from "@query/pools";
+import { useGetIncentiveCreationDeposit, useGetPoolDetailByPath, useGetPoolList } from "@query/pools";
 import PoolDetailData from "@repositories/pool/mock/pool-detail.json";
 import { EarnState } from "@states/index";
 import { makeDisplayTokenAmount } from "@utils/token-utils";

--- a/packages/web/src/layouts/pool/pool-incentivize/containers/pool-incentivize-container/PoolIncentivizeContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/containers/pool-incentivize-container/PoolIncentivizeContainer.tsx
@@ -2,6 +2,7 @@ import { useAtom } from "jotai";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } from "@common/values";
 import { GNS_TOKEN } from "@common/values/token-constant";
 import { GNS_TOKEN_PATH } from "@constants/environment.constant";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
@@ -12,7 +13,7 @@ import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { PoolDetailModel } from "@models/pool/pool-detail-model";
 import { TokenBalanceInfo } from "@models/token/token-balance-info";
 import { TokenModel } from "@models/token/token-model";
-import { DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT, useGetIncentiveCreationDeposit, useGetPoolList } from "@query/pools";
+import { useGetIncentiveCreationDeposit, useGetPoolList } from "@query/pools";
 import PoolDetailData from "@repositories/pool/mock/pool-detail.json";
 import { EarnState } from "@states/index";
 import { makeDisplayTokenAmount } from "@utils/token-utils";

--- a/packages/web/src/react-query/pools/use-get-incentive-creation-deposit.ts
+++ b/packages/web/src/react-query/pools/use-get-incentive-creation-deposit.ts
@@ -1,11 +1,9 @@
 import { UseQueryOptions, useQuery } from "@tanstack/react-query";
 
-import { GNS_DEPOSIT_AMOUNT } from "@common/values";
+import { DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } from "@common/values";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 
 import { QUERY_KEY } from "../query-keys";
-
-export const DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT = String(GNS_DEPOSIT_AMOUNT);
 
 export const useGetIncentiveCreationDeposit = (options?: UseQueryOptions<string, Error>) => {
   const { poolRepository } = useGnoswapContext();

--- a/packages/web/src/repositories/governance/governance.message.spec.ts
+++ b/packages/web/src/repositories/governance/governance.message.spec.ts
@@ -1,0 +1,33 @@
+jest.mock("@constants/environment.constant", () => ({
+  GNS_TOKEN_PATH: "gns_token_path",
+  PACKAGE_GOVERNANCE_PATH: "governance_path",
+  PACKAGE_GOVERNANCE_STAKER_ADDRESS: "governance_staker_address",
+  PACKAGE_GOVERNANCE_STAKER_PATH: "governance_staker_path",
+}));
+
+import { makeDelegateMessagesWithApproves } from "@repositories/governance/governance.message";
+
+describe("governance.message.ts", () => {
+  it("approves delegation with the exact delegated amount", async () => {
+    const caller = "caller";
+    const fetchAllowance = jest.fn(async () => 0);
+
+    const messages = await makeDelegateMessagesWithApproves(
+      { to: "validator", amount: "123000000", caller, referrerAddress: null },
+      fetchAllowance,
+    );
+
+    expect(messages[0]).toMatchObject({
+      caller,
+      pkg_path: "gns_token_path",
+      func: "Approve",
+      args: ["governance_staker_address", "123000000"],
+    });
+    expect(messages[1]).toMatchObject({
+      caller,
+      pkg_path: "governance_staker_path",
+      func: "Delegate",
+      args: ["validator", "123000000", ""],
+    });
+  });
+});

--- a/packages/web/src/repositories/governance/governance.message.ts
+++ b/packages/web/src/repositories/governance/governance.message.ts
@@ -11,7 +11,6 @@ import {
   PACKAGE_GOVERNANCE_STAKER_PATH,
 } from "@constants/environment.constant";
 import { makeProposalVariablesQuery } from "@utils/governance-utils";
-import { MAX_INT64 } from "@utils/math.utils";
 
 enum TransactionMessageFunctionType {
   ProposeText = "ProposeText",
@@ -182,7 +181,7 @@ export function makeDelegateMessagesWithApproves(
     {
       tokenPath: GNS_TOKEN_PATH,
       targetAddress: PACKAGE_GOVERNANCE_STAKER_ADDRESS,
-      amount: MAX_INT64,
+      amount,
       caller,
     },
   ];
@@ -236,7 +235,7 @@ export function makeReDelegateMessagesWithApproves(
     {
       tokenPath: GNS_TOKEN_PATH,
       targetAddress: PACKAGE_GOVERNANCE_STAKER_ADDRESS,
-      amount: MAX_INT64,
+      amount,
       caller,
     },
   ];

--- a/packages/web/src/repositories/launchpad/launchpad.message.spec.ts
+++ b/packages/web/src/repositories/launchpad/launchpad.message.spec.ts
@@ -1,0 +1,32 @@
+jest.mock("@constants/environment.constant", () => ({
+  GNS_TOKEN_PATH: "gns_token_path",
+  PACKAGE_LAUNCHPAD_ADDRESS: "launchpad_address",
+  PACKAGE_LAUNCHPAD_PATH: "launchpad_path",
+}));
+
+import { makeDepositGNSMessageWithApproves } from "@repositories/launchpad/launchpad.message";
+
+describe("launchpad.message.ts", () => {
+  it("approves launchpad deposits with the exact deposit amount", async () => {
+    const caller = "caller";
+    const fetchAllowance = jest.fn(async () => 0);
+
+    const messages = await makeDepositGNSMessageWithApproves(
+      { poolId: "pool-1", gnsTokenAmount: 456000000n, caller, referrerAddress: null },
+      fetchAllowance,
+    );
+
+    expect(messages[0]).toMatchObject({
+      caller,
+      pkg_path: "gns_token_path",
+      func: "Approve",
+      args: ["launchpad_address", "456000000"],
+    });
+    expect(messages[1]).toMatchObject({
+      caller,
+      pkg_path: "launchpad_path",
+      func: "DepositGns",
+      args: ["pool-1", "456000000", ""],
+    });
+  });
+});

--- a/packages/web/src/repositories/launchpad/launchpad.message.ts
+++ b/packages/web/src/repositories/launchpad/launchpad.message.ts
@@ -5,7 +5,6 @@ import {
   TokenApproveMessageInfo,
 } from "@common/clients/wallet-client/transaction-messages";
 import { GNS_TOKEN_PATH, PACKAGE_LAUNCHPAD_ADDRESS, PACKAGE_LAUNCHPAD_PATH } from "@constants/environment.constant";
-import { MAX_INT64 } from "@utils/math.utils";
 
 enum TransactionMessageFunctionType {
   DepositGns = "DepositGns",
@@ -39,7 +38,7 @@ export function makeDepositGNSMessageWithApproves(
     {
       tokenPath: GNS_TOKEN_PATH,
       targetAddress: PACKAGE_LAUNCHPAD_ADDRESS,
-      amount: MAX_INT64,
+      amount: gnsTokenAmount,
       caller,
     },
   ];

--- a/packages/web/src/repositories/pool/pool-repository-impl.ts
+++ b/packages/web/src/repositories/pool/pool-repository-impl.ts
@@ -4,7 +4,7 @@ import { WalletClient } from "@common/clients/wallet-client";
 import { SendTransactionResponse, SendTransactionSuccessResponse, WalletResponse } from "@common/clients/wallet-client/protocols";
 import { CommonError } from "@common/errors";
 import { PoolError } from "@common/errors/pool";
-import { DEFAULT_GAS_FEE, DEFAULT_GAS_WANTED, GNS_DEPOSIT_AMOUNT } from "@common/values";
+import { DEFAULT_GAS_FEE, DEFAULT_GAS_WANTED, DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } from "@common/values";
 import { PACKAGE_POOL_PATH, PACKAGE_STAKER_PATH } from "@constants/environment.constant";
 import { CHART_DAY_SCOPE_TYPE } from "@constants/option.constant";
 import { GnoProvider } from "@gnolang/gno-js-client";
@@ -83,10 +83,8 @@ export class PoolRepositoryImpl implements PoolRepository {
   };
 
   getIncentiveCreationDeposit = async (): Promise<string> => {
-    const defaultDepositGnsAmount = String(GNS_DEPOSIT_AMOUNT);
-
     if (!this.networkClient) {
-      return defaultDepositGnsAmount;
+      return DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT;
     }
 
     try {
@@ -96,10 +94,10 @@ export class PoolRepositoryImpl implements PoolRepository {
         url: "/incentivize/deposit",
       });
 
-      return response?.data?.data?.depositGnsAmount || defaultDepositGnsAmount;
+      return response?.data?.data?.depositGnsAmount || DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT;
     } catch (error) {
       console.error(error);
-      return defaultDepositGnsAmount;
+      return DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT;
     }
   };
 

--- a/packages/web/src/repositories/pool/pool-repository-mock.ts
+++ b/packages/web/src/repositories/pool/pool-repository-mock.ts
@@ -1,7 +1,7 @@
 import { PoolPricesResponse, PoolRepository } from ".";
 
 import { SendTransactionResponse, WalletResponse } from "@common/clients/wallet-client/protocols";
-import { GNS_DEPOSIT_AMOUNT } from "@common/values";
+import { DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } from "@common/values";
 import { PoolRPCMapper } from "@models/pool/mapper/pool-rpc-mapper";
 import { PoolBinModel } from "@models/pool/pool-bin-model";
 import { PoolDetailModel } from "@models/pool/pool-detail-model";
@@ -51,7 +51,7 @@ export class PoolRepositoryMock implements PoolRepository {
   };
 
   getIncentiveCreationDeposit = async (): Promise<string> => {
-    return String(GNS_DEPOSIT_AMOUNT);
+    return DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT;
   };
 
   getPoolDetailByPoolPath = async (): Promise<PoolDetailModel> => {

--- a/packages/web/src/repositories/pool/pool.message.spec.ts
+++ b/packages/web/src/repositories/pool/pool.message.spec.ts
@@ -1,0 +1,108 @@
+import type { TokenModel } from "@models/token/token-model";
+
+jest.mock("@constants/environment.constant", () => ({
+  GNS_TOKEN_PATH: "gns_token_path",
+  PACKAGE_POOL_ADDRESS: "pool_address",
+  PACKAGE_POOL_PATH: "pool_path",
+  PACKAGE_POSITION_PATH: "position_path",
+  PACKAGE_STAKER_ADDRESS: "staker_address",
+  PACKAGE_STAKER_PATH: "staker_path",
+  WRAPPED_GNOT_PATH: "wugnot",
+}));
+
+import {
+  makeCreateExternalIncentiveMessageWithApproves,
+  makePositionMintMessageWithApproves,
+} from "@repositories/pool/pool.message";
+
+const createTokenModel = (path: string, type: TokenModel["type"] = "GRC20"): TokenModel => ({
+  path,
+  type,
+  chainId: "dev.gnoswap",
+  createdAt: "2024-01-24T15:12:21Z",
+  name: path,
+  symbol: path,
+  decimals: 6,
+  logoURI: "",
+  priceID: path,
+});
+
+describe("pool.message.ts", () => {
+  it("approves mint tokens using exact desired raw amounts", async () => {
+    const caller = "caller";
+    const fetchAllowance = jest.fn(async () => 0);
+
+    const messages = await makePositionMintMessageWithApproves(
+      {
+        tokenA: createTokenModel("tokenA_path"),
+        tokenB: createTokenModel("tokenB_path"),
+        feeTier: "FEE_3000",
+        tokenAAmount: "1.25",
+        tokenBAmount: "3",
+        minTick: -10,
+        maxTick: 10,
+        slippage: 0,
+        caller,
+        referrerAddress: null,
+      },
+      fetchAllowance,
+    );
+
+    expect(messages[0]).toMatchObject({
+      caller,
+      pkg_path: "tokenA_path",
+      func: "Approve",
+      args: ["pool_address", "1250000"],
+    });
+    expect(messages[1]).toMatchObject({
+      caller,
+      pkg_path: "tokenB_path",
+      func: "Approve",
+      args: ["pool_address", "3000000"],
+    });
+    expect(messages[2]).toMatchObject({
+      caller,
+      pkg_path: "position_path",
+      func: "Mint",
+    });
+    expect(messages[2].args?.slice(0, 7)).toEqual([
+      "tokenA_path",
+      "tokenB_path",
+      "3000",
+      "-10",
+      "10",
+      "1250000",
+      "3000000",
+    ]);
+  });
+
+  it("sums GNS incentive reward and creation deposit approvals for the same spender", async () => {
+    const caller = "caller";
+    const fetchAllowance = jest.fn(async () => 0);
+
+    const messages = await makeCreateExternalIncentiveMessageWithApproves(
+      {
+        poolPath: "pool_path",
+        rewardToken: createTokenModel("gns_token_path"),
+        rewardAmount: "250",
+        startTime: 100,
+        endTime: 200,
+        caller,
+      },
+      fetchAllowance,
+    );
+
+    expect(messages[0]).toMatchObject({
+      caller,
+      pkg_path: "gns_token_path",
+      func: "Approve",
+      args: ["staker_address", "1250000000"],
+    });
+    expect(messages[1]).toMatchObject({
+      caller,
+      pkg_path: "staker_path",
+      func: "CreateExternalIncentive",
+      args: ["pool_path", "gns_token_path", "250000000", "100", "200"],
+    });
+  });
+});

--- a/packages/web/src/repositories/pool/pool.message.spec.ts
+++ b/packages/web/src/repositories/pool/pool.message.spec.ts
@@ -85,6 +85,7 @@ describe("pool.message.ts", () => {
         poolPath: "pool_path",
         rewardToken: createTokenModel("gns_token_path"),
         rewardAmount: "250",
+        incentiveCreationDepositGnsAmount: "1500000000",
         startTime: 100,
         endTime: 200,
         caller,
@@ -96,7 +97,7 @@ describe("pool.message.ts", () => {
       caller,
       pkg_path: "gns_token_path",
       func: "Approve",
-      args: ["staker_address", "1250000000"],
+      args: ["staker_address", "1750000000"],
     });
     expect(messages[1]).toMatchObject({
       caller,

--- a/packages/web/src/repositories/pool/pool.message.ts
+++ b/packages/web/src/repositories/pool/pool.message.ts
@@ -7,7 +7,7 @@ import {
   TokenApproveMessageInfo,
   TransactionMessage,
 } from "@common/clients/wallet-client/transaction-messages";
-import { DEFAULT_TRANSACTION_DEADLINE, GNS_DEPOSIT_AMOUNT } from "@common/values";
+import { DEFAULT_TRANSACTION_DEADLINE } from "@common/values";
 import {
   GNS_TOKEN_PATH,
   PACKAGE_POOL_ADDRESS,
@@ -178,6 +178,7 @@ export function makeCreateExternalIncentiveMessageWithApproves(
     poolPath,
     rewardToken,
     rewardAmount,
+    incentiveCreationDepositGnsAmount,
     startTime,
     endTime,
     caller,
@@ -185,6 +186,7 @@ export function makeCreateExternalIncentiveMessageWithApproves(
     poolPath: string;
     rewardToken: TokenModel;
     rewardAmount: string;
+    incentiveCreationDepositGnsAmount: string;
     startTime: number;
     endTime: number;
     caller: string;
@@ -202,7 +204,7 @@ export function makeCreateExternalIncentiveMessageWithApproves(
     approveMessageInfos.push({
       tokenPath: GNS_TOKEN_PATH,
       targetAddress: PACKAGE_STAKER_ADDRESS,
-      amount: GNS_DEPOSIT_AMOUNT,
+      amount: incentiveCreationDepositGnsAmount,
       caller,
     });
     approveMessageInfos.push({
@@ -215,7 +217,7 @@ export function makeCreateExternalIncentiveMessageWithApproves(
     approveMessageInfos.push({
       tokenPath: GNS_TOKEN_PATH,
       targetAddress: PACKAGE_STAKER_ADDRESS,
-      amount: GNS_DEPOSIT_AMOUNT,
+      amount: incentiveCreationDepositGnsAmount,
       caller,
     });
     approveMessageInfos.push({

--- a/packages/web/src/repositories/pool/pool.message.ts
+++ b/packages/web/src/repositories/pool/pool.message.ts
@@ -7,12 +7,11 @@ import {
   TokenApproveMessageInfo,
   TransactionMessage,
 } from "@common/clients/wallet-client/transaction-messages";
-import { DEFAULT_TRANSACTION_DEADLINE } from "@common/values";
+import { DEFAULT_TRANSACTION_DEADLINE, GNS_DEPOSIT_AMOUNT } from "@common/values";
 import {
   GNS_TOKEN_PATH,
   PACKAGE_POOL_ADDRESS,
   PACKAGE_POOL_PATH,
-  PACKAGE_POSITION_ADDRESS,
   PACKAGE_POSITION_PATH,
   PACKAGE_STAKER_ADDRESS,
   PACKAGE_STAKER_PATH,
@@ -21,7 +20,7 @@ import {
 import { SwapFeeTierInfoMap, SwapFeeTierType } from "@constants/option.constant";
 import { TokenModel } from "@models/token/token-model";
 import { checkGnotPath, isGNOTPath, wrapNativeTokenPath } from "@utils/common";
-import { MAX_INT64, tickToSqrtPriceX96 } from "@utils/math.utils";
+import { tickToSqrtPriceX96 } from "@utils/math.utils";
 import { isOrderedTokenPaths } from "@utils/pool-utils";
 import { sortTokenPaths } from "@utils/sort-utils";
 import { priceToTick } from "@utils/swap-utils";
@@ -64,7 +63,7 @@ export function makeCreatePoolMessageWithApproves(
     approveMessageInfos.push({
       tokenPath: GNS_TOKEN_PATH,
       targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: MAX_INT64,
+      amount: createPoolFee,
       caller,
     });
   }
@@ -134,7 +133,7 @@ export function makePositionMintMessageWithApproves(
     approveMessageInfos.push({
       tokenPath: tokenAWrappedPath,
       targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: MAX_INT64,
+      amount: tokenAAmountRaw,
       caller,
     });
   }
@@ -143,16 +142,7 @@ export function makePositionMintMessageWithApproves(
     approveMessageInfos.push({
       tokenPath: tokenBWrappedPath,
       targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: MAX_INT64,
-      caller,
-    });
-  }
-
-  if (sendAmount && Number(sendAmount) > 0) {
-    approveMessageInfos.push({
-      tokenPath: WRAPPED_GNOT_PATH,
-      targetAddress: PACKAGE_POSITION_ADDRESS,
-      amount: MAX_INT64,
+      amount: tokenBAmountRaw,
       caller,
     });
   }
@@ -212,20 +202,26 @@ export function makeCreateExternalIncentiveMessageWithApproves(
     approveMessageInfos.push({
       tokenPath: GNS_TOKEN_PATH,
       targetAddress: PACKAGE_STAKER_ADDRESS,
-      amount: MAX_INT64,
+      amount: GNS_DEPOSIT_AMOUNT,
+      caller,
+    });
+    approveMessageInfos.push({
+      tokenPath: GNS_TOKEN_PATH,
+      targetAddress: PACKAGE_STAKER_ADDRESS,
+      amount: rewardAmountRaw,
       caller,
     });
   } else {
     approveMessageInfos.push({
       tokenPath: GNS_TOKEN_PATH,
       targetAddress: PACKAGE_STAKER_ADDRESS,
-      amount: MAX_INT64,
+      amount: GNS_DEPOSIT_AMOUNT,
       caller,
     });
     approveMessageInfos.push({
       tokenPath: rewardTokenPath,
       targetAddress: PACKAGE_STAKER_ADDRESS,
-      amount: MAX_INT64,
+      amount: rewardAmountRaw,
       caller,
     });
   }

--- a/packages/web/src/repositories/pool/request/create-external-incentive-request.ts
+++ b/packages/web/src/repositories/pool/request/create-external-incentive-request.ts
@@ -7,6 +7,8 @@ export interface CreateExternalIncentiveRequest {
 
   rewardAmount: string;
 
+  incentiveCreationDepositGnsAmount: string;
+
   startTime: number;
 
   endTime: number;

--- a/packages/web/src/repositories/position/position.message.spec.ts
+++ b/packages/web/src/repositories/position/position.message.spec.ts
@@ -1,11 +1,9 @@
-import { DEFAULT_ALLOWANCE_LIMIT } from "@common/values";
 import type { RewardType } from "@constants/option.constant";
 import type { PoolPositionModel } from "@models/position/pool-position-model";
 import type { PositionModel } from "@models/position/position-model";
 import type { RewardModel } from "@models/position/reward-model";
 import type { TokenModel } from "@models/token/token-model";
 import type { TransactionMessage } from "@common/clients/wallet-client/transaction-messages/common";
-import { MAX_INT64_STR } from "@utils/math.utils";
 import BigNumber from "bignumber.js";
 
 jest.mock("@constants/environment.constant", () => ({
@@ -204,9 +202,9 @@ describe("position.message.ts", () => {
 
   describe("makeClaimMessageWithApproves", () => {
     const tokenFee = "fee_token";
-    const tokenStaking = "ugnot"; // native path, but will be wrapped via checkGnotPath(...)
+    const tokenStaking = "ugnot";
 
-    it("creates fee + staking collect tx messages and the required approve messages", async () => {
+    it("creates fee + staking collect tx messages without token approve messages", async () => {
       const caller = "caller";
       const position = createPosition("lp1", [
         createReward({ rewardType: "SWAP_FEE", rewardTokenPath: tokenFee, claimableAmount: "0" }),
@@ -216,36 +214,9 @@ describe("position.message.ts", () => {
       const fetchAllowance = jest.fn(async () => 0);
       const messages = await makeClaimMessageWithApproves({ position, caller }, fetchAllowance);
 
-      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 3);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 0, 0);
 
-      expect(approveMessages).toEqual(
-        expect.arrayContaining([
-          {
-            caller,
-            send: "",
-            pkg_path: tokenFee,
-            func: "Approve",
-            args: ["pool_address", MAX_INT64_STR],
-            gasFee: undefined,
-          },
-          {
-            caller,
-            send: "",
-            pkg_path: tokenFee,
-            func: "Approve",
-            args: ["position_address", MAX_INT64_STR],
-            gasFee: undefined,
-          },
-          {
-            caller,
-            send: "",
-            pkg_path: "wugnot",
-            func: "Approve",
-            args: ["staker_address", MAX_INT64_STR],
-            gasFee: undefined,
-          },
-        ]),
-      );
+      expect(approveMessages).toHaveLength(0);
 
       expect(txMessages).toEqual([
         {
@@ -265,18 +236,21 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
-      expectResetMessages(resetMessages, approveMessages);
+      expect(resetMessages).toHaveLength(0);
+      expect(fetchAllowance).not.toHaveBeenCalled();
     });
 
-    it("filters out approve messages when allowance is above the limit", async () => {
+    it("does not fetch allowance for fee claims because no approval is required", async () => {
       const caller = "caller";
       const position = createPosition("lp1", [
         createReward({ rewardType: "SWAP_FEE", rewardTokenPath: "fee_token", claimableAmount: "0" }),
       ]);
 
-      const fetchAllowance = jest.fn(async () => DEFAULT_ALLOWANCE_LIMIT * 2);
+      const fetchAllowance = jest.fn(async () => 0);
       const messages = await makeClaimMessageWithApproves({ position, caller }, fetchAllowance);
-      const { txMessages, resetMessages } = splitMessagesByApproveReset(messages, 0, 2);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 0, 0);
+
+      expect(approveMessages).toHaveLength(0);
 
       expect(txMessages).toEqual([
         {
@@ -288,24 +262,8 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
-      expect(resetMessages).toEqual([
-        {
-          caller,
-          send: "",
-          pkg_path: "fee_token",
-          func: "Approve",
-          args: ["pool_address", "0"],
-          gasFee: undefined,
-        },
-        {
-          caller,
-          send: "",
-          pkg_path: "fee_token",
-          func: "Approve",
-          args: ["position_address", "0"],
-          gasFee: undefined,
-        },
-      ]);
+      expect(resetMessages).toHaveLength(0);
+      expect(fetchAllowance).not.toHaveBeenCalled();
     });
   });
 
@@ -322,20 +280,9 @@ describe("position.message.ts", () => {
       const fetchAllowance = jest.fn(async () => 0);
       const messages = await makeClaimAllMessageWithApproves({ positions, caller }, fetchAllowance);
 
-      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 1);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 0, 0);
 
-      expect(approveMessages).toEqual(
-        expect.arrayContaining([
-          {
-            caller,
-            send: "",
-            pkg_path: "wugnot",
-            func: "Approve",
-            args: ["staker_address", MAX_INT64_STR],
-            gasFee: undefined,
-          },
-        ]),
-      );
+      expect(approveMessages).toHaveLength(0);
 
       // Only CollectReward should exist (no CollectFee because claimableAmount <= 0).
       expect(txMessages).toEqual([
@@ -348,10 +295,11 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
-      expectResetMessages(resetMessages, approveMessages);
+      expect(resetMessages).toHaveLength(0);
+      expect(fetchAllowance).not.toHaveBeenCalled();
     });
 
-    it("merges duplicate approveInfos across multiple positions (fee)", async () => {
+    it("creates CollectFee messages across multiple positions without approve messages", async () => {
       const caller = "caller";
 
       const positions = [
@@ -366,30 +314,9 @@ describe("position.message.ts", () => {
       const fetchAllowance = jest.fn(async () => 0);
       const messages = await makeClaimAllMessageWithApproves({ positions, caller }, fetchAllowance);
 
-      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 2);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 0, 0);
 
-      // Expect exactly 2 approve messages for fee_token: pool + position_address.
-      expect(approveMessages).toEqual(
-        expect.arrayContaining([
-          {
-            caller,
-            send: "",
-            pkg_path: "fee_token",
-            func: "Approve",
-            args: ["pool_address", MAX_INT64_STR],
-            gasFee: undefined,
-          },
-          {
-            caller,
-            send: "",
-            pkg_path: "fee_token",
-            func: "Approve",
-            args: ["position_address", MAX_INT64_STR],
-            gasFee: undefined,
-          },
-        ]),
-      );
-      expect(approveMessages).toHaveLength(2);
+      expect(approveMessages).toHaveLength(0);
 
       expect(txMessages).toEqual([
         {
@@ -409,12 +336,13 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
-      expectResetMessages(resetMessages, approveMessages);
+      expect(resetMessages).toHaveLength(0);
+      expect(fetchAllowance).not.toHaveBeenCalled();
     });
   });
 
   describe("makeUnStakePositionsMessagesWithApproves", () => {
-    it("creates pool and staker approve messages for wugnot rewards and one UnStakeToken per position", async () => {
+    it("creates one UnStakeToken per position without token approve messages", async () => {
       const caller = "caller";
 
       const positions: PoolPositionModel[] = [
@@ -429,29 +357,9 @@ describe("position.message.ts", () => {
       const fetchAllowance = jest.fn(async () => 0);
       const messages = await makeUnStakePositionsMessagesWithApproves({ positions, caller }, fetchAllowance);
 
-      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 2);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 0, 0);
 
-      expect(approveMessages).toEqual(
-        expect.arrayContaining([
-          {
-            caller,
-            send: "",
-            pkg_path: "wugnot",
-            func: "Approve",
-            args: ["pool_address", MAX_INT64_STR],
-            gasFee: undefined,
-          },
-          {
-            caller,
-            send: "",
-            pkg_path: "wugnot",
-            func: "Approve",
-            args: ["staker_address", MAX_INT64_STR],
-            gasFee: undefined,
-          },
-        ]),
-      );
-      expect(approveMessages).toHaveLength(2);
+      expect(approveMessages).toHaveLength(0);
 
       expect(txMessages).toEqual([
         {
@@ -471,7 +379,8 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
-      expectResetMessages(resetMessages, approveMessages);
+      expect(resetMessages).toHaveLength(0);
+      expect(fetchAllowance).not.toHaveBeenCalled();
     });
   });
 
@@ -509,7 +418,7 @@ describe("position.message.ts", () => {
             send: "",
             pkg_path: "wugnot",
             func: "Approve",
-            args: ["pool_address", MAX_INT64_STR],
+            args: ["pool_address", "2500"],
             gasFee: undefined,
           },
           {
@@ -517,7 +426,7 @@ describe("position.message.ts", () => {
             send: "",
             pkg_path: "tokenB_path",
             func: "Approve",
-            args: ["pool_address", MAX_INT64_STR],
+            args: ["pool_address", "3000000"],
             gasFee: undefined,
           },
         ]),
@@ -546,7 +455,7 @@ describe("position.message.ts", () => {
   });
 
   describe("makeDecreaseLiquidityMessagesWithApproves", () => {
-    it("creates DecreaseLiquidity tx and de-duplicates approve for wugnot", async () => {
+    it("creates DecreaseLiquidity tx without token approve messages", async () => {
       const caller = "caller";
       const lpTokenId = "lp1";
       const deadline = "deadline";
@@ -570,30 +479,9 @@ describe("position.message.ts", () => {
         fetchAllowance,
       );
 
-      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 2);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 0, 0);
 
-      // Base pool approves (wugnot + tokenB) + extra gnot approve should merge into a single wugnot->pool approve.
-      expect(approveMessages).toHaveLength(2);
-      expect(approveMessages).toEqual(
-        expect.arrayContaining([
-          {
-            caller,
-            send: "",
-            pkg_path: "wugnot",
-            func: "Approve",
-            args: ["pool_address", MAX_INT64_STR],
-            gasFee: undefined,
-          },
-          {
-            caller,
-            send: "",
-            pkg_path: "tokenB_path",
-            func: "Approve",
-            args: ["pool_address", MAX_INT64_STR],
-            gasFee: undefined,
-          },
-        ]),
-      );
+      expect(approveMessages).toHaveLength(0);
 
       expect(txMessages).toEqual([
         {
@@ -605,7 +493,8 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
-      expectResetMessages(resetMessages, approveMessages);
+      expect(resetMessages).toHaveLength(0);
+      expect(fetchAllowance).not.toHaveBeenCalled();
     });
   });
 
@@ -645,7 +534,7 @@ describe("position.message.ts", () => {
             send: "",
             pkg_path: "wugnot",
             func: "Approve",
-            args: ["pool_address", MAX_INT64_STR],
+            args: ["pool_address", "2500"],
             gasFee: undefined,
           },
           {
@@ -653,7 +542,7 @@ describe("position.message.ts", () => {
             send: "",
             pkg_path: "tokenB_path",
             func: "Approve",
-            args: ["pool_address", MAX_INT64_STR],
+            args: ["pool_address", "3000000"],
             gasFee: undefined,
           },
         ]),
@@ -682,7 +571,7 @@ describe("position.message.ts", () => {
   });
 
   describe("makeRemoveLiquidityMessagesWithApproves", () => {
-    it("creates approves for pool tokens and (when gnot included) for position package, then DecreaseLiquidity tx for each lpTokenId", async () => {
+    it("creates DecreaseLiquidity tx for each lpTokenId without token approve messages", async () => {
       const caller = "caller";
       const deadline = "deadline";
       const lpTokenIds = ["lp1", "lp2"];
@@ -706,38 +595,9 @@ describe("position.message.ts", () => {
         fetchAllowance,
       );
 
-      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 3);
+      const { approveMessages, txMessages, resetMessages } = splitMessagesByApproveReset(messages, 0, 0);
 
-      // wugnot->pool, tokenB->pool, wugnot->position_address
-      expect(approveMessages).toHaveLength(3);
-      expect(approveMessages).toEqual(
-        expect.arrayContaining([
-          {
-            caller,
-            send: "",
-            pkg_path: "wugnot",
-            func: "Approve",
-            args: ["pool_address", MAX_INT64_STR],
-            gasFee: undefined,
-          },
-          {
-            caller,
-            send: "",
-            pkg_path: "tokenB_path",
-            func: "Approve",
-            args: ["pool_address", MAX_INT64_STR],
-            gasFee: undefined,
-          },
-          {
-            caller,
-            send: "",
-            pkg_path: "wugnot",
-            func: "Approve",
-            args: ["position_address", MAX_INT64_STR],
-            gasFee: undefined,
-          },
-        ]),
-      );
+      expect(approveMessages).toHaveLength(0);
 
       expect(txMessages).toEqual([
         {
@@ -757,7 +617,8 @@ describe("position.message.ts", () => {
           gasFee: undefined,
         },
       ]);
-      expectResetMessages(resetMessages, approveMessages);
+      expect(resetMessages).toHaveLength(0);
+      expect(fetchAllowance).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/web/src/repositories/position/position.message.ts
+++ b/packages/web/src/repositories/position/position.message.ts
@@ -8,17 +8,14 @@ import {
 } from "@common/clients/wallet-client/transaction-messages";
 import {
   PACKAGE_POOL_ADDRESS,
-  PACKAGE_POSITION_ADDRESS,
   PACKAGE_POSITION_PATH,
   PACKAGE_STAKER_ADDRESS,
   PACKAGE_STAKER_PATH,
-  WRAPPED_GNOT_PATH,
 } from "@constants/environment.constant";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { PositionModel } from "@models/position/position-model";
 import { TokenModel } from "@models/token/token-model";
-import { checkGnotPath, isGNOTPath, wrapNativeTokenPath } from "@utils/common";
-import { MAX_INT64 } from "@utils/math.utils";
+import { checkGnotPath, wrapNativeTokenPath } from "@utils/common";
 import { calculateMinTokenAmount } from "@utils/reposition-utils";
 import { makeRawTokenAmount } from "@utils/token-utils";
 import { getWrappedGNOTDepositAmount } from "@utils/transaction-utils";
@@ -49,38 +46,11 @@ export function makeClaimMessageWithApproves(
 
   let hasFee = false;
   let hasStakingReward = false;
-  let isGnotApproved = false;
-
   position.rewards.forEach(reward => {
-    const rewardTokenWrappedPath = checkGnotPath(reward.rewardToken.path);
-    // Reward token approve to Pool
     if (reward.rewardToken.rewardType === "SWAP_FEE") {
       hasFee = true;
-      approveMessageInfos.push({
-        tokenPath: reward.rewardToken.path,
-        targetAddress: PACKAGE_POOL_ADDRESS,
-        amount: MAX_INT64,
-        caller,
-      });
-      approveMessageInfos.push({
-        tokenPath: reward.rewardToken.path,
-        targetAddress: PACKAGE_POSITION_ADDRESS,
-        amount: MAX_INT64,
-        caller,
-      });
-    }
-    // Reward token approve to Staker(When GNOT token)
-    else {
+    } else {
       hasStakingReward = true;
-      if (rewardTokenWrappedPath === WRAPPED_GNOT_PATH && !isGnotApproved) {
-        approveMessageInfos.push({
-          tokenPath: WRAPPED_GNOT_PATH,
-          targetAddress: PACKAGE_STAKER_ADDRESS,
-          amount: MAX_INT64,
-          caller,
-        });
-        isGnotApproved = true;
-      }
     }
   });
 
@@ -112,8 +82,6 @@ export function makeClaimMessageWithApproves(
 
 export function makeClaimAllMessageWithApprovesByIds(
   {
-    swapFeeTokenPaths,
-    hasGnotStakingReward,
     positionsWithSwapFee,
     positionsWithStakingReward,
     caller,
@@ -127,30 +95,6 @@ export function makeClaimAllMessageWithApprovesByIds(
   fetchAllowance: (packagePath: string, owner: string, spender: string) => Promise<number>,
 ): Promise<TransactionMessage[]> {
   const approveMessageInfos: TokenApproveMessageInfo[] = [];
-
-  swapFeeTokenPaths.forEach(tokenPath => {
-    approveMessageInfos.push({
-      tokenPath,
-      targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: MAX_INT64,
-      caller,
-    });
-    approveMessageInfos.push({
-      tokenPath,
-      targetAddress: PACKAGE_POSITION_ADDRESS,
-      amount: MAX_INT64,
-      caller,
-    });
-  });
-
-  if (hasGnotStakingReward) {
-    approveMessageInfos.push({
-      tokenPath: WRAPPED_GNOT_PATH,
-      targetAddress: PACKAGE_STAKER_ADDRESS,
-      amount: MAX_INT64,
-      caller,
-    });
-  }
 
   const messages: TransactionMessage[] = [];
 
@@ -195,13 +139,9 @@ export function makeClaimAllMessageWithApproves(
   const messages: TransactionMessage[] = positions.flatMap(position => {
     let hasFee = false;
     let hasStakingReward = false;
-    let isGnotApproved = false;
-
     const collectMessages: TransactionMessage[] = [];
 
     position.rewards.forEach(reward => {
-      const rewardTokenWrappedPath = checkGnotPath(reward.rewardToken.path);
-      // Reward token approve to Pool
       if (reward.rewardToken.rewardType === "SWAP_FEE") {
         const claimableAmount = BigNumber(reward.claimableAmount).toNumber();
         if (claimableAmount <= 0) {
@@ -209,33 +149,8 @@ export function makeClaimAllMessageWithApproves(
         }
 
         hasFee = true;
-
-        approveMessageInfos.push({
-          tokenPath: reward.rewardToken.path,
-          targetAddress: PACKAGE_POOL_ADDRESS,
-          amount: MAX_INT64,
-          caller,
-        });
-        approveMessageInfos.push({
-          tokenPath: reward.rewardToken.path,
-          targetAddress: PACKAGE_POSITION_ADDRESS,
-          amount: MAX_INT64,
-          caller,
-        });
-      }
-
-      // Reward token approve to Staker(When GNOT token)
-      else {
+      } else {
         hasStakingReward = true;
-        if (rewardTokenWrappedPath === WRAPPED_GNOT_PATH && !isGnotApproved) {
-          approveMessageInfos.push({
-            tokenPath: WRAPPED_GNOT_PATH,
-            targetAddress: PACKAGE_STAKER_ADDRESS,
-            amount: MAX_INT64,
-            caller,
-          });
-          isGnotApproved = true;
-        }
       }
     });
 
@@ -303,33 +218,6 @@ export function makeUnStakePositionsMessagesWithApproves(
 ): Promise<TransactionMessage[]> {
   const approveMessageInfos: TokenApproveMessageInfo[] = [];
 
-  // Reward token approve to Pool and Staker(When GNOT token)
-  const collectRewardApproveMessageInfos = positions.flatMap(position =>
-    position.rewards.flatMap(reward => {
-      const messages: TokenApproveMessageInfo[] = [];
-
-      messages.push({
-        tokenPath: WRAPPED_GNOT_PATH,
-        targetAddress: PACKAGE_POOL_ADDRESS,
-        amount: MAX_INT64,
-        caller,
-      });
-
-      if (reward.rewardToken.path === WRAPPED_GNOT_PATH) {
-        messages.push({
-          tokenPath: WRAPPED_GNOT_PATH,
-          targetAddress: PACKAGE_STAKER_ADDRESS,
-          amount: MAX_INT64,
-          caller,
-        });
-      }
-
-      return messages;
-    }),
-  );
-
-  approveMessageInfos.push(...collectRewardApproveMessageInfos);
-
   const unstakeMessages = positions.map(position =>
     makeTransactionMessage({
       send: "",
@@ -376,13 +264,13 @@ export function makeIncreaseLiquidityMessagesWithApproves(
     {
       tokenPath: tokenAWrappedPath,
       targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: MAX_INT64,
+      amount: tokenAAmountRaw,
       caller,
     },
     {
       tokenPath: tokenBWrappedPath,
       targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: MAX_INT64,
+      amount: tokenBAmountRaw,
       caller,
     },
   ];
@@ -422,8 +310,6 @@ export function makeDecreaseLiquidityMessagesWithApproves(
   {
     lpTokenId,
     calculatedLiquidity,
-    tokenA,
-    tokenB,
     tokenAAmount,
     tokenBAmount,
     slippage,
@@ -442,34 +328,7 @@ export function makeDecreaseLiquidityMessagesWithApproves(
   },
   fetchAllowance: (packagePath: string, owner: string, spender: string) => Promise<number>,
 ): Promise<TransactionMessage[]> {
-  const tokenAWrappedPath = tokenA.wrappedPath || checkGnotPath(tokenA.path);
-  const tokenBWrappedPath = tokenB.wrappedPath || checkGnotPath(tokenB.path);
-
-  // Make Approve messages that can be managed by a Pool package of tokens.
-  const approveMessageInfos: TokenApproveMessageInfo[] = [
-    {
-      tokenPath: tokenAWrappedPath,
-      targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: MAX_INT64,
-      caller,
-    },
-    {
-      tokenPath: tokenBWrappedPath,
-      targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: MAX_INT64,
-      caller,
-    },
-  ];
-
-  // If the GNOT token is included, the Position package must include the token approve.
-  if (isGNOTPath(tokenAWrappedPath) || isGNOTPath(tokenBWrappedPath)) {
-    approveMessageInfos.push({
-      tokenPath: WRAPPED_GNOT_PATH,
-      targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: MAX_INT64,
-      caller,
-    });
-  }
+  const approveMessageInfos: TokenApproveMessageInfo[] = [];
 
   const slippageRatio = (100 - slippage) / 100;
 
@@ -531,13 +390,13 @@ export function makeRepositionLiquidityMessagesWithApproves(
     {
       tokenPath: tokenAWrappedPath,
       targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: MAX_INT64,
+      amount: tokenAAmountRaw,
       caller,
     },
     {
       tokenPath: tokenBWrappedPath,
       targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: MAX_INT64,
+      amount: tokenBAmountRaw,
       caller,
     },
   ];
@@ -576,7 +435,6 @@ export function makeRemoveLiquidityMessagesWithApproves(
   {
     lpTokenIds,
     positionLiquidities,
-    tokenPaths,
     caller,
     deadline = (Math.floor(Date.now() / 1000) + 60 * 5).toString(),
   }: {
@@ -588,23 +446,7 @@ export function makeRemoveLiquidityMessagesWithApproves(
   },
   fetchAllowance: (packagePath: string, owner: string, spender: string) => Promise<number>,
 ): Promise<TransactionMessage[]> {
-  // Make Approve messages that can be managed by a Pool package of tokens.
-  const approveMessageInfos: TokenApproveMessageInfo[] = tokenPaths.map(tokenPath => ({
-    tokenPath: wrapNativeTokenPath(tokenPath),
-    targetAddress: PACKAGE_POOL_ADDRESS,
-    amount: MAX_INT64,
-    caller,
-  }));
-
-  // If the GNOT token is included, the Position package must include the token approve.
-  if (tokenPaths.some(isGNOTPath)) {
-    approveMessageInfos.push({
-      tokenPath: WRAPPED_GNOT_PATH,
-      targetAddress: PACKAGE_POSITION_ADDRESS,
-      amount: MAX_INT64,
-      caller,
-    });
-  }
+  const approveMessageInfos: TokenApproveMessageInfo[] = [];
 
   const removeLiquidityMessages = lpTokenIds.map(lpTokenId => {
     const positionLiquidity = positionLiquidities[lpTokenId] || new BigNumber(0);

--- a/packages/web/src/repositories/swap-router/swap-router.message.spec.ts
+++ b/packages/web/src/repositories/swap-router/swap-router.message.spec.ts
@@ -3,7 +3,6 @@ import type { EstimatedRoute } from "@models/swap/swap-route-info";
 import type { TokenModel } from "@models/token/token-model";
 
 jest.mock("@constants/environment.constant", () => ({
-  PACKAGE_POOL_ADDRESS: "pool_address",
   PACKAGE_ROUTER_ADDRESS: "router_address",
   PACKAGE_ROUTER_PATH: "router_path",
   WRAPPED_GNOT_PATH: "wugnot",
@@ -71,17 +70,9 @@ describe("swap-router.message.ts", () => {
       fetchAllowance,
     );
 
-    const { approveMessages, txMessages, resetMessages } = splitMessages(messages, 2);
+    const { approveMessages, txMessages, resetMessages } = splitMessages(messages, 1);
 
     expect(approveMessages).toEqual([
-      {
-        caller,
-        send: "",
-        pkg_path: "token_in",
-        func: "Approve",
-        args: ["pool_address", "1250000"],
-        gasFee: undefined,
-      },
       {
         caller,
         send: "",
@@ -100,6 +91,7 @@ describe("swap-router.message.ts", () => {
     expect(resetMessages).toEqual(
       approveMessages.map(message => ({ ...message, args: [message.args?.[0] || "", "0"] })),
     );
+    expect(messages.some(message => message.args?.[0] === "pool_address" && message.func === "Approve")).toBe(false);
     expect(messages.some(message => message.pkg_path === "token_out" && message.func === "Approve")).toBe(false);
   });
 
@@ -123,17 +115,9 @@ describe("swap-router.message.ts", () => {
       fetchAllowance,
     );
 
-    const { approveMessages, txMessages, resetMessages } = splitMessages(messages, 2);
+    const { approveMessages, txMessages, resetMessages } = splitMessages(messages, 1);
 
     expect(approveMessages).toEqual([
-      {
-        caller,
-        send: "",
-        pkg_path: "token_in",
-        func: "Approve",
-        args: ["pool_address", "1250000"],
-        gasFee: undefined,
-      },
       {
         caller,
         send: "",
@@ -152,6 +136,7 @@ describe("swap-router.message.ts", () => {
     expect(resetMessages).toEqual(
       approveMessages.map(message => ({ ...message, args: [message.args?.[0] || "", "0"] })),
     );
+    expect(messages.some(message => message.args?.[0] === "pool_address" && message.func === "Approve")).toBe(false);
     expect(messages.some(message => message.pkg_path === "token_out" && message.func === "Approve")).toBe(false);
   });
 });

--- a/packages/web/src/repositories/swap-router/swap-router.message.spec.ts
+++ b/packages/web/src/repositories/swap-router/swap-router.message.spec.ts
@@ -1,0 +1,157 @@
+import type { TransactionMessage } from "@common/clients/wallet-client/transaction-messages/common";
+import type { EstimatedRoute } from "@models/swap/swap-route-info";
+import type { TokenModel } from "@models/token/token-model";
+
+jest.mock("@constants/environment.constant", () => ({
+  PACKAGE_POOL_ADDRESS: "pool_address",
+  PACKAGE_ROUTER_ADDRESS: "router_address",
+  PACKAGE_ROUTER_PATH: "router_path",
+  WRAPPED_GNOT_PATH: "wugnot",
+}));
+
+import {
+  makeExactInSwapRouteMessageWithApproves,
+  makeExactOutSwapRouteMessageWithApproves,
+} from "@repositories/swap-router/swap-router.message";
+
+const createTokenModel = (path: string, overrides?: Partial<TokenModel>): TokenModel => ({
+  path,
+  type: "GRC20",
+  chainId: "dev.gnoswap",
+  createdAt: "2024-01-24T15:12:21Z",
+  name: path,
+  symbol: path,
+  decimals: 6,
+  logoURI: "",
+  priceID: path,
+  ...overrides,
+});
+
+const route: EstimatedRoute = {
+  quote: 1,
+  amountIn: 1_000_000n,
+  amountOut: 2_000_000n,
+  pools: [
+    {
+      tokenA: "token_in",
+      tokenB: "token_out",
+      fee: 3000,
+      price: 1,
+      tokenABalance: 0,
+      tokenBBalance: 0,
+      poolPath: "pool_path",
+    },
+  ],
+};
+
+const splitMessages = (messages: TransactionMessage[], approveCount: number) => ({
+  approveMessages: messages.slice(0, approveCount),
+  txMessages: messages.slice(approveCount, messages.length - approveCount),
+  resetMessages: messages.slice(messages.length - approveCount),
+});
+
+describe("swap-router.message.ts", () => {
+  it("approves only input token for exact-in swaps using exact input amount", async () => {
+    const caller = "caller";
+    const inputToken = createTokenModel("token_in");
+    const outputToken = createTokenModel("token_out");
+    const fetchAllowance = jest.fn(async () => 0);
+
+    const messages = await makeExactInSwapRouteMessageWithApproves(
+      {
+        inputToken,
+        outputToken,
+        tokenAmount: 1.25,
+        estimatedRoutes: [route],
+        tokenAmountLimit: 2,
+        deadline: 123,
+        caller,
+        referrerAddress: null,
+      },
+      fetchAllowance,
+    );
+
+    const { approveMessages, txMessages, resetMessages } = splitMessages(messages, 2);
+
+    expect(approveMessages).toEqual([
+      {
+        caller,
+        send: "",
+        pkg_path: "token_in",
+        func: "Approve",
+        args: ["pool_address", "1250000"],
+        gasFee: undefined,
+      },
+      {
+        caller,
+        send: "",
+        pkg_path: "token_in",
+        func: "Approve",
+        args: ["router_address", "1250000"],
+        gasFee: undefined,
+      },
+    ]);
+    expect(txMessages).toHaveLength(1);
+    expect(txMessages[0]).toMatchObject({
+      pkg_path: "router_path",
+      func: "ExactInSwapRoute",
+      args: ["token_in", "token_out", "1250000", "token_in:token_out:3000", "1", "2000000", "123", ""],
+    });
+    expect(resetMessages).toEqual(
+      approveMessages.map(message => ({ ...message, args: [message.args?.[0] || "", "0"] })),
+    );
+    expect(messages.some(message => message.pkg_path === "token_out" && message.func === "Approve")).toBe(false);
+  });
+
+  it("approves only input token for exact-out swaps using max sent amount", async () => {
+    const caller = "caller";
+    const inputToken = createTokenModel("token_in");
+    const outputToken = createTokenModel("token_out");
+    const fetchAllowance = jest.fn(async () => 0);
+
+    const messages = await makeExactOutSwapRouteMessageWithApproves(
+      {
+        inputToken,
+        outputToken,
+        tokenAmount: 2,
+        estimatedRoutes: [route],
+        tokenAmountLimit: 1.25,
+        deadline: 123,
+        caller,
+        referrerAddress: null,
+      },
+      fetchAllowance,
+    );
+
+    const { approveMessages, txMessages, resetMessages } = splitMessages(messages, 2);
+
+    expect(approveMessages).toEqual([
+      {
+        caller,
+        send: "",
+        pkg_path: "token_in",
+        func: "Approve",
+        args: ["pool_address", "1250000"],
+        gasFee: undefined,
+      },
+      {
+        caller,
+        send: "",
+        pkg_path: "token_in",
+        func: "Approve",
+        args: ["router_address", "1250000"],
+        gasFee: undefined,
+      },
+    ]);
+    expect(txMessages).toHaveLength(1);
+    expect(txMessages[0]).toMatchObject({
+      pkg_path: "router_path",
+      func: "ExactOutSwapRoute",
+      args: ["token_in", "token_out", "2000000", "token_in:token_out:3000", "1", "1250000", "123", ""],
+    });
+    expect(resetMessages).toEqual(
+      approveMessages.map(message => ({ ...message, args: [message.args?.[0] || "", "0"] })),
+    );
+    expect(messages.some(message => message.pkg_path === "token_out" && message.func === "Approve")).toBe(false);
+  });
+});

--- a/packages/web/src/repositories/swap-router/swap-router.message.ts
+++ b/packages/web/src/repositories/swap-router/swap-router.message.ts
@@ -14,7 +14,6 @@ import {
 import { EstimatedRoute } from "@models/swap/swap-route-info";
 import { isNativeToken, TokenModel } from "@models/token/token-model";
 import { checkGnotPath } from "@utils/common";
-import { MAX_INT64 } from "@utils/math.utils";
 import { makeRoutesQuery } from "@utils/swap-route-utils";
 import { isNativeTokenPath, makeRawTokenAmount } from "@utils/token-utils";
 
@@ -89,19 +88,13 @@ export function makeExactInSwapRouteMessageWithApproves(
     {
       tokenPath: inputTokenWrappedPath,
       targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: MAX_INT64,
+      amount: tokenAmountRaw,
       caller,
     },
     {
       tokenPath: inputTokenWrappedPath,
       targetAddress: PACKAGE_ROUTER_ADDRESS,
-      amount: MAX_INT64,
-      caller,
-    },
-    {
-      tokenPath: outputTokenWrappedPath,
-      targetAddress: PACKAGE_ROUTER_ADDRESS,
-      amount: MAX_INT64,
+      amount: tokenAmountRaw,
       caller,
     },
   ];
@@ -162,19 +155,13 @@ export function makeExactOutSwapRouteMessageWithApproves(
     {
       tokenPath: inputTokenWrappedPath,
       targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: MAX_INT64,
+      amount: tokenAmountLimitRaw,
       caller,
     },
     {
       tokenPath: inputTokenWrappedPath,
       targetAddress: PACKAGE_ROUTER_ADDRESS,
-      amount: MAX_INT64,
-      caller,
-    },
-    {
-      tokenPath: outputTokenWrappedPath,
-      targetAddress: PACKAGE_ROUTER_ADDRESS,
-      amount: MAX_INT64,
+      amount: tokenAmountLimitRaw,
       caller,
     },
   ];

--- a/packages/web/src/repositories/swap-router/swap-router.message.ts
+++ b/packages/web/src/repositories/swap-router/swap-router.message.ts
@@ -6,11 +6,7 @@ import {
   TokenApproveMessageInfo,
   TransactionMessage,
 } from "@common/clients/wallet-client/transaction-messages";
-import {
-  PACKAGE_POOL_ADDRESS,
-  PACKAGE_ROUTER_ADDRESS,
-  PACKAGE_ROUTER_PATH,
-} from "@constants/environment.constant";
+import { PACKAGE_ROUTER_ADDRESS, PACKAGE_ROUTER_PATH } from "@constants/environment.constant";
 import { EstimatedRoute } from "@models/swap/swap-route-info";
 import { isNativeToken, TokenModel } from "@models/token/token-model";
 import { checkGnotPath } from "@utils/common";
@@ -87,12 +83,6 @@ export function makeExactInSwapRouteMessageWithApproves(
   const approveInfos: TokenApproveMessageInfo[] = [
     {
       tokenPath: inputTokenWrappedPath,
-      targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: tokenAmountRaw,
-      caller,
-    },
-    {
-      tokenPath: inputTokenWrappedPath,
       targetAddress: PACKAGE_ROUTER_ADDRESS,
       amount: tokenAmountRaw,
       caller,
@@ -152,12 +142,6 @@ export function makeExactOutSwapRouteMessageWithApproves(
   messages.push(swapMessage);
 
   const approveInfos: TokenApproveMessageInfo[] = [
-    {
-      tokenPath: inputTokenWrappedPath,
-      targetAddress: PACKAGE_POOL_ADDRESS,
-      amount: tokenAmountLimitRaw,
-      caller,
-    },
     {
       tokenPath: inputTokenWrappedPath,
       targetAddress: PACKAGE_ROUTER_ADDRESS,


### PR DESCRIPTION
## Summary

This PR updates approval injection messages to match the current contract flows from GSW-2690. It removes approval/revoke transactions where contracts no longer consume user allowances, and replaces broad `MAX_INT64` approvals with exact, dynamic, or slippage-bounded raw spend amounts where approval is still required.

## Flow changes

| Flow | Before | After | Contract basis |
| --- | --- | --- | --- |
| Swap - Exact In | Approved input token and output token with `MAX_INT64` | Approves only input token to Router with exact input raw amount | Router callback performs `TransferFrom(user -> pool)` as the spender; Pool approval and output-token approval are unused for router swaps |
| Swap - Exact Out | Approved input token and output token with `MAX_INT64` | Approves only input token to Router with max sent raw amount, calculated from the slippage-bounded input limit | Exact-out transfer is capped by `amountInMax`; output token approval and Pool approval are unused |
| Claim Swap Fees | Approved fee tokens to Pool + Position, then reset | Removes token approve/reset messages | `CollectFee` pays out owed balances and does not pull user GRC20 allowance |
| Unstaking | Approved wGNOT to Pool/Staker, then reset | Removes token approve/reset messages | `UnStakeToken` transfers the staked position back; no user GRC20 allowance is consumed |
| Remove Position | Approved pool tokens and wGNOT to Pool/Position, then reset | Removes token approve/reset messages | Remove-position path uses `DecreaseLiquidity`; it pays tokens out and does not pull user GRC20 allowance |
| Mint Position | Approved deposit tokens with `MAX_INT64`; also approved wGNOT to Position for native GNOT paths | Approves token0/token1 to Pool using desired raw token amounts only | Pool `Mint` pulls desired token amounts from the user via Pool allowance |
| Increase / Reposition | Approved token0/token1 with `MAX_INT64` | Approves token0/token1 to Pool using desired raw token amounts | Position add-liquidity path caps spend by desired token amounts |
| Create Pool | Approved GNS creation fee with `MAX_INT64` | Approves exact `createPoolFee` | Pool creation consumes only the configured GNS creation fee |
| External Incentive | Approved GNS/reward tokens with `MAX_INT64` | Approves API-provided incentive creation deposit amount + exact reward raw amount | Staker pulls the incentive creation deposit and reward token amount; the deposit amount is sourced from `/incentivize/deposit` with a named default fallback |
| Governance Delegate / Redelegate | Approved GNS with `MAX_INT64` | Approves exact delegate/redelegate amount | Governance staker pulls only the requested GNS amount |
| Launchpad Deposit | Approved GNS with `MAX_INT64` | Approves exact launchpad deposit amount | Launchpad pulls only the requested GNS deposit amount |

## Tests added / updated

| Area | Coverage |
| --- | --- |
| Swap router messages | Exact-in approves only input token to Router with exact input amount; exact-out approves only input token to Router with slippage-bounded max sent amount |
| Pool messages | Mint approvals use exact desired amounts; GNS incentive approval combines the provided creation deposit + reward amount |
| Position messages | Claim, unstake, decrease, and remove position produce no GRC20 approve/reset messages |
| Governance messages | Delegate approval uses the exact delegated GNS amount |
| Launchpad messages | Deposit approval uses the exact deposited GNS amount |

## Verification

- Rebased onto latest `origin/develop` (`daff23ff`)
- `yarn workspace @gnoswap-labs/web jest --runTestsByPath src/repositories/pool/pool.message.spec.ts --runInBand`
- `yarn workspace @gnoswap-labs/web jest --runTestsByPath src/repositories/position/position.message.spec.ts src/repositories/swap-router/swap-router.message.spec.ts src/repositories/pool/pool.message.spec.ts src/repositories/governance/governance.message.spec.ts src/repositories/launchpad/launchpad.message.spec.ts --runInBand`
- `yarn workspace @gnoswap-labs/web lint` (passes with existing warnings)
- `yarn build`
- LSP diagnostics on modified files: no errors
- Oracle review: no blockers

## Notes

- No flow in this PR intentionally creates broad `MAX_INT64` approvals. The shared approval combiner still clamps sums above int64 to `MAX_INT64_STR` as an overflow guard.
- Full `tsc --noEmit` still reports existing unrelated spec fixture type errors outside this change set.
- Jira: GSW-2690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated token approval amounts across swap operations, liquidity management, governance delegations, and incentive creation to use exact transaction amounts instead of unlimited allowances.

* **Tests**
  * Added comprehensive test coverage for swap-router, pool, launchpad, and governance message workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->