### PR TITLE
fix: apply token decimals to amount handling

### DIFF
--- a/packages/web/src/components/common/header/wallet-connector-button/wallet-connector-menu/WalletConnectorMenu.tsx
+++ b/packages/web/src/components/common/header/wallet-connector-button/wallet-connector-menu/WalletConnectorMenu.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useTheme } from "@emotion/react";
 import { Trans, useTranslation } from "next-i18next";
 
+import { GNOT_TOKEN } from "@common/values/token-constant";
 import { SOCIAL_WALLET_EXTERNAL_URL } from "@constants/external-url.contant";
 import Button, { ButtonHierarchy } from "@components/common/button/Button";
 import IconInfo from "@components/common/icons/IconInfo";
@@ -130,7 +131,7 @@ const WalletConnectorMenu: React.FC<WalletConnectorMenuProps> = ({
     const balance = gnotBalance || account?.balances?.[0].amount || "-";
     const formattedPrice =
       BigNumber(balance ?? 0)
-        .shiftedBy((gnotToken?.decimals ?? 0) * -1)
+        .shiftedBy((gnotToken?.decimals ?? GNOT_TOKEN.decimals) * -1)
         .toString()
         .match(roundDownDecimalNumber(6))
         ?.toString() ?? 0;

--- a/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/LaunchpadClaimAllModal.tsx
+++ b/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/LaunchpadClaimAllModal.tsx
@@ -46,7 +46,7 @@ const LaunchpadClaimAllModal = ({
         ...participation,
         claimableRewardAmount: rawToDisplayAmount(
           participation.claimableRewardAmount,
-          participation.rewardToken?.decimals || 0,
+          participation.rewardToken?.decimals ?? rewardInfo.rewardTokenDecimals,
         ),
         depositAmount: rawToDisplayAmount(participation.depositAmount, GNS_TOKEN.decimals),
       };

--- a/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/launchpad-claim-amount-field/LaunchpadClaimAmountField.tsx
+++ b/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/launchpad-claim-amount-field/LaunchpadClaimAmountField.tsx
@@ -56,7 +56,7 @@ const LaunchpadClaimAmountField = ({ amount, rewardInfo, type }: LaunchpadClaimA
             src={DEFAULT_DEPOSIT_TOKEN?.logoURI}
             alt={`${DEFAULT_DEPOSIT_TOKEN?.symbol} token symbol image`}
           />
-          {toNumberFormat(amount, 6)} {DEFAULT_DEPOSIT_TOKEN?.symbol}
+          {toNumberFormat(amount, DEFAULT_DEPOSIT_TOKEN.decimals)} {DEFAULT_DEPOSIT_TOKEN?.symbol}
         </div>
         <div className="value-price">{estimatePrice}</div>
       </ClaimAllFieldWrapper>
@@ -68,7 +68,7 @@ const LaunchpadClaimAmountField = ({ amount, rewardInfo, type }: LaunchpadClaimA
       <ClaimAllFieldWrapper>
         <div className="value-token">
           <MissingLogo symbol={rewardInfo.rewardTokenSymbol} url={rewardInfo?.rewardTokenLogoURL} width={24} />
-          {toNumberFormat(amount, 6)} {rewardInfo?.rewardTokenSymbol}
+          {toNumberFormat(amount, rewardInfo.rewardTokenDecimals)} {rewardInfo?.rewardTokenSymbol}
         </div>
         <div className="value-price">{estimatePrice}</div>
       </ClaimAllFieldWrapper>

--- a/packages/web/src/components/swap/confirm-swap-modal/ConfirmSwapModal.tsx
+++ b/packages/web/src/components/swap/confirm-swap-modal/ConfirmSwapModal.tsx
@@ -110,8 +110,9 @@ const ConfirmSwapModal: React.FC<ConfirmSwapModalProps> = ({
   const guaranteedStr = useMemo(() => {
     if (!swapSummaryInfo) return;
     const { amount, currency } = swapSummaryInfo.guaranteedAmount;
-    return `${toNumberFormat(amount, 6)} ${currency}`;
-  }, [swapSummaryInfo?.guaranteedAmount]);
+    const guaranteedToken = swapSummaryInfo.swapDirection === "EXACT_IN" ? swapSummaryInfo.tokenB : swapSummaryInfo.tokenA;
+    return `${toNumberFormat(amount, guaranteedToken.decimals)} ${currency}`;
+  }, [swapSummaryInfo]);
 
   const gasFeeStr = useMemo(() => {
     if (!swapSummaryInfo) return;

--- a/packages/web/src/components/swap/swap-card-content-detail/swap-card-fee-info/SwapCardFeeInfo.tsx
+++ b/packages/web/src/components/swap/swap-card-content-detail/swap-card-fee-info/SwapCardFeeInfo.tsx
@@ -51,12 +51,13 @@ const SwapCardFeeInfo: React.FC<ContentProps> = ({
   const { guaranteedTypeStr, guaranteedStr } = useMemo(() => {
     const swapDirection = swapSummaryInfo.swapDirection;
     const { amount, currency } = swapSummaryInfo.guaranteedAmount;
+    const guaranteedToken = swapDirection === "EXACT_IN" ? swapSummaryInfo.tokenB : swapSummaryInfo.tokenA;
 
     return {
       guaranteedTypeStr: t(swapDirectionToGuaranteedType(swapDirection)),
-      guaranteedStr: `${toNumberFormat(amount || 0, 6)} ${currency}`,
+      guaranteedStr: `${toNumberFormat(amount || 0, guaranteedToken.decimals)} ${currency}`,
     };
-  }, [swapSummaryInfo.swapDirection, swapSummaryInfo.guaranteedAmount, t]);
+  }, [swapSummaryInfo.swapDirection, swapSummaryInfo.guaranteedAmount, swapSummaryInfo.tokenA, swapSummaryInfo.tokenB, t]);
 
   const { gasFeeStr, gasFeeUSDStr } = useMemo(() => {
     const { amount, currency } = swapSummaryInfo.gasFee;

--- a/packages/web/src/hooks/governance/data/use-governance-tx.tsx
+++ b/packages/web/src/hooks/governance/data/use-governance-tx.tsx
@@ -14,6 +14,7 @@ import { useTransactionConfirmModal } from "@hooks/common/use-transaction-confir
 import { useTransactionEventStore } from "@hooks/common/use-transaction-event-store";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { DexEvent, DexEventType } from "@repositories/common";
+import { makeRawTokenAmount } from "@utils/token-utils";
 
 export const useGovernanceTx = () => {
   const { getNextReferralAddress, removeReferrerFromLocalStorage } = useReferral();
@@ -103,10 +104,10 @@ export const useGovernanceTx = () => {
       return;
     }
 
-    const unitAmount = Math.floor(Number(amount) * 10 ** GNS_TOKEN.decimals);
+    const unitAmount = makeRawTokenAmount(GNS_TOKEN, amount) || "0";
 
     const messageData = {
-      tokenAAmount: (unitAmount / 10 ** GNS_TOKEN.decimals).toLocaleString("en"),
+      tokenAAmount: Number(amount).toLocaleString("en"),
       tokenASymbol: GNS_TOKEN.symbol,
       target: toName,
     };
@@ -117,7 +118,7 @@ export const useGovernanceTx = () => {
       () =>
         governanceRepository.sendDelegate({
           to: toAddress,
-          amount: unitAmount.toString(),
+          amount: unitAmount,
           referrerAddress: currentReferralAddress,
         }),
       DexEvent.DELEGATE,
@@ -142,10 +143,10 @@ export const useGovernanceTx = () => {
       return;
     }
 
-    const unitAmount = Math.floor(Number(amount) * 10 ** GNS_TOKEN.decimals);
+    const unitAmount = makeRawTokenAmount(GNS_TOKEN, amount) || "0";
 
     const messageData = {
-      tokenAAmount: (unitAmount / 10 ** GNS_TOKEN.decimals).toLocaleString("en"),
+      tokenAAmount: Number(amount).toLocaleString("en"),
       tokenASymbol: GNS_TOKEN.symbol,
       target: fromName,
     };
@@ -154,7 +155,7 @@ export const useGovernanceTx = () => {
       () =>
         governanceRepository.sendUndelegate({
           to: fromAddress,
-          amount: unitAmount.toString(),
+          amount: unitAmount,
         }),
       DexEvent.UNDELEGATE,
       messageData,
@@ -246,7 +247,7 @@ export const useGovernanceTx = () => {
       return;
     }
 
-    const unitAmount = Math.floor(Number(amount) * 10 ** GNS_TOKEN.decimals);
+    const unitAmount = makeRawTokenAmount(GNS_TOKEN, amount) || "0";
     const messageData = {
       target: t("Governance:proposal.type.community"),
     };
@@ -258,7 +259,7 @@ export const useGovernanceTx = () => {
           description,
           tokenPath,
           to: toAddress,
-          amount: unitAmount.toString(),
+          amount: unitAmount,
         }),
       DexEvent.PROPOSE_COMM_POOL_SPEND,
       messageData,

--- a/packages/web/src/hooks/launchpad/data/use-launchpad-handler.ts
+++ b/packages/web/src/hooks/launchpad/data/use-launchpad-handler.ts
@@ -165,7 +165,7 @@ export const useLaunchpadHandler = () => {
 
     // Calculate the USD value of the Deposited USD available for withdrawal.
     const depositAmount = isWithdrawable ? participationInfo.depositAmount : 0;
-    const depositUSDValue = calculateUSDValueBy(depositAmount, tokenPriceMap?.[GNS_TOKEN.path]?.usd);
+    const depositUSDValue = calculateUSDValueBy(depositAmount, tokenPriceMap?.[GNS_TOKEN.priceID]?.usd);
 
     // Calculate the USD value of the claimable reward.
     const rewardAmount = participationInfo.claimableRewardAmount;
@@ -236,7 +236,7 @@ export const useLaunchpadHandler = () => {
       return BigNumber(accumulated).plus(info.depositAmount);
     }, BigNumber(0));
 
-    const depositUSDValue = calculateUSDValueBy(depositAmount, tokenPriceMap?.[GNS_TOKEN.path]?.usd);
+    const depositUSDValue = calculateUSDValueBy(depositAmount, tokenPriceMap?.[GNS_TOKEN.priceID]?.usd);
 
     // Calculate the USD value of the claimable reward.
     const rewardAmount = participationInfos.reduce((accumulated, current) => {

--- a/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
@@ -258,10 +258,10 @@ export const usePoolAddLiquidityConfirmModal = ({
   } => {
     return {
       token: GNS_TOKEN,
-      fee: GNS_TOKEN ? `${makeDisplayTokenAmount(GNS_TOKEN, creationFee || 0)}` : "",
+      fee: `${makeDisplayTokenAmount(GNS_TOKEN, creationFee || 0)}`,
       errorMsg: (() => {
         let totalGnsAmount = makeDisplayTokenAmount(GNS_TOKEN, creationFee || 0) || 0;
-        const gnsBalance = displayBalanceMap[GNS_TOKEN?.priceID ?? ""] || 0;
+        const gnsBalance = displayBalanceMap[GNS_TOKEN.priceID] || 0;
 
         if (tokenA?.priceID === GNS_TOKEN_PATH) {
           totalGnsAmount += Number(tokenAAmount);

--- a/packages/web/src/hooks/swap/data/use-swap-handler.tsx
+++ b/packages/web/src/hooks/swap/data/use-swap-handler.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { ERROR_VALUE } from "@common/errors/adena";
 import { ERROR_VALUE as SWAP_ERROR_VALUE } from "@common/errors/swap";
 import { DEFAULT_GAS_FEE, MINIMUM_GNOT_SWAP_AMOUNT } from "@common/values";
+import { GNOT_TOKEN } from "@common/values/token-constant";
 import ConfirmSwapModal from "@components/swap/confirm-swap-modal/ConfirmSwapModal";
 import { PAGE_PATH } from "@constants/page.constant";
 import { useBroadcastHandler } from "@hooks/common/use-broadcast-handler";
@@ -126,7 +127,11 @@ function compareAmountFn(amountA: string | number | bigint, amountB: string | nu
 
 function handleAmount(changed: string, token: TokenModel | null) {
   let value = changed;
-  const decimals = token?.decimals || 0;
+  const decimals = token?.decimals;
+
+  if (decimals === undefined) {
+    return { isValid: false, value: changed };
+  }
 
   // Check if input exceeds decimal places
   if (changed.includes(".") && changed.split(".")[1].length > decimals) {
@@ -137,7 +142,7 @@ function handleAmount(changed: string, token: TokenModel | null) {
   if (!value || BigNumber(value).isZero()) {
     value = changed;
   } else {
-    value = BigNumber(value).toFixed(decimals || 0, 1);
+    value = BigNumber(value).toFixed(decimals, 1);
   }
 
   if (BigNumber(changed).isEqualTo(value)) {
@@ -234,7 +239,7 @@ export const useSwapHandler = () => {
   const defaultGasFeeAmount = useMemo(
     () =>
       BigNumber(DEFAULT_GAS_FEE)
-        .shiftedBy(-(gnotToken?.decimals ?? 0))
+        .shiftedBy(-(gnotToken?.decimals ?? GNOT_TOKEN.decimals))
         .toNumber(),
     [gnotToken?.decimals],
   );
@@ -332,8 +337,12 @@ export const useSwapHandler = () => {
       const tokenAUSDValue = tokenPrices[checkGnotPath(tokenA.path)]?.usd || 0;
       const tokenBUSDValue = tokenPrices[checkGnotPath(tokenB.path)]?.usd || 0;
 
-      const tokenAUSDAmount = (makeDisplayTokenAmount(tokenA, tokenAAmount) || 0) * Number(tokenAUSDValue);
-      const tokenBUSDAmount = (makeDisplayTokenAmount(tokenB, tokenBAmount) || 0) * Number(tokenBUSDValue);
+      const tokenAUSDAmount = BigNumber(tokenAAmount || 0)
+        .multipliedBy(tokenAUSDValue)
+        .toNumber();
+      const tokenBUSDAmount = BigNumber(tokenBAmount || 0)
+        .multipliedBy(tokenBUSDValue)
+        .toNumber();
 
       const priceImpactNum =
         tokenAUSDAmount !== 0

--- a/packages/web/src/hooks/token/data/use-token-amount-input.tsx
+++ b/packages/web/src/hooks/token/data/use-token-amount-input.tsx
@@ -31,11 +31,16 @@ const DELEGATE_MIN_AMOUNT = 1;
 
 function handleAmount(changed: string, token: TokenModel | null) {
   let value = changed;
-  const decimals = token?.decimals || 0;
+  const decimals = token?.decimals;
+
+  if (decimals === undefined) {
+    return changed;
+  }
+
   if (!value || BigNumber(value).isZero()) {
     value = changed;
   } else {
-    value = BigNumber(value).toFixed(decimals || 0, 1);
+    value = BigNumber(value).toFixed(decimals, 1);
   }
 
   if (BigNumber(changed).isEqualTo(value)) {

--- a/packages/web/src/layouts/dashboard/containers/dashboard-info-container/DashboardInfoContainer.tsx
+++ b/packages/web/src/layouts/dashboard/containers/dashboard-info-container/DashboardInfoContainer.tsx
@@ -21,14 +21,14 @@ const formatDashboardPrice = (price?: string, unit?: string) => {
 const DashboardInfoContainer: React.FC = () => {
   const { breakpoint } = useWindowSize();
   const { isLoading: isLoadingCommon } = useLoading();
-
   const { data: dashboardTokenData, isFetched: isFetchedDashboardToken } = useGetDashboardToken();
-  const convertedDashboardTokenData = React.useMemo(() => {
-    return ExploreDashboardConverter.convertDashboardToken(dashboardTokenData);
-  }, [dashboardTokenData]);
 
   const { data: governanceOverview = null, isFetched: isFetchedGovernanceOverview } =
     useGetDashboardGovernanceOverview();
+
+  const convertedDashboardTokenData = React.useMemo(() => {
+    return ExploreDashboardConverter.convertDashboardToken(dashboardTokenData);
+  }, [dashboardTokenData]);
 
   const convertedGovernanceOverview = React.useMemo(() => {
     return ExploreDashboardConverter.convertGovernanceOverview(governanceOverview);
@@ -99,7 +99,7 @@ const DashboardInfoContainer: React.FC = () => {
         community: formatOtherPrice(Math.floor(emissionDistribution.community), { isKMB: false, usd: false }),
       },
     };
-  }, [dashboardTokenData, progressBar, stakingRatio]);
+  }, [convertedDashboardTokenData, progressBar, stakingRatio]);
 
   const governanceOverviewInfo = useMemo(() => {
     if (!convertedGovernanceOverview) {

--- a/packages/web/src/layouts/earn/components/earn-my-positions/earn-my-positions-content/earn-my-positions-no-liquidity/EarnMyPositionNoLiquidity.tsx
+++ b/packages/web/src/layouts/earn/components/earn-my-positions/earn-my-positions-content/earn-my-positions-no-liquidity/EarnMyPositionNoLiquidity.tsx
@@ -3,12 +3,14 @@ import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { sanitizeHtml } from "@utils/sanitize-html";
 
+import { GNOT_TOKEN } from "@common/values/token-constant";
 import IconNoPosition from "@components/common/icons/IconNoPosition";
 import { WRAPPED_GNOT_PATH } from "@constants/environment.constant";
 import { useTokenData } from "@hooks/token/data/use-token-data";
 import { AccountModel } from "@models/account/account-model";
 import { useGetAllTokenPrices } from "@query/token";
 import { convertToKMB } from "@utils/stake-position-utils";
+import { makeDisplayTokenAmount } from "@utils/token-utils";
 
 import { NoLiquidityWrapper } from "./EarnMyPositionNoLiquidity.styles";
 
@@ -19,19 +21,24 @@ interface EarnMyPositionNoLiquidityProps {
 
 const EarnMyPositionNoLiquidity: React.FC<EarnMyPositionNoLiquidityProps> = ({ highestApr }) => {
   const { t } = useTranslation();
-  const { balances: balancesPrice } = useTokenData();
+  const { balances: balancesPrice, tokens } = useTokenData();
   const { data: tokenPrices = {} } = useGetAllTokenPrices();
   const availableBalance = useMemo(() => {
     return Object.entries(balancesPrice).reduce((acc, [key, value]) => {
       const path = key === "ugnot" ? WRAPPED_GNOT_PATH : key;
+      const token = tokens.find(token => token.priceID === key || token.path === key || token.path === path);
+      const displayAmount = token
+        ? makeDisplayTokenAmount(token, value || 0) || 0
+        : BigNumber(value || 0)
+            .shiftedBy(-GNOT_TOKEN.decimals)
+            .toNumber();
       const balance =
-        BigNumber(value || 0)
+        BigNumber(displayAmount)
           .multipliedBy(tokenPrices?.[path]?.pricesBefore?.latestPrice || 0)
-          .dividedBy(10 ** 6)
           .toNumber() || 0;
       return BigNumber(acc).plus(balance).toNumber();
     }, 0);
-  }, [balancesPrice, tokenPrices]);
+  }, [balancesPrice, tokenPrices, tokens]);
   const isInterger = Number.isInteger(Number(availableBalance));
   const converted = `$${convertToKMB(`${availableBalance}`, {
     maximumFractionDigits: isInterger ? 0 : 2,

--- a/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.tsx
+++ b/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.tsx
@@ -47,17 +47,16 @@ const GovernanceSummary: React.FC<GovernanceSummaryProps> = ({
 
   const displayGovernanceSummary: GovernanceSummaryInfo = React.useMemo(() => {
     const { delegationInfo } = governanceSummary;
-    const GNS_TOKEN_DECIMALS = GNS_TOKEN.decimals;
 
     return {
       ...governanceSummary,
       delegationInfo: {
-        totalDelegationAmount: String(rawToDisplayAmount(delegationInfo.totalDelegationAmount, GNS_TOKEN_DECIMALS)),
+        totalDelegationAmount: String(rawToDisplayAmount(delegationInfo.totalDelegationAmount, GNS_TOKEN.decimals)),
         governanceDelegationAmount: String(
-          rawToDisplayAmount(delegationInfo.governanceDelegationAmount, GNS_TOKEN_DECIMALS),
+          rawToDisplayAmount(delegationInfo.governanceDelegationAmount, GNS_TOKEN.decimals),
         ),
         launchpadDelegationAmount: String(
-          rawToDisplayAmount(delegationInfo.launchpadDelegationAmount, GNS_TOKEN_DECIMALS),
+          rawToDisplayAmount(delegationInfo.launchpadDelegationAmount, GNS_TOKEN.decimals),
         ),
       },
     };
@@ -101,7 +100,7 @@ const GovernanceSummary: React.FC<GovernanceSummaryProps> = ({
           ...gnotPathInfo,
         };
 
-        const displayAmount = rawToDisplayAmount(balance.amount, tokenInfo.decimals || 0);
+        const displayAmount = rawToDisplayAmount(balance.amount, tokenInfo.decimals);
         const usdValue = getTokenUSDPrice(balance.path, displayAmount) || 0;
 
         return {
@@ -111,7 +110,7 @@ const GovernanceSummary: React.FC<GovernanceSummaryProps> = ({
         };
       })
       .sort((a, b) => b.usdValue - a.usdValue);
-  }, [governanceCommunityPoolBalances]);
+  }, [getGnotPath, getTokenUSDPrice, governanceCommunityPoolBalances, tokens]);
 
   const delegatedRatioValue = React.useMemo(() => {
     return `${formatOtherPrice(Number(governanceSummary.delegatedRatio) * 100, {

--- a/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
+++ b/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
@@ -97,7 +97,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
         }),
       )
       .sort(sortByAmountAndDate);
-  }, [myDelegates.delegates]);
+  }, [myDelegates.delegates, sortByAmountAndDate]);
 
   const myUnDelegatesInfo: DelegationItemInfo[] = useMemo(() => {
     return myUnDelegates.delegations
@@ -114,7 +114,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
         }),
       )
       .sort(sortByAmountAndDate);
-  }, [myUnDelegates.delegations]);
+  }, [myUnDelegates.delegations, sortByAmountAndDate]);
 
   const hasMyDelegates = myDelegatesInfo.length > 0;
   const hasMyUnDelegates = myUnDelegatesInfo.length > 0;

--- a/packages/web/src/layouts/governance/components/my-delegation/my-delegation-modals/MyDelegationDelegateModal.tsx
+++ b/packages/web/src/layouts/governance/components/my-delegation/my-delegation-modals/MyDelegationDelegateModal.tsx
@@ -264,7 +264,6 @@ const MyDelegationDelegateModal: React.FC<MyDelegationDelegateModalProps> = ({
           changeAmount={gnsAmountInput.changeAmount}
           changeToken={() => {}}
           style={{ padding: "16px" }}
-          integersOnly={true}
         />
       </article>
 
@@ -428,7 +427,7 @@ const MyDelegationDelegateModal: React.FC<MyDelegationDelegateModalProps> = ({
         <div className="delegatee-info-rows">
           <div className="label">{t("Governance:myDel.delModal.selectDel.votingPower")}</div>
           <div className="value no-wrap">
-            <MissingLogo symbol="xGNS" url={XGNS_TOKEN.logoURI} width={24} />
+            <MissingLogo symbol={XGNS_TOKEN.symbol} url={XGNS_TOKEN.logoURI} width={24} />
             {formatOtherPrice(toDisplayVotingPowerFromRaw(selectedDelegateVotingPowerRaw), {
               isKMB: false,
               usd: false,

--- a/packages/web/src/layouts/governance/components/proposals-list/create-proposal-modal/CreateProposalModal.tsx
+++ b/packages/web/src/layouts/governance/components/proposals-list/create-proposal-modal/CreateProposalModal.tsx
@@ -351,8 +351,8 @@ const CreateProposalModal: React.FC<CreateProposalModalProps> = ({
     const decimalIndex = value.indexOf(".");
     if (decimalIndex !== -1) {
       const decimals = value.slice(decimalIndex + 1);
-      if (decimals.length > 6) {
-        e.target.value = value.slice(0, decimalIndex + 7);
+      if (decimals.length > GNS_TOKEN.decimals) {
+        e.target.value = value.slice(0, decimalIndex + GNS_TOKEN.decimals + 1);
       }
     }
   };

--- a/packages/web/src/layouts/governance/components/proposals-list/view-proposal-modal/ViewProposalModal.tsx
+++ b/packages/web/src/layouts/governance/components/proposals-list/view-proposal-modal/ViewProposalModal.tsx
@@ -3,7 +3,7 @@ import { Trans, useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import { GNOT_TOKEN, GNS_TOKEN, XGNS_TOKEN } from "@common/values/token-constant";
+import { GNS_TOKEN, XGNS_TOKEN } from "@common/values/token-constant";
 import Badge, { BADGE_TYPE } from "@components/common/badge/Badge";
 import IconClose from "@components/common/icons/IconCancel";
 import IconInfo from "@components/common/icons/IconInfo";
@@ -70,7 +70,6 @@ const ViewProposalModal: React.FC<ViewProposalModalProps> = ({
   );
 
   const { data, isLoading } = useGetProposalDetails({ proposalId, address });
-
   const proposalDetail = useMemo(() => {
     if (!data?.proposal) return nullProposalDetailsInfo.proposal;
     return data.proposal;
@@ -209,7 +208,7 @@ const ViewProposalModal: React.FC<ViewProposalModalProps> = ({
                 </div>
                 <div className="variable">
                   <div className="variable-type">{t("Governance:detailModal.content.amount")}</div>
-                  {rawToDisplayAmount(proposalDetailContent.amount, GNOT_TOKEN.decimals)} {GNS_TOKEN.symbol}
+                  {rawToDisplayAmount(proposalDetailContent.amount, GNS_TOKEN.decimals)} {GNS_TOKEN.symbol}
                 </div>
               </>
             )}

--- a/packages/web/src/layouts/governance/containers/proposal-list-container/ProposalListContainer.tsx
+++ b/packages/web/src/layouts/governance/containers/proposal-list-container/ProposalListContainer.tsx
@@ -10,9 +10,8 @@ import { useCreateProposalModal } from "@hooks/governance/ui/use-create-proposal
 import ProposalList from "../../components/proposals-list/ProposalList";
 import { useGovernanceTx } from "@hooks/governance/data/use-governance-tx";
 import { rawToDisplayAmount } from "@utils/number-utils";
-import { GNS_TOKEN, XGNS_TOKEN } from "@common/values/token-constant";
-
-const DEFAULT_PROPOSAL_CREATION_THRESHOLD = 1000 as const;
+import { XGNS_TOKEN } from "@common/values/token-constant";
+import { getProposalCreationThreshold } from "@utils/governance-utils";
 
 const ProposalListContainer: React.FC = () => {
   const router = useRouter();
@@ -72,12 +71,7 @@ const ProposalListContainer: React.FC = () => {
   }, [proposalParameterInfo?.functions]);
 
   const proposalCreationThreshold = useMemo(() => {
-    if (!proposalParameterInfo) return DEFAULT_PROPOSAL_CREATION_THRESHOLD;
-
-    return (
-      rawToDisplayAmount(proposalParameterInfo.proposalCreationThreshold, GNS_TOKEN.decimals) ||
-      DEFAULT_PROPOSAL_CREATION_THRESHOLD
-    );
+    return getProposalCreationThreshold(proposalParameterInfo?.proposalCreationThreshold, XGNS_TOKEN.decimals);
   }, [proposalParameterInfo?.proposalCreationThreshold]);
 
   const fetchNextItems = () => {

--- a/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-my-participation/LaunchpadMyParticipation.tsx
+++ b/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-my-participation/LaunchpadMyParticipation.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
+import { GNS_TOKEN } from "@common/values/token-constant";
 import { useLaunchpadHandler } from "@hooks/launchpad/data/use-launchpad-handler";
 import { LaunchpadParticipationModel, LaunchpadPoolModel } from "@models/launchpad";
 import { ProjectRewardInfoModel } from "../../LaunchpadDetail";
-import { GNS_TOKEN } from "@common/values/token-constant";
 
 import { MyParticipationWrapper } from "./LaunchpadMyParticipation.styles";
 import Button, { ButtonHierarchy } from "@components/common/button/Button";

--- a/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-my-participation/launchpad-my-participation-box/LaunchpadMyParticipationBox.tsx
+++ b/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-my-participation/launchpad-my-participation-box/LaunchpadMyParticipationBox.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from "next-i18next";
 
 import { LaunchpadParticipationModel } from "@models/launchpad";
 import { ParticipateButtonProps } from "../LaunchpadMyParticipation";
-import { GNS_TOKEN, LAUNCHPAD_DEFAULT_DEPOSIT_TOKEN } from "@common/values/token-constant";
 import { ProjectRewardInfoModel } from "@layouts/launchpad/launchpad-detail/LaunchpadDetail";
+import { GNS_TOKEN } from "@common/values/token-constant";
 import { getDateUtcToLocal } from "@common/utils/date-util";
 import { rawToDisplayAmount, toNumberFormat } from "@utils/number-utils";
 import { formatRate } from "@utils/new-number-utils";
@@ -73,8 +73,13 @@ const LaunchpadMyParticipationBox = ({ item, idx, rewardInfo, handleClickClaim }
         <div className="participation-box-data">
           <div className="participation-box-data-key">{t("Launchpad:myParticipation.col.depositAmounts")}</div>
           <div className="participation-box-data-value">
-            <Image src="/gns.svg" width={24} height={24} alt="GNS symbol image" />
-            {toNumberFormat(displayParticipationModel.depositAmount, 2)} {LAUNCHPAD_DEFAULT_DEPOSIT_TOKEN}
+            <Image
+              src={GNS_TOKEN.logoURI || "/gns.svg"}
+              width={24}
+              height={24}
+              alt={`${GNS_TOKEN.symbol} symbol image`}
+            />
+            {toNumberFormat(displayParticipationModel.depositAmount, 2)} {GNS_TOKEN.symbol}
           </div>
         </div>
         <div className="participation-box-data">
@@ -91,7 +96,7 @@ const LaunchpadMyParticipationBox = ({ item, idx, rewardInfo, handleClickClaim }
               mobileWidth={24}
             />
             <>
-              {isClaimed ? 0 : toNumberFormat(displayParticipationModel.claimableRewardAmount, 6)}{" "}
+              {isClaimed ? 0 : toNumberFormat(displayParticipationModel.claimableRewardAmount, rewardInfo.rewardTokenDecimals)}{" "}
               {rewardInfo?.rewardTokenSymbol}
             </>
           </div>
@@ -114,7 +119,7 @@ const LaunchpadMyParticipationBox = ({ item, idx, rewardInfo, handleClickClaim }
                   mobileWidth={24}
                 />
                 <>
-                  {toNumberFormat(displayParticipationModel.claimedRewardAmount, 6)} {rewardInfo?.rewardTokenSymbol}
+                  {toNumberFormat(displayParticipationModel.claimedRewardAmount, rewardInfo.rewardTokenDecimals)} {rewardInfo?.rewardTokenSymbol}
                 </>
               </div>
             </div>

--- a/packages/web/src/layouts/launchpad/launchpad-detail/containers/launchpad-project-summary-container/LaunchpadProjectSummaryContainer.tsx
+++ b/packages/web/src/layouts/launchpad/launchpad-detail/containers/launchpad-project-summary-container/LaunchpadProjectSummaryContainer.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
+import { GNS_TOKEN } from "@common/values/token-constant";
 import { rawToDisplayAmount } from "@utils/number-utils";
 import { ProjectRewardInfoModel, ProjectSummaryDataModel } from "../../LaunchpadDetail";
-import { GNS_TOKEN } from "@common/values/token-constant";
 
 import LaunchpadProjectSummary from "../../components/launchpad-project-summary/LaunchpadProjectSummary";
 
@@ -20,13 +20,12 @@ const LaunchpadProjectSummaryContainer: React.FC<LaunchpadProjectSummaryContaine
   isLoading,
 }) => {
   const displaySummaryData: ProjectSummaryDataModel = React.useMemo(() => {
-    const GNS_TOKEN_DECIMALS = GNS_TOKEN.decimals;
     const REWARD_TOKEN_DECIMALS = rewardInfo.rewardTokenDecimals;
 
     return {
       ...data,
       totalAllocation: rawToDisplayAmount(data.totalAllocation, REWARD_TOKEN_DECIMALS),
-      totalDeposited: rawToDisplayAmount(data.totalDeposited, GNS_TOKEN_DECIMALS),
+      totalDeposited: rawToDisplayAmount(data.totalDeposited, GNS_TOKEN.decimals),
       totalDistributed: rawToDisplayAmount(data.totalDistributed, REWARD_TOKEN_DECIMALS),
     };
   }, [data, rewardInfo]);

--- a/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustom.tsx
+++ b/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustom.tsx
@@ -104,10 +104,10 @@ const SelectPriceRangeCustom = forwardRef<SelectPriceRangeCustomHandle, SelectPr
 
       const currentPrice = (() => {
         if (selectPool.compareToken?.path === tokenA.path) {
-          return 10 ** ((tokenB.decimals || 0) - (tokenA.decimals || 0)) * selectPool.currentPrice;
+          return 10 ** (tokenB.decimals - tokenA.decimals) * selectPool.currentPrice;
         }
 
-        return 10 ** ((tokenA.decimals || 0) - (tokenB.decimals || 0)) * selectPool.currentPrice;
+        return 10 ** (tokenA.decimals - tokenB.decimals) * selectPool.currentPrice;
       })();
 
       return (
@@ -305,7 +305,7 @@ const SelectPriceRangeCustom = forwardRef<SelectPriceRangeCustomHandle, SelectPr
       return [getGnotPath(tokenA).symbol, getGnotPath(tokenB).symbol];
     }, [tokenA, tokenB, isKeepToken]);
 
-    const decimalsRatio = useMemo(() => tokenB.decimals - tokenA.decimals || 0, [tokenA.decimals, tokenB.decimals]);
+    const decimalsRatio = useMemo(() => tokenB.decimals - tokenA.decimals, [tokenA.decimals, tokenB.decimals]);
 
     if (selectPool.renderState() === "NONE") {
       return <></>;

--- a/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustomReposition.tsx
+++ b/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustomReposition.tsx
@@ -117,10 +117,10 @@ const SelectPriceRangeCustomReposition: React.FC<SelectPriceRangeCustomRepositio
 
     const priceWithDecimal = (() => {
       if (selectPool.compareToken?.path === tokenA.path) {
-        return 10 ** ((tokenB.decimals || 0) - (tokenA.decimals || 0)) * currentPrice;
+        return 10 ** (tokenB.decimals - tokenA.decimals) * currentPrice;
       }
 
-      return 10 ** ((tokenA.decimals || 0) - (tokenB.decimals || 0)) * currentPrice;
+      return 10 ** (tokenA.decimals - tokenB.decimals) * currentPrice;
     })();
 
     return (

--- a/packages/web/src/layouts/pool/pool-decrease-liquidity/components/decrease-pool-info/DecreasePoolInfo.tsx
+++ b/packages/web/src/layouts/pool/pool-decrease-liquidity/components/decrease-pool-info/DecreasePoolInfo.tsx
@@ -59,8 +59,8 @@ const DecreasePoolInfo: React.FC<Props> = ({ tokenA, tokenB, pooledTokenInfos, i
       return BigNumber(pooledTokenInfos?.unClaimTokenBAmount ?? 0).toFormat();
     }
 
-    return BigNumber(pooledTokenInfos?.unClaimTokenBAmount ?? 0).toFormat(tokenA.decimals);
-  }, [pooledTokenInfos?.unClaimTokenBAmount, tokenA.decimals]);
+    return BigNumber(pooledTokenInfos?.unClaimTokenBAmount ?? 0).toFormat(tokenB.decimals);
+  }, [pooledTokenInfos?.unClaimTokenBAmount, tokenB.decimals]);
 
   const isNotMobile = breakpoint !== DEVICE_TYPE.MOBILE;
   return (

--- a/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-content/PoolPairInfoContent.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-content/PoolPairInfoContent.tsx
@@ -223,8 +223,8 @@ const PoolPairInfoContent: React.FC<PoolPairInfoContentProps> = ({
   }, [pool?.tokenB?.symbol, pool?.tokenA?.symbol]);
 
   const currentPriceRatioNumber = useMemo(() => {
-    const tokenADecimals = pool.tokenA.decimals || 0;
-    const tokenBDecimals = pool.tokenB.decimals || 0;
+    const tokenADecimals = pool.tokenA.decimals;
+    const tokenBDecimals = pool.tokenB.decimals;
 
     return BigNumber(tickToPrice(pool.currentTick))
       .shiftedBy(-tokenADecimals + tokenBDecimals)

--- a/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
@@ -41,7 +41,6 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
     incentiveId ?? "",
   );
   const { getGnotPath } = useGnotToGnot();
-
   const currentPool = React.useMemo(() => {
     if (!pool) {
       return null;

--- a/packages/web/src/layouts/pool/pool-incentivize/containers/incentivize-pool-history-container/IncentivizePoolHistoryContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/containers/incentivize-pool-history-container/IncentivizePoolHistoryContainer.tsx
@@ -13,13 +13,12 @@ import IncentivizePoolHistory from "../../components/incentivize-pool-history/In
 const shiftToDisplay = (token: Pick<TokenModel, "decimals">, amount: string) => {
   const bn = new BigNumber(amount);
   if (bn.isNaN()) return "0";
-  return bn.shiftedBy(-(token.decimals || 0)).toFixed();
+  return bn.shiftedBy(-token.decimals).toFixed();
 };
 
 const IncentivizePoolHistoryContainer = () => {
   const { account } = useWallet();
   const { gnot, wugnotPath, getGnotPath } = useGnotToGnot();
-
   const { data: rawPoolStakingList = [], isFetched: isFetchedStakingList } = useGetPoolStakingListByAddress(
     account?.address || "",
     {

--- a/packages/web/src/layouts/pool/pool-incentivize/containers/pool-add-incentivize-container/PoolAddIncentivizeContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/containers/pool-add-incentivize-container/PoolAddIncentivizeContainer.tsx
@@ -1,3 +1,4 @@
+import BigNumber from "bignumber.js";
 import { useAtom } from "jotai";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -135,7 +136,7 @@ const PoolAddIncentivizeContainer: React.FC = () => {
 
   const btnStatus: { text: string; disabled: boolean } = useMemo(() => {
     const depositDisplayAmount = makeDisplayTokenAmount(GNS_TOKEN, depositGnsAmount) || 0;
-    const depositRawAmount = Number(depositGnsAmount);
+    const depositRawAmount = depositGnsAmount;
 
     if (!connected) {
       return {
@@ -176,7 +177,7 @@ const PoolAddIncentivizeContainer: React.FC = () => {
     if (
       (token?.path === GNS_TOKEN_PATH &&
         Number(tokenAmountInput.amount) + depositDisplayAmount > Number(tokenAmountInput.balance.replace(/,/g, ""))) ||
-      (token?.path !== GNS_TOKEN_PATH && depositRawAmount > (balances[GNS_TOKEN_PATH] || 0))
+      (token?.path !== GNS_TOKEN_PATH && BigNumber(depositRawAmount).isGreaterThan(balances[GNS_TOKEN_PATH] || 0))
     )
       return {
         text: t("IncentivizePool:submitBtn.insuffiDep"),

--- a/packages/web/src/layouts/pool/pool-incentivize/containers/pool-incentivize-container/PoolIncentivizeContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/containers/pool-incentivize-container/PoolIncentivizeContainer.tsx
@@ -1,3 +1,4 @@
+import BigNumber from "bignumber.js";
 import { useAtom } from "jotai";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -109,7 +110,7 @@ const PoolIncentivizeContainer: React.FC = () => {
 
   const btnStatus: { text: string; disabled: boolean } = useMemo(() => {
     const depositDisplayAmount = makeDisplayTokenAmount(GNS_TOKEN, depositGnsAmount) || 0;
-    const depositRawAmount = Number(depositGnsAmount);
+    const depositRawAmount = depositGnsAmount;
 
     if (!connected) {
       return {
@@ -150,7 +151,7 @@ const PoolIncentivizeContainer: React.FC = () => {
     if (
       (token?.path === GNS_TOKEN_PATH &&
         Number(tokenAmountInput.amount) + depositDisplayAmount > Number(tokenAmountInput.balance.replace(/,/g, ""))) ||
-      (token?.path !== GNS_TOKEN_PATH && depositRawAmount > (balances[GNS_TOKEN_PATH] || 0))
+      (token?.path !== GNS_TOKEN_PATH && BigNumber(depositRawAmount).isGreaterThan(balances[GNS_TOKEN_PATH] || 0))
     )
       return {
         text: t("IncentivizePool:submitBtn.insuffiDep"),

--- a/packages/web/src/layouts/portfolio/components/asset-send-modal/AssetSendModal.tsx
+++ b/packages/web/src/layouts/portfolio/components/asset-send-modal/AssetSendModal.tsx
@@ -109,7 +109,8 @@ const AssetSendModal: React.FC<Props> = ({
   const onChangeAmount = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
-      const decimals = withdrawInfo?.decimals || 0;
+      if (!withdrawInfo) return;
+      const decimals = withdrawInfo.decimals;
 
       if (value === "") {
         setAmount("");

--- a/packages/web/src/layouts/portfolio/containers/asset-list-container/AssetListContainer.tsx
+++ b/packages/web/src/layouts/portfolio/containers/asset-list-container/AssetListContainer.tsx
@@ -17,6 +17,7 @@ import { useGetAvgBlockTime } from "@query/address";
 import { useGetTokens } from "@query/token";
 import { checkGnotPath } from "@utils/common";
 import { formatPoolPairAmount, formatPrice } from "@utils/new-number-utils";
+import { makeRawTokenAmount } from "@utils/token-utils";
 import { isEmptyObject } from "@utils/validation-utils";
 
 import useSendAsset from "@hooks/wallet/data/useSendAsset";
@@ -188,7 +189,7 @@ const AssetListContainer: React.FC = () => {
           return formatPrice(
             BigNumber(tokenPrice)
               .multipliedBy(tokenPrices[checkGnotPath(item?.path)]?.usd || 0)
-              .dividedBy(10 ** (item.decimals || 0)),
+              .dividedBy(10 ** item.decimals),
             {
               isKMB: false,
             },
@@ -251,7 +252,7 @@ const AssetListContainer: React.FC = () => {
           return formatPrice(
             BigNumber(tokenPrice)
               .multipliedBy(tokenPrices[checkGnotPath(item?.path)]?.usd || 0)
-              .dividedBy(10 ** (item.decimals || 0)),
+              .dividedBy(10 ** item.decimals),
             {
               isKMB: false,
             },
@@ -431,7 +432,7 @@ const AssetListContainer: React.FC = () => {
         fromAddress: account.address,
         toAddress: address,
         token: withdrawInfo,
-        tokenAmount: BigNumber(amount).multipliedBy(1000000).toNumber(),
+        tokenAmount: makeRawTokenAmount(withdrawInfo, amount) || "0",
       },
       withdrawInfo.type,
     );

--- a/packages/web/src/layouts/portfolio/containers/wallet-balance-container/WalletBalanceContainer.tsx
+++ b/packages/web/src/layouts/portfolio/containers/wallet-balance-container/WalletBalanceContainer.tsx
@@ -26,6 +26,7 @@ import { DexEvent } from "@repositories/common";
 import { delay } from "@utils/common";
 import { formatOtherPrice } from "@utils/new-number-utils";
 import { toUnitFormat } from "@utils/number-utils";
+import { makeRawTokenAmount } from "@utils/token-utils";
 import { isEmptyObject } from "@utils/validation-utils";
 
 import { BROADCAST_ERROR_VALUE } from "@common/errors/broadcast/broadcast-error";
@@ -186,14 +187,16 @@ const WalletBalanceContainer: React.FC = () => {
   const availableBalance = useMemo(() => {
     return Object.entries(balancesPrice).reduce((acc, [key, value]) => {
       const path = key === "ugnot" ? WRAPPED_GNOT_PATH : key;
+      const token = tokens.find(token => token.priceID === key || token.path === key || token.path === path);
+      const decimals = token?.decimals ?? GNOT_TOKEN.decimals;
       const balance =
         BigNumber(value || 0)
           .multipliedBy(tokenPrices?.[path]?.pricesBefore?.latestPrice || 0)
-          .shiftedBy(GNOT_TOKEN.decimals * -1)
+          .shiftedBy(-decimals)
           .toNumber() || 0;
       return BigNumber(acc).plus(balance).toNumber();
     }, 0);
-  }, [balancesPrice, tokenPrices]);
+  }, [balancesPrice, tokenPrices, tokens]);
 
   const availableBalanceStr = useMemo(() => {
     return availableBalance;
@@ -264,7 +267,7 @@ const WalletBalanceContainer: React.FC = () => {
         fromAddress: account.address,
         toAddress: address,
         token: withdrawInfo,
-        tokenAmount: BigNumber(amount).multipliedBy(Math.pow(10, withdrawInfo.decimals)).toNumber(),
+        tokenAmount: makeRawTokenAmount(withdrawInfo, amount) || "0",
       },
       withdrawInfo.type,
     );

--- a/packages/web/src/repositories/swap-router/swap-router-repository-impl.spec.ts
+++ b/packages/web/src/repositories/swap-router/swap-router-repository-impl.spec.ts
@@ -1,0 +1,74 @@
+import { NetworkClient } from "@common/clients/network-client";
+import {
+  HttpDeleteRequestParam,
+  HttpPostRequestParam,
+  HttpPutRequestParam,
+  HttpResponse,
+} from "@common/clients/network-client/protocols";
+import { TokenModel } from "@models/token/token-model";
+
+import { SwapRouterRepositoryImpl } from "./swap-router-repository-impl";
+import { GetRoutesResponse } from "./response/get-routes-response";
+
+const createToken = (symbol: string, decimals: number): TokenModel => ({
+  path: `gno.land/r/demo/${symbol.toLowerCase()}`,
+  type: "GRC20",
+  chainId: "dev.gnoswap",
+  name: symbol,
+  symbol,
+  decimals,
+  logoURI: "",
+  createdAt: "2026-05-19T00:00:00Z",
+  priceID: `gno.land/r/demo/${symbol.toLowerCase()}`,
+});
+
+describe("SwapRouterRepositoryImpl", () => {
+  it("uses output token decimals for exact-out route quotes", async () => {
+    const response: GetRoutesResponse = {
+      estimatedRoutes: [],
+      originAmount: 0,
+      amount: "0",
+      status: "SUCCESS",
+    };
+    const post = jest.fn();
+    const networkClient: NetworkClient = {
+      get: async <R>(): Promise<HttpResponse<R>> => ({ status: 200, message: "", data: response as R }),
+      post: async <_T, R>(params: HttpPostRequestParam<_T>): Promise<HttpResponse<R>> => {
+        post(params);
+        return { status: 200, message: "", data: response as R };
+      },
+      put: async <T, R>(params: HttpPutRequestParam<T>): Promise<HttpResponse<R>> => {
+        void params;
+        return {
+          status: 200,
+          message: "",
+          data: response as R,
+        };
+      },
+      delete: async <T, R>(params: HttpDeleteRequestParam<T>): Promise<HttpResponse<R>> => {
+        void params;
+        return {
+          status: 200,
+          message: "",
+          data: response as R,
+        };
+      },
+    };
+    const repository = new SwapRouterRepositoryImpl(null, null, networkClient);
+
+    await repository.getRoutes({
+      inputToken: createToken("IN", 6),
+      outputToken: createToken("OUT", 8),
+      tokenAmount: 1.23,
+      exactType: "EXACT_OUT",
+    });
+
+    expect(post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          amount: "123000000",
+        }),
+      }),
+    );
+  });
+});

--- a/packages/web/src/repositories/swap-router/swap-router-repository-impl.ts
+++ b/packages/web/src/repositories/swap-router/swap-router-repository-impl.ts
@@ -57,7 +57,7 @@ export class SwapRouterRepositoryImpl implements SwapRouterRepository {
     const tokenAmountRaw =
       exactType === "EXACT_IN"
         ? makeRawTokenAmount(inputToken, tokenAmount)
-        : makeRawTokenAmount(inputToken, tokenAmount);
+        : makeRawTokenAmount(outputToken, tokenAmount);
 
     const response = await this.networkClient.post<
       {

--- a/packages/web/src/repositories/wallet/request/transfer-grc20-token-request.ts
+++ b/packages/web/src/repositories/wallet/request/transfer-grc20-token-request.ts
@@ -4,7 +4,7 @@ export interface TransferGRC20TokenRequest {
   token: TokenModel;
 
   // only integer
-  tokenAmount: number;
+  tokenAmount: string;
 
   fromAddress: string;
 

--- a/packages/web/src/repositories/wallet/request/transfer-native-token-request.ts
+++ b/packages/web/src/repositories/wallet/request/transfer-native-token-request.ts
@@ -4,7 +4,7 @@ export interface TransferNativeTokenRequest {
   token: TokenModel;
 
   // only integer
-  tokenAmount: number;
+  tokenAmount: string;
 
   fromAddress: string;
 

--- a/packages/web/src/repositories/wallet/wallet.message.spec.ts
+++ b/packages/web/src/repositories/wallet/wallet.message.spec.ts
@@ -1,0 +1,38 @@
+import { GNS_TOKEN, GNOT_UNIT_DENOM } from "@common/values/token-constant";
+import { isContractMessage } from "@common/clients/wallet-client/protocols";
+
+import { makeTransferGNOTTokenMessages, makeTransferGRC20TokenMessages } from "./wallet.message";
+
+describe("wallet messages", () => {
+  it("preserves native transfer raw amounts as strings", () => {
+    const rawAmount = "123456789012345678901234567890";
+
+    const [message] = makeTransferGNOTTokenMessages({
+      tokenAmount: rawAmount,
+      fromAddress: "g1from",
+      toAddress: "g1to",
+    });
+
+    expect(message).toEqual({
+      amount: `${rawAmount}${GNOT_UNIT_DENOM}`,
+      from_address: "g1from",
+      to_address: "g1to",
+    });
+  });
+
+  it("preserves GRC20 transfer raw amounts as strings", () => {
+    const rawAmount = "123456789012345678901234567890";
+
+    const [message] = makeTransferGRC20TokenMessages({
+      token: GNS_TOKEN,
+      tokenAmount: rawAmount,
+      fromAddress: "g1from",
+      toAddress: "g1to",
+    });
+
+    expect(isContractMessage(message)).toBe(true);
+    if (isContractMessage(message)) {
+      expect(message.args).toEqual(["g1to", rawAmount]);
+    }
+  });
+});

--- a/packages/web/src/repositories/wallet/wallet.message.ts
+++ b/packages/web/src/repositories/wallet/wallet.message.ts
@@ -9,12 +9,12 @@ export function makeTransferGNOTTokenMessages({
   fromAddress,
   toAddress,
 }: {
-  tokenAmount: number;
+  tokenAmount: string;
   fromAddress: string;
   toAddress: string;
 }): TransactionMessage[] {
   const bankSendMessage = makeTransferNativeTokenMessage(
-    tokenAmount.toString(),
+    tokenAmount,
     GNOT_UNIT_DENOM,
     fromAddress,
     toAddress,
@@ -30,7 +30,7 @@ export function makeTransferGRC20TokenMessages({
   toAddress,
 }: {
   token: TokenModel;
-  tokenAmount: number;
+  tokenAmount: string;
   fromAddress: string;
   toAddress: string;
 }): TransactionMessage[] {
@@ -38,7 +38,7 @@ export function makeTransferGRC20TokenMessages({
     packagePath: token.path,
     send: "",
     func: "Transfer",
-    args: [toAddress, tokenAmount.toString()],
+    args: [toAddress, tokenAmount],
     caller: fromAddress,
   });
 

--- a/packages/web/src/services/converters/common/amount/amount.converter.ts
+++ b/packages/web/src/services/converters/common/amount/amount.converter.ts
@@ -32,8 +32,8 @@ export class AmountConverter {
         return "0";
       }
 
-      const rawDecimals = token?.decimals || 0;
-      const normalizedDecimals = Math.abs(Math.floor(rawDecimals));
+      const rawDecimals = token.decimals;
+      const normalizedDecimals = Number.isFinite(rawDecimals) ? Math.abs(Math.floor(rawDecimals)) : 0;
 
       const divisor = new BigNumber(10).pow(normalizedDecimals);
       const result = amount.dividedBy(divisor);

--- a/packages/web/src/utils/governance-utils.spec.ts
+++ b/packages/web/src/utils/governance-utils.spec.ts
@@ -1,4 +1,4 @@
-import { isQuorumReached, makeProposalVariablesQuery } from "./governance-utils";
+import { getProposalCreationThreshold, isQuorumReached, makeProposalVariablesQuery } from "./governance-utils";
 
 describe("make proposal's variable query", () => {
   test("single variable", () => {
@@ -64,5 +64,15 @@ describe("isQuorumReached", () => {
     });
 
     expect(result).toBe(false);
+  });
+});
+
+describe("governance utils", () => {
+  it("converts proposal creation threshold with xGNS decimals", () => {
+    expect(getProposalCreationThreshold(250000000, 8)).toBe(2.5);
+  });
+
+  it("falls back when proposal creation threshold is missing", () => {
+    expect(getProposalCreationThreshold(undefined, 8)).toBe(1000);
   });
 });

--- a/packages/web/src/utils/governance-utils.ts
+++ b/packages/web/src/utils/governance-utils.ts
@@ -1,5 +1,7 @@
 import BigNumber from "bignumber.js";
 
+import { rawToDisplayAmount } from "./number-utils";
+
 interface ProposalVariables {
   pkgPath: string;
   func: string;
@@ -33,7 +35,11 @@ export const makeProposalVariablesQuery = (variables: ProposalVariables[]): stri
   return methodQueries.join(queryMethodSeparator);
 };
 
-export const isQuorumReached = ({ yesVotingWeight, noVotingWeight, quorumAmount }: GovernanceVotingAmounts): boolean => {
+export const isQuorumReached = ({
+  yesVotingWeight,
+  noVotingWeight,
+  quorumAmount,
+}: GovernanceVotingAmounts): boolean => {
   const yesVotingWeightValue = BigNumber(yesVotingWeight || 0);
   const noVotingWeightValue = BigNumber(noVotingWeight || 0);
   const quorumAmountValue = BigNumber(quorumAmount || 0);
@@ -44,3 +50,16 @@ export const isQuorumReached = ({ yesVotingWeight, noVotingWeight, quorumAmount 
 
   return yesVotingWeightValue.plus(noVotingWeightValue).isGreaterThanOrEqualTo(quorumAmountValue);
 };
+
+export const DEFAULT_PROPOSAL_CREATION_THRESHOLD = 1000 as const;
+
+export function getProposalCreationThreshold(
+  proposalCreationThreshold: number | string | null | undefined,
+  xGnsDecimals: number,
+): number {
+  if (proposalCreationThreshold == null) {
+    return DEFAULT_PROPOSAL_CREATION_THRESHOLD;
+  }
+
+  return rawToDisplayAmount(proposalCreationThreshold, xGnsDecimals) || DEFAULT_PROPOSAL_CREATION_THRESHOLD;
+}

--- a/packages/web/src/utils/launchpad-condition-utils.ts
+++ b/packages/web/src/utils/launchpad-condition-utils.ts
@@ -27,7 +27,7 @@ export function getLaunchpadConditionDisplayAmount(
     return amount;
   }
 
-  return amount.shiftedBy(-(token.decimals || 0));
+  return amount.shiftedBy(-token.decimals);
 }
 
 export function formatLaunchpadConditionAmount(

--- a/packages/web/src/utils/token-utils.spec.ts
+++ b/packages/web/src/utils/token-utils.spec.ts
@@ -50,6 +50,15 @@ describe("make token raw price", () => {
     const result = makeRawTokenAmount(token, amount);
     expect(result).toBe("123456");
   });
+
+  test("1.23 to 123000000 with 8 decimals", () => {
+    const token = {
+      ...DEFAULT_TOKEN,
+      decimals: 8,
+    };
+    const result = makeRawTokenAmount(token, 1.23);
+    expect(result).toBe("123000000");
+  });
 });
 
 describe("make token display price", () => {
@@ -81,6 +90,15 @@ describe("make token display price", () => {
     const amount = "1";
     const result = makeDisplayTokenAmount(token, amount);
     expect(result).toBe(0.000001);
+  });
+
+  test("123000000 to 1.23 with 8 decimals", () => {
+    const token = {
+      ...DEFAULT_TOKEN,
+      decimals: 8,
+    };
+    const result = makeDisplayTokenAmount(token, "123000000");
+    expect(result).toBe(1.23);
   });
 });
 

--- a/packages/web/src/utils/token-utils.ts
+++ b/packages/web/src/utils/token-utils.ts
@@ -25,7 +25,7 @@ export function makeDisplayTokenAmount(
   amount: bigint | string | number,
   options?: { decimalsWithoutRounding?: number },
 ) {
-  const number = BigNumber(Number(amount));
+  const number = BigNumber(amount.toString());
   if (number.isNaN()) {
     return null;
   }
@@ -36,7 +36,7 @@ export function makeDisplayTokenAmount(
     );
   }
 
-  return number.shiftedBy(-(token.decimals || 0)).toNumber();
+  return number.shiftedBy(-token.decimals).toNumber();
 }
 
 export function makeShiftAmount(


### PR DESCRIPTION
## Summary
- Replace hardcoded 6-decimal amount conversions with token metadata across swap, governance, launchpad, pool, and portfolio flows.
- Preserve raw transfer amounts as strings to avoid precision loss.
- Fix exact-out route quote conversion to use output token decimals.

## Changes
- Added focused coverage for token amount conversion, wallet transfer messages, governance thresholds, and exact-out route quote decimals.
- Rebased onto latest develop and kept the incentive creation deposit API flow intact while applying dynamic decimal comparisons.

## Verification
- yarn workspace @gnoswap-labs/web jest --runInBand
- yarn workspace @gnoswap-labs/web lint (existing warnings only)
- yarn workspace @gnoswap-labs/web build
- LSP diagnostics: 0 errors
- GIT_MASTER=1 git diff --check