### PR TITLE
fix(token): truncate long token symbols

### DIFF
--- a/packages/web/src/components/common/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/web/src/components/common/breadcrumbs/Breadcrumbs.tsx
@@ -4,6 +4,7 @@ import { cx } from "@emotion/css";
 import { useTheme } from "@emotion/react";
 import { useGnoscanUrl } from "@hooks/common/use-gnoscan-url";
 import { isNativeToken, TokenModel } from "@models/token/token-model";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import IconOpenLink from "../icons/IconOpenLink";
@@ -59,7 +60,7 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ steps, onClickPath }) => {
     if (step.options?.type === "TOKEN_SYMBOL") {
       return (
         <div className="token-symbol-path">
-          <div className="token-title">{step.title}</div>
+          <div className="token-title">{formatDisplayTokenSymbol(step.title)}</div>
           <div className="token-path" onClick={e => onClickTokenPath(e, step.options?.token?.path ?? "")}>
             <div>{tokenPathDisplay(step.options.token)}</div>
             <IconOpenLink fill={theme.color.text04} className="path-link-icon" />

--- a/packages/web/src/components/common/header/search-menu-modal/SearchMenuModal.tsx
+++ b/packages/web/src/components/common/header/search-menu-modal/SearchMenuModal.tsx
@@ -29,7 +29,7 @@ import {
 } from "./SearchMenuModal.styles";
 import useElementWidth from "@hooks/common/use-element-width";
 import useElementWidthList from "@hooks/common/use-element-width-list";
-import { formatTokenPath } from "@utils/token-utils";
+import { formatDisplayTokenSymbol, formatTokenPath } from "@utils/token-utils";
 import PriceWarning from "@components/common/price-warning/PriceWarning";
 
 interface NegativeStatusType {
@@ -244,7 +244,7 @@ const SearchMenuModal: React.FC<SearchMenuModalProps> = ({
                                 <IconNewTab />
                               </div>
                             </div>
-                            <span>{item.token.symbol}</span>
+                            <span>{formatDisplayTokenSymbol(item.token.symbol)}</span>
                           </TokenInfoWrapper>
                         </div>
                         <div className="coin-infor-value" ref={recentPriceRef.current[idx]}>
@@ -273,7 +273,8 @@ const SearchMenuModal: React.FC<SearchMenuModalProps> = ({
                             rightSymbol={item?.tokenB?.symbol}
                           />
                           <span className="token-name">
-                            {item.token.symbol}/{item?.tokenB?.symbol}
+                            {formatDisplayTokenSymbol(item.token.symbol)}/
+                            {formatDisplayTokenSymbol(item?.tokenB?.symbol || "")}
                           </span>
                           <Badge text={item.fee} type={BADGE_TYPE.DARK_DEFAULT} />
                         </div>
@@ -323,7 +324,7 @@ const SearchMenuModal: React.FC<SearchMenuModalProps> = ({
                               <IconNewTab />
                             </div>
                           </div>
-                          <span>{item.token.symbol}</span>
+                          <span>{formatDisplayTokenSymbol(item.token.symbol)}</span>
                         </TokenInfoWrapper>
                       </div>
                       <div className="coin-infor-value" ref={popularPriceRef.current[idx]}>
@@ -359,7 +360,8 @@ const SearchMenuModal: React.FC<SearchMenuModalProps> = ({
                           rightSymbol={item?.tokenB?.symbol}
                         />
                         <span className="token-name">
-                          {item.token.symbol}/{item?.tokenB?.symbol}
+                          {formatDisplayTokenSymbol(item.token.symbol)}/
+                          {formatDisplayTokenSymbol(item?.tokenB?.symbol || "")}
                         </span>
                         <Badge text={item.fee} type={BADGE_TYPE.DARK_DEFAULT} />
                       </div>

--- a/packages/web/src/components/common/my-position-card-list/my-position-card/MyPositionCard.tsx
+++ b/packages/web/src/components/common/my-position-card-list/my-position-card/MyPositionCard.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from "react-i18next";
 import MissingLogo from "../../missing-logo/MissingLogo";
 import { QUERY_PARAMETER } from "@constants/page.constant";
 import { usePrefetchNavigation } from "@hooks/common/use-prefetch-navigation";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 interface MyPositionCardProps {
   address?: string | null;
@@ -364,7 +365,7 @@ const MyPositionCard: React.FC<MyPositionCardProps> = ({
           <div className="title-wrapper">
             <div id={boxHeaderId} className="box-header">
               <MissingLogo symbol={`ID #${position.id}`} url={position.tokenUri} width={24} showTooltip />
-              <span>{`${tokenA.symbol}/${tokenB.symbol}`}</span>
+              <span>{`${formatDisplayTokenSymbol(tokenA.symbol)}/${formatDisplayTokenSymbol(tokenB.symbol)}`}</span>
               <div className="badge-group">
                 <Badge type={BADGE_TYPE.DARK_DEFAULT} text={feeRateStr} />
               </div>
@@ -439,7 +440,7 @@ const MyPositionCard: React.FC<MyPositionCardProps> = ({
                     {minPriceStr}(<span>{minTickLabel}</span>) ~
                   </p>
                   <p className={`label-text ${endClass}`}>
-                    {maxPriceStr}(<span>{maxTickLabel}</span>) {tokenB.symbol}
+                    {maxPriceStr}(<span>{maxTickLabel}</span>) {formatDisplayTokenSymbol(tokenB.symbol)}
                   </p>
                 </div>
               </React.Fragment>

--- a/packages/web/src/components/common/overlap-logo/OverlapLogo.tsx
+++ b/packages/web/src/components/common/overlap-logo/OverlapLogo.tsx
@@ -1,4 +1,5 @@
 import Tooltip from "../tooltip/Tooltip";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 import {
   OverlapLogoImageWrapper,
   OverlapLogoStyleProps,
@@ -31,7 +32,7 @@ const OverlapLogo = ({ logos, size = 36 }: OverlapLogoProps) => {
             {logo.src ? (
               <img src={logo.src} alt="logo-image" />
             ) : (
-              <div className="missing-logo right-logo">{logo.symbol}</div>
+              <div className="missing-logo right-logo">{formatDisplayTokenSymbol(logo.symbol)}</div>
             )}
           </OverlapLogoImageWrapper>
         </Tooltip>

--- a/packages/web/src/components/common/pool-graph/pool-graph-tooltip/PoolGraphTooltip.tsx
+++ b/packages/web/src/components/common/pool-graph/pool-graph-tooltip/PoolGraphTooltip.tsx
@@ -59,16 +59,16 @@ const PoolGraphTooltip: React.FC<React.PropsWithRef<PoolGraphTooltipProps>> = ({
     } = tooltipInfo;
 
     return {
-      tokenAPrice: `${tokenAPrice} ${tokenB.symbol}`,
-      tokenBPrice: `${tokenBPrice} ${tokenA.symbol}`,
+      tokenAPrice: `${tokenAPrice} ${formatDisplayTokenSymbol(tokenB.symbol)}`,
+      tokenBPrice: `${tokenBPrice} ${formatDisplayTokenSymbol(tokenA.symbol)}`,
       tokenAPriceRange:
         breakpoint === DEVICE_TYPE.MOBILE
           ? `${tokenARange.min} - ${tokenARange.max}`
-          : `${tokenARange.min} - ${tokenARange.max} ${tokenB.symbol}`,
+          : `${tokenARange.min} - ${tokenARange.max} ${formatDisplayTokenSymbol(tokenB.symbol)}`,
       tokenBPriceRange:
         breakpoint === DEVICE_TYPE.MOBILE
           ? `${tokenBRange.max} - ${tokenBRange.min}`
-          : `${tokenBRange.max} - ${tokenBRange.min} ${tokenA.symbol}`,
+          : `${tokenBRange.max} - ${tokenBRange.min} ${formatDisplayTokenSymbol(tokenA.symbol)}`,
       totalTokenAAmount: tokenAAmount || "0",
       totalTokenBAmount: tokenBAmount || "0",
       depositTokenAAmount: depositTokenAAmount || "0",
@@ -107,7 +107,7 @@ const PoolGraphTooltip: React.FC<React.PropsWithRef<PoolGraphTooltipProps>> = ({
               mobileWidth={20}
             />
             <span>
-              {tooltipInfo.tokenA.symbol} {t("common:price")}
+              {formatDisplayTokenSymbol(tooltipInfo.tokenA.symbol)} {t("common:price")}
             </span>
           </span>
           <span className={"token-amount-value price"}>{displayTooltipInfo.tokenAPrice}</span>
@@ -123,7 +123,7 @@ const PoolGraphTooltip: React.FC<React.PropsWithRef<PoolGraphTooltipProps>> = ({
               mobileWidth={20}
             />
             <span>
-              {tooltipInfo.tokenB.symbol} {t("common:price")}
+              {formatDisplayTokenSymbol(tooltipInfo.tokenB.symbol)} {t("common:price")}
             </span>
           </span>
           <span className={"token-amount-value price"}>{displayTooltipInfo.tokenBPrice}</span>

--- a/packages/web/src/components/common/pool-graph/pool-graph-tooltip/PoolGraphTooltip.tsx
+++ b/packages/web/src/components/common/pool-graph/pool-graph-tooltip/PoolGraphTooltip.tsx
@@ -7,6 +7,7 @@ import { TooltipInfo } from "../PoolGraph.types";
 import { PoolGraphTooltipContainer } from "./PoolGraphTooltip.styles";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { DEVICE_TYPE } from "@styles/media";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 function makeClassNameWithSmallFont(className: string, target: string, limitLength = 21) {
   const additionalClassName = "small-font";
@@ -150,7 +151,7 @@ const PoolGraphTooltip: React.FC<React.PropsWithRef<PoolGraphTooltipProps>> = ({
               width={20}
               mobileWidth={20}
             />
-            <span className="symbol">{tooltipInfo.tokenA.symbol}</span>
+            <span className="symbol">{formatDisplayTokenSymbol(tooltipInfo.tokenA.symbol)}</span>
           </span>
           <span className="amount total-amount">
             <span className={makeClassNameWithSmallFont("token-amount-value", displayTooltipInfo.totalTokenAAmount)}>
@@ -182,7 +183,7 @@ const PoolGraphTooltip: React.FC<React.PropsWithRef<PoolGraphTooltipProps>> = ({
               width={20}
               mobileWidth={20}
             />
-            <span className="symbol">{tooltipInfo.tokenB.symbol}</span>
+            <span className="symbol">{formatDisplayTokenSymbol(tooltipInfo.tokenB.symbol)}</span>
           </span>
           <span className="amount total-amount">
             <span className={makeClassNameWithSmallFont("token-amount-value", displayTooltipInfo.totalTokenBAmount)}>

--- a/packages/web/src/components/common/pool-selection-graph/PoolSelectionGraphBinTooltip.tsx
+++ b/packages/web/src/components/common/pool-selection-graph/PoolSelectionGraphBinTooltip.tsx
@@ -36,7 +36,7 @@ export const PoolSelectionGraphBinTooptip: React.FC<PoolSelectionGraphBinTooptip
     if (!tokenAPrice) {
       return "-";
     }
-    return `${tokenAPrice} ${tokenB.symbol}`;
+    return `${tokenAPrice} ${formatDisplayTokenSymbol(tokenB.symbol)}`;
   }, [tooltipInfo]);
 
   const tokenBPriceString = useMemo(() => {
@@ -47,7 +47,7 @@ export const PoolSelectionGraphBinTooptip: React.FC<PoolSelectionGraphBinTooptip
     if (!tokenBPrice) {
       return "-";
     }
-    return `${tokenBPrice} ${tokenA.symbol}`;
+    return `${tokenBPrice} ${formatDisplayTokenSymbol(tokenA.symbol)}`;
   }, [tooltipInfo]);
 
   const tokenAPriceRangeStr = useMemo(() => {
@@ -58,7 +58,7 @@ export const PoolSelectionGraphBinTooptip: React.FC<PoolSelectionGraphBinTooptip
     if (tokenARange?.min === null || tokenARange?.max === null) {
       return "-";
     }
-    return `${tokenARange.min} - ${tokenARange.max} ${tokenB.symbol}`;
+    return `${tokenARange.min} - ${tokenARange.max} ${formatDisplayTokenSymbol(tokenB.symbol)}`;
   }, [tooltipInfo]);
 
   const tokenBPriceRangeStr = useMemo(() => {
@@ -69,7 +69,7 @@ export const PoolSelectionGraphBinTooptip: React.FC<PoolSelectionGraphBinTooptip
     if (tokenBRange?.min === null || tokenBRange?.max === null) {
       return "-";
     }
-    return `${tokenBRange.max} - ${tokenBRange.min} ${tokenA.symbol}`;
+    return `${tokenBRange.max} - ${tokenBRange.min} ${formatDisplayTokenSymbol(tokenA.symbol)}`;
   }, [tooltipInfo]);
 
   return tooltipInfo ? (
@@ -91,7 +91,7 @@ export const PoolSelectionGraphBinTooptip: React.FC<PoolSelectionGraphBinTooptip
               mobileWidth={20}
             />
             <span>
-              {tooltipInfo.tokenA.symbol} {t("common:price")}
+              {formatDisplayTokenSymbol(tooltipInfo.tokenA.symbol)} {t("common:price")}
             </span>
           </span>
           <span className="price-range">{tokenAPriceString}</span>
@@ -106,7 +106,7 @@ export const PoolSelectionGraphBinTooptip: React.FC<PoolSelectionGraphBinTooptip
               mobileWidth={20}
             />
             <span>
-              {tooltipInfo.tokenB.symbol} {t("common:price")}
+              {formatDisplayTokenSymbol(tooltipInfo.tokenB.symbol)} {t("common:price")}
             </span>
           </span>
           <span className="price-range">{tokenBPriceString}</span>

--- a/packages/web/src/components/common/pool-selection-graph/PoolSelectionGraphBinTooltip.tsx
+++ b/packages/web/src/components/common/pool-selection-graph/PoolSelectionGraphBinTooltip.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import MissingLogo from "../missing-logo/MissingLogo";
 import { TokenModel } from "@models/token/token-model";
 import { useTranslation } from "react-i18next";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 export interface TooltipInfo {
   tokenA: TokenModel;
@@ -128,7 +129,7 @@ export const PoolSelectionGraphBinTooptip: React.FC<PoolSelectionGraphBinTooptip
               width={20}
               mobileWidth={20}
             />
-            <span>{tooltipInfo.tokenA.symbol}</span>
+            <span>{formatDisplayTokenSymbol(tooltipInfo.tokenA.symbol)}</span>
           </span>
           <span className="amount total-amount">
             <MissingLogo
@@ -155,7 +156,7 @@ export const PoolSelectionGraphBinTooptip: React.FC<PoolSelectionGraphBinTooptip
               width={20}
               mobileWidth={20}
             />
-            <span>{tooltipInfo.tokenB.symbol}</span>
+            <span>{formatDisplayTokenSymbol(tooltipInfo.tokenB.symbol)}</span>
           </span>
           <span className="amount total-amount">
             <MissingLogo

--- a/packages/web/src/components/common/reward-tooltip-content/RewardTooltipContent.tsx
+++ b/packages/web/src/components/common/reward-tooltip-content/RewardTooltipContent.tsx
@@ -8,6 +8,7 @@ import { DisplayRewardType, RewardType } from "@constants/option.constant";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { TokenModel } from "@models/token/token-model";
 import { formatOtherPrice, formatPoolPairAmount } from "@utils/new-number-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 import { RewardTooltipContentWrapper } from "./RewardTooltipContent.styles";
 
 export interface PositionRewardForTooltip {
@@ -101,7 +102,7 @@ const RewardTooltipContent: React.FC<RewardTooltipContentProps> = ({ rewardInfo,
                       width={20}
                       mobileWidth={20}
                     />
-                    <span className="position">{getGnotPath(reward.token).symbol}</span>
+                    <span className="position">{formatDisplayTokenSymbol(getGnotPath(reward.token).symbol)}</span>
                   </div>
                   <span className="position">
                     {formatPoolPairAmount(reward.amount, {

--- a/packages/web/src/components/common/select-pair-button/SelectPairButton.tsx
+++ b/packages/web/src/components/common/select-pair-button/SelectPairButton.tsx
@@ -6,6 +6,7 @@ import { useSelectTokenModal } from "@hooks/token/ui/use-select-token-modal";
 import { TokenModel } from "@models/token/token-model";
 import MissingLogo from "../missing-logo/MissingLogo";
 import { useTranslation } from "react-i18next";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 interface SelectPairButtonProps {
   token: TokenModel | null;
@@ -52,7 +53,7 @@ const SelectPairButton: React.FC<SelectPairButtonProps> = ({
       {token ? (
         <div className={cx("token-info", { isChanging: isChanging })}>
           <MissingLogo symbol={token.symbol} url={token.logoURI} className="token-logo" width={24} mobileWidth={24} />
-          <span className={"token-symbol"}>{token.symbol}</span>
+          <span className={"token-symbol"}>{formatDisplayTokenSymbol(token.symbol)}</span>
         </div>
       ) : (
         <span>{t("common:selectPairBtn.select")}</span>

--- a/packages/web/src/components/common/select-pair-button/SelectPairIncentivizeButton.tsx
+++ b/packages/web/src/components/common/select-pair-button/SelectPairIncentivizeButton.tsx
@@ -5,6 +5,7 @@ import { TokenModel } from "@models/token/token-model";
 import { useSelectTokenIncentivizeModal } from "@hooks/token/ui/use-select-token-incentivize-modal";
 import MissingLogo from "../missing-logo/MissingLogo";
 import { useTranslation } from "react-i18next";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 interface SelectPairIncentivizeButtonProps {
   token: TokenModel | null;
@@ -49,7 +50,7 @@ const SelectPairIncentivizeButton: React.FC<SelectPairIncentivizeButtonProps> = 
       {token ? (
         <div className="token-pair-wrapper">
           <MissingLogo symbol={token.symbol} url={token.logoURI} className="token-logo" width={24} mobileWidth={24} />
-          <span className="token-symbol">{token.symbol}</span>
+          <span className="token-symbol">{formatDisplayTokenSymbol(token.symbol)}</span>
         </div>
       ) : (
         <span className="token-label-select">{t("common:selectPairBtn.select")}</span>

--- a/packages/web/src/components/common/select-token-incentivize/SelectTokenIncentivize.tsx
+++ b/packages/web/src/components/common/select-token-incentivize/SelectTokenIncentivize.tsx
@@ -5,6 +5,7 @@ import { TokenModel } from "@models/token/token-model";
 import BigNumber from "bignumber.js";
 import MissingLogo from "../missing-logo/MissingLogo";
 import { useTranslation } from "react-i18next";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 export interface SelectTokenIncentivizeProps {
   keyword: string;
   defaultTokens: TokenModel[];
@@ -67,7 +68,7 @@ const SelectTokenIncentivize: React.FC<SelectTokenIncentivizeProps> = ({ tokens,
                   mobileWidth={24}
                 />
                 <span className="token-name">{token.name}</span>
-                <span className="token-symbol">{token.symbol}</span>
+                <span className="token-symbol">{formatDisplayTokenSymbol(token.symbol)}</span>
               </div>
               <span className="token-balance">{getTokenPrice(token)}</span>
             </div>

--- a/packages/web/src/components/common/select-token/SelectToken.tsx
+++ b/packages/web/src/components/common/select-token/SelectToken.tsx
@@ -6,7 +6,7 @@ import { TokenModel } from "@models/token/token-model";
 import { TokenState } from "@states/index";
 import { DEVICE_TYPE } from "@styles/media";
 import { removeDuplicatesByWrappedPath } from "@utils/common";
-import { formatTokenModelPath } from "@utils/token-utils";
+import { formatDisplayTokenSymbol, formatTokenModelPath } from "@utils/token-utils";
 import BigNumber from "bignumber.js";
 import { useAtom } from "jotai";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -169,7 +169,7 @@ const SelectToken: React.FC<SelectTokenProps> = ({
                 width={24}
                 mobileWidth={24}
               />
-              <span>{token.symbol}</span>
+              <span>{formatDisplayTokenSymbol(token.symbol)}</span>
             </div>
           ))}
         </div>
@@ -206,7 +206,7 @@ const SelectToken: React.FC<SelectTokenProps> = ({
                         <IconNewTab />
                       </div>
                     </div>
-                    <span className="token-symbol">{token.symbol}</span>
+                    <span className="token-symbol">{formatDisplayTokenSymbol(token.symbol)}</span>
                   </TokenInfoWrapper>
                 </div>
                 <span className="token-balance" ref={priceRefs.current[index]}>

--- a/packages/web/src/components/common/token-info-cell/TokenInfoCell.tsx
+++ b/packages/web/src/components/common/token-info-cell/TokenInfoCell.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useRef } from "react";
 
 import { useGnoscanUrl } from "@hooks/common/use-gnoscan-url";
 import { DEVICE_TYPE } from "@styles/media";
-import { formatTokenPath } from "@utils/token-utils";
+import { formatDisplayTokenSymbol, formatTokenPath } from "@utils/token-utils";
 import useElementWidth from "@hooks/common/use-element-width";
 
 import { TokenInfoCellWrapper } from "./TokenInfoCell.styles";
@@ -62,7 +62,7 @@ function TokenInfoCell({ token, breakpoint, isNative }: TokenInfoCellProps) {
             <IconOpenLink fill={theme.color.text04} className="path-link-icon" />
           </div>
         </div>
-        <span className="token-symbol">{symbol}</span>
+        <span className="token-symbol">{formatDisplayTokenSymbol(symbol)}</span>
       </div>
     </TokenInfoCellWrapper>
   );

--- a/packages/web/src/components/home/card-list-item/CardListPoolItem.tsx
+++ b/packages/web/src/components/home/card-list-item/CardListPoolItem.tsx
@@ -7,6 +7,7 @@ import { useCallback, useMemo } from "react";
 import { SwapFeeTierInfoMap } from "@constants/option.constant";
 import IconStar from "@components/common/icons/IconStar";
 import { formatRate } from "@utils/new-number-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 interface CardListPoolItemProps {
   index: number;
@@ -17,7 +18,7 @@ interface CardListPoolItemProps {
 const CardListPoolItem: React.FC<CardListPoolItemProps> = ({ index, item, onClickItem }) => {
   const pairName = useMemo(() => {
     const pool = item.pool;
-    return `${pool.tokenA.symbol}/${pool.tokenB.symbol}`;
+    return `${formatDisplayTokenSymbol(pool.tokenA.symbol)}/${formatDisplayTokenSymbol(pool.tokenB.symbol)}`;
   }, [item]);
 
   const poolFeeRate = useMemo(() => {

--- a/packages/web/src/components/home/card-list-item/CardListTokenItem.tsx
+++ b/packages/web/src/components/home/card-list-item/CardListTokenItem.tsx
@@ -3,6 +3,7 @@ import { ListItem } from "./CardListItem.styles";
 import IconTriangleArrowUp from "@components/common/icons/IconTriangleArrowUp";
 import IconTriangleArrowDown from "@components/common/icons/IconTriangleArrowDown";
 import { CardListTokenInfo } from "@models/common/card-list-item-info";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 import { useCallback, useMemo } from "react";
 
 interface CardListTokenItemProps {
@@ -36,7 +37,7 @@ const CardListTokenItem: React.FC<CardListTokenItemProps> = ({ index, item, onCl
         mobileWidth={20}
       />
       <strong className="token-name">{item.token.name}</strong>
-      <span className="list-content">{item.token.symbol}</span>
+      <span className="list-content">{formatDisplayTokenSymbol(item.token.symbol)}</span>
       {visibleUp && <IconTriangleArrowUp className="arrow-up" />}
       {visibleDown && <IconTriangleArrowDown className="arrow-down" />}
       <span className="notation-value">{item.content}</span>

--- a/packages/web/src/components/swap/confirm-swap-modal/ConfirmSwapModal.tsx
+++ b/packages/web/src/components/swap/confirm-swap-modal/ConfirmSwapModal.tsx
@@ -9,6 +9,7 @@ import { swapDirectionToGuaranteedType } from "@models/swap/swap-summary-info";
 import { SwapTokenInfo } from "@models/swap/swap-token-info";
 import { floorNumber, toNumberFormat } from "@utils/number-utils";
 import { convertToKMBWithPrefix } from "@utils/stake-position-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import Button, { ButtonHierarchy } from "@components/common/button/Button";
 import ExchangeRate from "@components/common/exchange-rate/ExchangeRate";
@@ -67,18 +68,18 @@ const ConfirmSwapModal: React.FC<ConfirmSwapModalProps> = ({
     if (swapRateAction === SwapRateAction.ATOB) {
       return (
         <>
-          1&nbsp;{tokenA.symbol}&nbsp;=&nbsp;
+          1&nbsp;{formatDisplayTokenSymbol(tokenA.symbol)}&nbsp;=&nbsp;
           <ExchangeRate value={convertSwapRate(swapRate)} />
-          &nbsp;{tokenB.symbol}
+          &nbsp;{formatDisplayTokenSymbol(tokenB.symbol)}
         </>
       );
     }
 
     return (
       <>
-        1&nbsp;{tokenB.symbol}&nbsp;=&nbsp;
+        1&nbsp;{formatDisplayTokenSymbol(tokenB.symbol)}&nbsp;=&nbsp;
         <ExchangeRate value={convertSwapRate(swapRate)} />
-        &nbsp;{tokenA.symbol}
+        &nbsp;{formatDisplayTokenSymbol(tokenA.symbol)}
       </>
     );
   }, [swapSummaryInfo]);
@@ -227,7 +228,7 @@ const ConfirmSwapModal: React.FC<ConfirmSwapModalProps> = ({
                     width={24}
                     mobileWidth={24}
                   />
-                  <span>{swapSummaryInfo?.tokenA.symbol}</span>
+                  <span>{formatDisplayTokenSymbol(swapSummaryInfo?.tokenA.symbol || "")}</span>
                 </div>
               </div>
               <div className="amount-info">
@@ -252,7 +253,7 @@ const ConfirmSwapModal: React.FC<ConfirmSwapModalProps> = ({
                     width={24}
                     mobileWidth={24}
                   />
-                  <span>{swapSummaryInfo?.tokenB.symbol}</span>
+                  <span>{formatDisplayTokenSymbol(swapSummaryInfo?.tokenB.symbol || "")}</span>
                 </div>
               </div>
               <div className="amount-info">

--- a/packages/web/src/components/swap/swap-card-content-detail/SwapCardContentDetail.tsx
+++ b/packages/web/src/components/swap/swap-card-content-detail/SwapCardContentDetail.tsx
@@ -14,6 +14,7 @@ import { SwapTokenInfo } from "@models/swap/swap-token-info";
 import { DEVICE_TYPE } from "@styles/media";
 import { floorNumber, toNumberFormat } from "@utils/number-utils";
 import { convertToKMBWithPrefix } from "@utils/stake-position-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import SwapCardAutoRouter from "./swap-card-auto-router/SwapCardAutoRouter";
 import SwapCardFeeInfo from "./swap-card-fee-info/SwapCardFeeInfo";
@@ -58,17 +59,17 @@ const SwapCardContentDetail: React.FC<SwapCardContentDetailProps> = ({
     if (swapRateAction === SwapRateAction.ATOB) {
       return (
         <>
-          1 {tokenA.symbol} =&nbsp;
+          1 {formatDisplayTokenSymbol(tokenA.symbol)} =&nbsp;
           <ExchangeRate value={convertSwapRate(swapRate)} />
-          &nbsp;{tokenB.symbol}
+          &nbsp;{formatDisplayTokenSymbol(tokenB.symbol)}
         </>
       );
     } else {
       return (
         <>
-          1 {tokenB.symbol} =&nbsp;
+          1 {formatDisplayTokenSymbol(tokenB.symbol)} =&nbsp;
           <ExchangeRate value={convertSwapRate(swapRate)} />
-          &nbsp;{tokenA.symbol}
+          &nbsp;{formatDisplayTokenSymbol(tokenA.symbol)}
         </>
       );
     }

--- a/packages/web/src/containers/breadcrumbs-container/BreadcrumbsContainer.tsx
+++ b/packages/web/src/containers/breadcrumbs-container/BreadcrumbsContainer.tsx
@@ -5,6 +5,7 @@ import { pulseSkeletonStyle } from "@constants/skeleton.constant";
 import { useGetToken } from "@query/token";
 import { ITokenResponse } from "@repositories/token";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 import { useTranslation } from "react-i18next";
 
 export type BreadcrumbTypes = "TOKEN_SYMBOL" | "LAUNCHPAD" | "OTHERs";
@@ -50,7 +51,9 @@ const BreadcrumbsContainer: React.FC<Props> = ({ listBreadcrumb, isLoading, w = 
         path: "/",
       },
       {
-        title: getMapping(tokenB?.symbol || "")[router.pathname] || `${getGnotPath(tokenB)?.symbol || "BTC"}`,
+        title:
+          getMapping(formatDisplayTokenSymbol(tokenB?.symbol || ""))[router.pathname] ||
+          `${formatDisplayTokenSymbol(getGnotPath(tokenB)?.symbol || "BTC")}`,
         path: "",
       },
     ];

--- a/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
@@ -31,7 +31,7 @@ import { CommonState } from "@states/index";
 import { subscriptFormat } from "@utils/number-utils";
 import { formatTokenExchangeRate } from "@utils/stake-position-utils";
 import { priceToNearTick } from "@utils/swap-utils";
-import { makeDisplayTokenAmount } from "@utils/token-utils";
+import { formatDisplayTokenSymbol, makeDisplayTokenAmount } from "@utils/token-utils";
 
 import { GnoProvider } from "@common/clients/gno-provider/gno-provider";
 import { BROADCAST_ERROR_VALUE } from "@common/errors/broadcast/broadcast-error";
@@ -204,8 +204,12 @@ export const usePoolAddLiquidityConfirmModal = ({
     if (!selectPool) {
       return null;
     }
-    const tokenASymbol = selectPool.compareToken?.symbol === tokenA?.symbol ? tokenA?.symbol : tokenB?.symbol;
-    const tokenBSymbol = selectPool.compareToken?.symbol === tokenA?.symbol ? tokenB?.symbol : tokenA?.symbol;
+    const tokenASymbol = formatDisplayTokenSymbol(
+      selectPool.compareToken?.symbol === tokenA?.symbol ? tokenA?.symbol || "" : tokenB?.symbol || "",
+    );
+    const tokenBSymbol = formatDisplayTokenSymbol(
+      selectPool.compareToken?.symbol === tokenA?.symbol ? tokenB?.symbol || "" : tokenA?.symbol || "",
+    );
     const currentPrice = `${selectPool.currentPrice}`;
     if (selectPool.selectedFullRange) {
       return {

--- a/packages/web/src/layouts/dashboard/components/dashboard-info/dashboard-info-title/DashboardInfoTitle.tsx
+++ b/packages/web/src/layouts/dashboard/components/dashboard-info/dashboard-info-title/DashboardInfoTitle.tsx
@@ -1,6 +1,7 @@
 import { GNS_TOKEN } from "@common/values/token-constant";
 import IconLogoWhite from "@components/common/icons/IconLogoWhite";
 import { DEVICE_TYPE } from "@styles/media";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { DashboardInfoTitleWrapper, TitleDivider, TokenLogoWrapper, TokenWrapper } from "./DashboardInfoTitle.styles";
 
@@ -21,7 +22,7 @@ const DashboardInfoTitle: React.FC<DashboardInfoTitleProps> = ({ dashboardTokenI
         <div className="token-image-wrapper">
           <IconLogoWhite />
         </div>
-        <div className="token-symbol">{GNS_TOKEN.symbol}</div>
+        <div className="token-symbol">{formatDisplayTokenSymbol(GNS_TOKEN.symbol)}</div>
       </TokenLogoWrapper>
       <div className="amount-info">{dashboardTokenInfo.gnosAmount}</div>
     </TokenWrapper>

--- a/packages/web/src/layouts/earn/components/incentivized-pool-card-list/incentivized-pool-card/IncentivizedPoolCard.tsx
+++ b/packages/web/src/layouts/earn/components/incentivized-pool-card-list/incentivized-pool-card/IncentivizedPoolCard.tsx
@@ -16,7 +16,7 @@ import { IncentivizePoolCardInfoWithPriceGrade } from "@models/pool/info/pool-ca
 import { useGetBinsByPath } from "@query/pools";
 import { formatRate } from "@utils/new-number-utils";
 import { numberToFormat } from "@utils/string-utils";
-import { getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
+import { formatDisplayTokenSymbol, getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
 
 import LoadingSpinner from "@components/common/loading-spinner/LoadingSpinner";
 import PriceWarning from "@components/common/price-warning/PriceWarning";
@@ -57,7 +57,7 @@ const IncentivizedPoolCard: React.FC<IncentivizedPoolCardProps> = ({ pool, route
   const staked = pool.hasStakedPosition;
 
   const pairName = useMemo(() => {
-    return `${pool.tokenA.symbol}/${pool.tokenB.symbol}`;
+    return `${formatDisplayTokenSymbol(pool.tokenA.symbol)}/${formatDisplayTokenSymbol(pool.tokenB.symbol)}`;
   }, [pool.tokenA.symbol, pool.tokenB.symbol]);
 
   const rewardTokenLogos = useMemo(() => {
@@ -172,9 +172,12 @@ const IncentivizedPoolCard: React.FC<IncentivizedPoolCardProps> = ({ pool, route
               )}
               <div className="price-section">
                 <span className="label-text">{t("Earn:incentiPools.card.current.price")}</span>
-                <span className="label-text">{`1 ${pool.tokenA.symbol} = ${numberToFormat(pool.price, {
-                  decimals: 2,
-                })} ${pool.tokenB.symbol}`}</span>
+                <span className="label-text">{`1 ${formatDisplayTokenSymbol(pool.tokenA.symbol)} = ${numberToFormat(
+                  pool.price,
+                  {
+                    decimals: 2,
+                  },
+                )} ${formatDisplayTokenSymbol(pool.tokenB.symbol)}`}</span>
               </div>
             </div>
           </div>

--- a/packages/web/src/layouts/earn/components/pool-list/pool-list-table/pool-info/PoolInfo.tsx
+++ b/packages/web/src/layouts/earn/components/pool-list/pool-list-table/pool-info/PoolInfo.tsx
@@ -10,7 +10,7 @@ import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { PoolListInfo } from "@models/pool/info/pool-list-info";
 import { DEVICE_TYPE } from "@styles/media";
 import { formatOtherPrice, formatRate } from "@utils/new-number-utils";
-import { getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
+import { formatDisplayTokenSymbol, getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
 
 import PoolInfoLazyChart from "./pool-info-lazy-chart/PoolInfoLazyChart";
 
@@ -102,10 +102,10 @@ const PoolInfo: React.FC<PoolInfoProps> = ({ pool, routeItem, breakpoint }) => {
     breakpoint === DEVICE_TYPE.MOBILE
       ? POOL_INFO_MOBILE
       : breakpoint === DEVICE_TYPE.TABLET_M
-      ? POOL_INFO_SMALL_TABLET
-      : breakpoint === DEVICE_TYPE.TABLET
-      ? POOL_INFO_TABLET
-      : POOL_INFO;
+        ? POOL_INFO_SMALL_TABLET
+        : breakpoint === DEVICE_TYPE.TABLET
+          ? POOL_INFO_TABLET
+          : POOL_INFO;
 
   /**
    * Checks if either token has missing price information
@@ -174,7 +174,9 @@ const PoolInfo: React.FC<PoolInfoProps> = ({ pool, routeItem, breakpoint }) => {
           leftSymbol={tokenA.symbol}
           rightSymbol={tokenB.symbol}
         />
-        <span className="symbol-pair">{`${tokenA.symbol}/${tokenB.symbol}`}</span>
+        <span className="symbol-pair">{`${formatDisplayTokenSymbol(tokenA.symbol)}/${formatDisplayTokenSymbol(
+          tokenB.symbol,
+        )}`}</span>
         <span className="feeRate">{SwapFeeTierInfoMap[feeTier].rateStr}</span>
       </TableColumn>
       {/* TVL */}

--- a/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustom.tsx
+++ b/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustom.tsx
@@ -26,6 +26,7 @@ import { checkGnotPath } from "@utils/common";
 import { sortTokenPaths } from "@utils/sort-utils";
 import { formatTokenExchangeRate } from "@utils/stake-position-utils";
 import { priceToTick, tickToPrice } from "@utils/swap-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import PriceSteps from "./price-steps/PriceSteps";
 import StartingPrice from "./starting-price/StartingPrice";
@@ -85,10 +86,10 @@ const SelectPriceRangeCustom = forwardRef<SelectPriceRangeCustomHandle, SelectPr
 
     const isCustom = true;
 
-    const isLoading = useMemo(() => selectPool.renderState() === "LOADING" || isLoadingSelectPriceRange, [
-      selectPool.renderState(),
-      isLoadingSelectPriceRange,
-    ]);
+    const isLoading = useMemo(
+      () => selectPool.renderState() === "LOADING" || isLoadingSelectPriceRange,
+      [selectPool.renderState(), isLoadingSelectPriceRange],
+    );
 
     const availSelect = Array.isArray(selectPool.liquidityOfTickPoints) && selectPool.renderState() === "DONE";
 
@@ -112,13 +113,13 @@ const SelectPriceRangeCustom = forwardRef<SelectPriceRangeCustomHandle, SelectPr
 
       return (
         <>
-          1 {tokenA.symbol} =&nbsp;
+          1 {formatDisplayTokenSymbol(tokenA.symbol)} =&nbsp;
           {formatTokenExchangeRate(currentPrice, {
             maxSignificantDigits: 6,
             minLimit: 0.000001,
           })}
           &nbsp;
-          {tokenB.symbol}
+          {formatDisplayTokenSymbol(tokenB.symbol)}
         </>
       );
     }, [

--- a/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustomReposition.tsx
+++ b/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustomReposition.tsx
@@ -21,6 +21,7 @@ import { checkGnotPath } from "@utils/common";
 import { formatTokenExchangeRate } from "@utils/stake-position-utils";
 import { priceToTick, tickToPrice } from "@utils/swap-utils";
 import { sortTokenPaths } from "@utils/sort-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import SelectPriceRangeCutomController from "./price-steps/PriceSteps";
 
@@ -125,13 +126,13 @@ const SelectPriceRangeCustomReposition: React.FC<SelectPriceRangeCustomRepositio
 
     return (
       <>
-        1 {currentTokenA.symbol} =&nbsp;
+        1 {formatDisplayTokenSymbol(currentTokenA.symbol)} =&nbsp;
         {formatTokenExchangeRate(priceWithDecimal, {
           maxSignificantDigits: 6,
           minLimit: 0.000001,
         })}
         &nbsp;
-        {currentTokenB.symbol}
+        {formatDisplayTokenSymbol(currentTokenB.symbol)}
       </>
     );
   }, [

--- a/packages/web/src/layouts/pool/pool-add/PoolAdd.tsx
+++ b/packages/web/src/layouts/pool/pool-add/PoolAdd.tsx
@@ -12,6 +12,7 @@ import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { useGetPoolDetailByPath } from "@query/pools";
 import { DeviceSize } from "@styles/media";
 import { makeRouteUrl } from "@utils/page.utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import EarnAddLiquidityContainer from "./containers/earn-add-liquidity-container/EarnAddLiquidityContainer";
 import PoolAddLiquidityContainer from "./containers/pool-add-liquidity-container/PoolAddLiquidityContainer";
@@ -40,7 +41,9 @@ const PoolAdd: React.FC<PoolAddProps> = ({ useDedicatedPool }) => {
       base.push({
         title:
           width > DeviceSize.mediumWeb
-            ? `${getGnotPath(data?.tokenA).symbol}/${getGnotPath(data?.tokenB).symbol} (${Number(data?.fee) / 10000}%)`
+            ? `${formatDisplayTokenSymbol(getGnotPath(data?.tokenA).symbol)}/${formatDisplayTokenSymbol(
+                getGnotPath(data?.tokenB).symbol,
+              )} (${Number(data?.fee) / 10000}%)`
             : "...",
         path: makeRouteUrl(PAGE_PATH.POOL, {
           [QUERY_PARAMETER.POOL_PATH]: data?.poolPath,

--- a/packages/web/src/layouts/pool/pool-add/components/pool-add-confirm-fee-info/PoolAddConfirmFeeInfo.tsx
+++ b/packages/web/src/layouts/pool/pool-add/components/pool-add-confirm-fee-info/PoolAddConfirmFeeInfo.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { TokenInfo } from "@models/token/token-info";
 import Tooltip from "@components/common/tooltip/Tooltip";
 import IconInfo from "@components/common/icons/IconInfo";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import {
   CreationFeeErrorMsgWrapper,
@@ -39,7 +40,7 @@ const PoolAddConfirmFeeInfo: React.FC<EarnAddConfirmFeeInfoProps> = ({ token, fe
       <PoolAddConfirmFeeInfoSection $hasError={!!errorMsg}>
         <div className="token-info">
           <img src={token?.logoURI} alt="token logo" />
-          <div>{token?.symbol}</div>
+          <div>{formatDisplayTokenSymbol(token?.symbol || "")}</div>
         </div>
         <div className="fee-info">
           <span>{fee}</span>

--- a/packages/web/src/layouts/pool/pool-add/components/pool-add-confirm-price-range-info/PoolAddConfirmPriceRangeInfo.tsx
+++ b/packages/web/src/layouts/pool/pool-add/components/pool-add-confirm-price-range-info/PoolAddConfirmPriceRangeInfo.tsx
@@ -8,6 +8,7 @@ import Tooltip from "@components/common/tooltip/Tooltip";
 import { RANGE_STATUS_OPTION } from "@constants/option.constant";
 import { formatRate } from "@utils/new-number-utils";
 import { formatTokenExchangeRate } from "@utils/stake-position-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { EarnAddConfirmAmountInfoProps } from "../pool-add-confirm-amount-info/PoolAddConfirmAmountInfo";
 
@@ -48,19 +49,21 @@ const PoolAddConfirmPriceRangeInfo: React.FC<PoolAddConfirmPriceRangeInfoProps> 
   const { t } = useTranslation();
 
   const [swap, setSwap] = useState(false);
+  const tokenASymbol = formatDisplayTokenSymbol(tokenA.info.symbol);
+  const tokenBSymbol = formatDisplayTokenSymbol(tokenB.info.symbol);
 
   const currentPriceStr = useMemo(() => {
     if (!swap) {
-      return `1 ${tokenA.info.symbol} = ${formatTokenExchangeRate(currentPrice, {
+      return `1 ${tokenASymbol} = ${formatTokenExchangeRate(currentPrice, {
         maxSignificantDigits: 6,
         minLimit: 0.000001,
-      })} ${tokenB.info.symbol}`;
+      })} ${tokenBSymbol}`;
     }
-    return `1 ${tokenB.info.symbol} = ${formatTokenExchangeRate(1 / Number(currentPrice), {
+    return `1 ${tokenBSymbol} = ${formatTokenExchangeRate(1 / Number(currentPrice), {
       maxSignificantDigits: 6,
       minLimit: 0.000001,
-    })} ${tokenA.info.symbol}`;
-  }, [currentPrice, tokenA.info.symbol, tokenB.info.symbol, swap]);
+    })} ${tokenASymbol}`;
+  }, [currentPrice, tokenASymbol, tokenBSymbol, swap]);
 
   const rangeStatus = useMemo(() => {
     return inRange ? RANGE_STATUS_OPTION.IN : RANGE_STATUS_OPTION.OUT;
@@ -68,17 +71,17 @@ const PoolAddConfirmPriceRangeInfo: React.FC<PoolAddConfirmPriceRangeInfoProps> 
 
   const displayPriceLabelMin = useMemo(() => {
     if (breakpoint === DEVICE_TYPE.MOBILE) {
-      return `${tokenA.info.symbol} per ${tokenB.info.symbol}`;
+      return `${tokenASymbol} per ${tokenBSymbol}`;
     }
     return priceLabelMin;
-  }, [breakpoint, priceLabelMin, tokenA, tokenB]);
+  }, [breakpoint, priceLabelMin, tokenASymbol, tokenBSymbol]);
 
   const displayPriceLabelMax = useMemo(() => {
     if (breakpoint === DEVICE_TYPE.MOBILE) {
-      return `${tokenA.info.symbol} per ${tokenB.info.symbol}`;
+      return `${tokenASymbol} per ${tokenBSymbol}`;
     }
     return priceLabelMax;
-  }, [breakpoint, priceLabelMax, tokenA, tokenB]);
+  }, [breakpoint, priceLabelMax, tokenASymbol, tokenBSymbol]);
 
   return (
     <PoolAddConfirmPriceRangeInfoWrapper>

--- a/packages/web/src/layouts/pool/pool-decrease-liquidity/PoolDecreaseLiquidity.tsx
+++ b/packages/web/src/layouts/pool/pool-decrease-liquidity/PoolDecreaseLiquidity.tsx
@@ -11,6 +11,7 @@ import { useWindowSize } from "@hooks/common/use-window-size";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { DeviceSize } from "@styles/media";
 import { makeRouteUrl } from "@utils/page.utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 import { useGetPoolDetailByPath } from "src/react-query/pools";
 
 import DecreaseLiquidityContainer from "./containers/decrease-liquidity-container/DecreaseLiquidityContainer";
@@ -31,7 +32,9 @@ const PoolDecreaseLiquidity: React.FC = () => {
       {
         title:
           width > DeviceSize.mediumWeb
-            ? `${getGnotPath(data?.tokenA).symbol}/${getGnotPath(data?.tokenB).symbol} (${Number(data?.fee) / 10000}%)`
+            ? `${formatDisplayTokenSymbol(getGnotPath(data?.tokenA).symbol)}/${formatDisplayTokenSymbol(
+                getGnotPath(data?.tokenB).symbol,
+              )} (${Number(data?.fee) / 10000}%)`
             : "...",
         path: makeRouteUrl(PAGE_PATH.POOL, {
           [QUERY_PARAMETER.POOL_PATH]: poolPath,

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/BalanceTooltipContent.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/BalanceTooltipContent.tsx
@@ -5,6 +5,7 @@ import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { TokenModel } from "@models/token/token-model";
 import { formatPoolPairAmount } from "@utils/new-number-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { BalanceTooltipContentWrapper } from "./BalanceTooltipContent.styles";
 
@@ -36,7 +37,7 @@ export const BalanceTooltipContent: React.FC<BalanceTooltipContentProps> = ({ ba
               width={20}
               mobileWidth={20}
             />
-            <span className="position">{balance.token.symbol}</span>
+            <span className="position">{formatDisplayTokenSymbol(balance.token.symbol)}</span>
           </div>
           <span className="position">
             {formatPoolPairAmount(balance.balance, {

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
@@ -1022,7 +1022,7 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
                   dangerouslySetInnerHTML={{
                     __html: sanitizeHtml(
                       t("Pool:position.ratioTooltip", {
-                        symbol: (!isSwap ? tokenA : tokenB)?.symbol,
+                        symbol: formatDisplayTokenSymbol((!isSwap ? tokenA : tokenB)?.symbol || ""),
                       }),
                     ),
                   }}
@@ -1046,7 +1046,7 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
                   dangerouslySetInnerHTML={{
                     __html: sanitizeHtml(
                       t("Pool:position.ratioTooltip", {
-                        symbol: (!isSwap ? tokenB : tokenA)?.symbol,
+                        symbol: formatDisplayTokenSymbol((!isSwap ? tokenB : tokenA)?.symbol || ""),
                       }),
                     ),
                   }}

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
@@ -37,7 +37,7 @@ import { formatOtherPrice } from "@utils/new-number-utils";
 import { makeRouteUrl } from "@utils/page.utils";
 import { formatTokenExchangeRate } from "@utils/stake-position-utils";
 import { isEndTickBy, tickToPrice, tickToPriceStr } from "@utils/swap-utils";
-import { makeDisplayTokenAmount } from "@utils/token-utils";
+import { formatDisplayTokenSymbol, makeDisplayTokenAmount } from "@utils/token-utils";
 import { isClaimableReward, mapToDisplayRewardType } from "@utils/reward-utils";
 import { sortTokensByPoolOrder } from "@utils/pool-utils";
 
@@ -500,23 +500,23 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
     if (isSwap) {
       return (
         <>
-          1 {tokenB?.symbol} ={" "}
+          1 {formatDisplayTokenSymbol(tokenB?.symbol || "")} ={" "}
           {formatTokenExchangeRate(1 / price, {
             maxSignificantDigits: 6,
             minLimit: 0.000001,
           })}{" "}
-          {tokenA?.symbol}
+          {formatDisplayTokenSymbol(tokenA?.symbol || "")}
         </>
       );
     }
     return (
       <>
-        1 {tokenA?.symbol} ={" "}
+        1 {formatDisplayTokenSymbol(tokenA?.symbol || "")} ={" "}
         {formatTokenExchangeRate(price, {
           maxSignificantDigits: 6,
           minLimit: 0.000001,
         })}{" "}
-        {tokenB?.symbol}
+        {formatDisplayTokenSymbol(tokenB?.symbol || "")}
       </>
     );
   }, [isSwap, tokenB?.symbol, tokenA?.symbol, position?.pool?.currentTick]);
@@ -1020,9 +1020,11 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
               FloatingContent={
                 <ToolTipContentWrapper
                   dangerouslySetInnerHTML={{
-                    __html: sanitizeHtml(t("Pool:position.ratioTooltip", {
-                      symbol: (!isSwap ? tokenA : tokenB)?.symbol,
-                    })),
+                    __html: sanitizeHtml(
+                      t("Pool:position.ratioTooltip", {
+                        symbol: (!isSwap ? tokenA : tokenB)?.symbol,
+                      }),
+                    ),
                   }}
                 />
               }
@@ -1042,9 +1044,11 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
               FloatingContent={
                 <ToolTipContentWrapper
                   dangerouslySetInnerHTML={{
-                    __html: sanitizeHtml(t("Pool:position.ratioTooltip", {
-                      symbol: (!isSwap ? tokenB : tokenA)?.symbol,
-                    })),
+                    __html: sanitizeHtml(
+                      t("Pool:position.ratioTooltip", {
+                        symbol: (!isSwap ? tokenB : tokenA)?.symbol,
+                      }),
+                    ),
                   }}
                 />
               }

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-liquidity-content/MyLiquidityContent.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-liquidity-content/MyLiquidityContent.tsx
@@ -21,7 +21,7 @@ import { TokenPriceModel } from "@models/token/token-price-model";
 import { DEVICE_TYPE } from "@styles/media";
 import { isGNOTPath } from "@utils/common";
 import { formatOtherPrice, formatPoolPairAmount } from "@utils/new-number-utils";
-import { makeDisplayTokenAmount } from "@utils/token-utils";
+import { formatDisplayTokenSymbol, makeDisplayTokenAmount } from "@utils/token-utils";
 import { mapToDisplayRewardType } from "@utils/reward-utils";
 import { DEFAULT_TOKEN_PRICE_RATIO } from "@common/values";
 import { sortDisplayRewards } from "@utils/pool-utils";
@@ -693,7 +693,7 @@ const MyLiquidityContent: React.FC<MyLiquidityContentProps> = ({
                     isKMB: false,
                     decimals: positionData.tokenA.decimals,
                   })}{" "}
-                  <span>{positionData?.tokenA?.symbol}</span>{" "}
+                  <span>{formatDisplayTokenSymbol(positionData?.tokenA?.symbol || "")}</span>{" "}
                 </TokenAmountTooltipContentWrapper>
               }
             >
@@ -709,7 +709,9 @@ const MyLiquidityContent: React.FC<MyLiquidityContentProps> = ({
                     {formatPoolPairAmount(tokenABalance, {
                       decimals: 2,
                     })}{" "}
-                    <span className={"token-symbol wrap-text"}>{positionData?.tokenA?.symbol}</span>{" "}
+                    <span className={"token-symbol wrap-text"}>
+                      {formatDisplayTokenSymbol(positionData?.tokenA?.symbol || "")}
+                    </span>{" "}
                     <span className="token-percent">{depositRatioStrOfTokenA}</span>
                   </>
                 ) : (
@@ -734,7 +736,7 @@ const MyLiquidityContent: React.FC<MyLiquidityContentProps> = ({
                     isKMB: false,
                     decimals: positionData.tokenA.decimals,
                   })}{" "}
-                  <span>{positionData?.tokenB?.symbol}</span>{" "}
+                  <span>{formatDisplayTokenSymbol(positionData?.tokenB?.symbol || "")}</span>{" "}
                 </TokenAmountTooltipContentWrapper>
               }
             >
@@ -750,7 +752,9 @@ const MyLiquidityContent: React.FC<MyLiquidityContentProps> = ({
                     {formatPoolPairAmount(tokenBBalance, {
                       decimals: 2,
                     })}{" "}
-                    <span className={"token-symbol  wrap-text"}>{positionData?.tokenB?.symbol}</span>{" "}
+                    <span className={"token-symbol  wrap-text"}>
+                      {formatDisplayTokenSymbol(positionData?.tokenB?.symbol || "")}
+                    </span>{" "}
                     <span className="token-percent">{depositRatioStrOfTokenB}</span>
                   </>
                 ) : (

--- a/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-content/PoolPairInfoContent.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-content/PoolPairInfoContent.tsx
@@ -23,6 +23,7 @@ import { ThemeState } from "@states/index";
 import { formatOtherPrice, formatPoolPairAmount, formatRate } from "@utils/new-number-utils";
 import { formatTokenExchangeRate } from "@utils/stake-position-utils";
 import { tickToPrice } from "@utils/swap-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import {
   AprDivider,
@@ -329,7 +330,7 @@ const PoolPairInfoContent: React.FC<PoolPairInfoContentProps> = ({
                         isKMB: false,
                         decimals: pool.tokenA.decimals,
                       })}{" "}
-                      <span>{pool?.tokenA?.symbol}</span>{" "}
+                      <span>{formatDisplayTokenSymbol(pool?.tokenA?.symbol || "")}</span>{" "}
                     </TokenAmountTooltipContentWrapper>
                   }
                   className={`section-image ${pool.tokenABalance ? "can-hover" : ""}`}
@@ -344,7 +345,9 @@ const PoolPairInfoContent: React.FC<PoolPairInfoContentProps> = ({
                     {formatPoolPairAmount(pool.tokenABalance, {
                       decimals: 2,
                     })}{" "}
-                    <span className={`token-symbol ${isWrapText ? "wrap-text" : ""}`}>{pool?.tokenA?.symbol}</span>{" "}
+                    <span className={`token-symbol ${isWrapText ? "wrap-text" : ""}`}>
+                      {formatDisplayTokenSymbol(pool?.tokenA?.symbol || "")}
+                    </span>{" "}
                     <span className="token-percent">{depositRatioStrOfTokenA}</span>
                   </span>
                 </Tooltip>
@@ -363,7 +366,7 @@ const PoolPairInfoContent: React.FC<PoolPairInfoContentProps> = ({
                         isKMB: false,
                         decimals: pool.tokenA.decimals,
                       })}
-                      <span>{pool?.tokenB?.symbol}</span>{" "}
+                      <span>{formatDisplayTokenSymbol(pool?.tokenB?.symbol || "")}</span>{" "}
                     </TokenAmountTooltipContentWrapper>
                   }
                   className={`section-image ${pool.tokenBBalance ? "can-hover" : ""}`}
@@ -378,7 +381,9 @@ const PoolPairInfoContent: React.FC<PoolPairInfoContentProps> = ({
                     {formatPoolPairAmount(pool.tokenBBalance, {
                       decimals: 2,
                     })}{" "}
-                    <span className={`token-symbol ${isWrapText ? "wrap-text" : ""}`}>{pool?.tokenB?.symbol}</span>{" "}
+                    <span className={`token-symbol ${isWrapText ? "wrap-text" : ""}`}>
+                      {formatDisplayTokenSymbol(pool?.tokenB?.symbol || "")}
+                    </span>{" "}
                     <span className="token-percent">{depositRatioStrOfTokenB}</span>
                   </span>
                 </Tooltip>
@@ -501,7 +506,8 @@ const PoolPairInfoContent: React.FC<PoolPairInfoContentProps> = ({
                       width={20}
                       className="image-logo"
                     />
-                    {width >= 768 && `1 ${pool?.tokenA?.symbol}`} = {currentPriceRatio} {pool?.tokenB?.symbol}
+                    {width >= 768 && `1 ${formatDisplayTokenSymbol(pool?.tokenA?.symbol || "")}`} = {currentPriceRatio}{" "}
+                    {formatDisplayTokenSymbol(pool?.tokenB?.symbol || "")}
                   </div>
                 )}
                 {loading && (
@@ -523,7 +529,8 @@ const PoolPairInfoContent: React.FC<PoolPairInfoContentProps> = ({
                       width={20}
                       className="image-logo"
                     />
-                    {width >= 768 && `1 ${pool?.tokenB?.symbol}`} = {currentPriceReverse} {pool?.tokenA?.symbol}
+                    {width >= 768 && `1 ${formatDisplayTokenSymbol(pool?.tokenB?.symbol || "")}`} ={" "}
+                    {currentPriceReverse} {formatDisplayTokenSymbol(pool?.tokenA?.symbol || "")}
                   </div>
                 )}
               </div>

--- a/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-header/PoolPairInfoHeader.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-header/PoolPairInfoHeader.tsx
@@ -6,7 +6,7 @@ import OverlapTokenLogo from "@components/common/overlap-token-logo/OverlapToken
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { TokenModel } from "@models/token/token-model";
 import { RewardTokenModel } from "@models/position/reward-model";
-import { getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
+import { formatDisplayTokenSymbol, getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
 
 import { PoolInfoHeaderWrapper } from "./PoolPairInfoHeader.styles";
 
@@ -52,7 +52,7 @@ const PoolPairInfoHeader: React.FC<PoolPairInfoHeaderProps> = ({
           size={doubleLogoSize}
         />
         <h3>
-          {tokenA.symbol}/{tokenB.symbol}
+          {formatDisplayTokenSymbol(tokenA.symbol)}/{formatDisplayTokenSymbol(tokenB.symbol)}
         </h3>
       </div>
       <div className="badge-wrap">

--- a/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/incentivized-token-detail-tooltip-content/IncentivizeTokenDetailTooltipContent.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/incentivized-token-detail-tooltip-content/IncentivizeTokenDetailTooltipContent.tsx
@@ -8,6 +8,7 @@ import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { PoolStakingModel } from "@models/pool/pool-staking";
 import { formatPoolPairAmount } from "@utils/new-number-utils";
 import { capitalize } from "@utils/string-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import * as S from "./IncentivizeTokenDetailTooltipContent.styles";
 
@@ -46,7 +47,7 @@ const IncentivizeTokenDetailTooltipContent: React.FC<Props> = ({ poolStakings }:
             <S.TokenItem key={item.startTimestamp + item.incentivizedAmount}>
               <S.ItemHeader>
                 <MissingLogo symbol={tokenData.symbol} url={tokenData.logoURI} width={18} />
-                <S.ItemHeaderSymbol>{tokenData.symbol}</S.ItemHeaderSymbol>
+                <S.ItemHeaderSymbol>{formatDisplayTokenSymbol(tokenData.symbol)}</S.ItemHeaderSymbol>
                 <S.ItemHeaderTag>{incentiveTypeText(item.incentiveType)}</S.ItemHeaderTag>
               </S.ItemHeader>
               <S.DataGrid>

--- a/packages/web/src/layouts/pool/pool-incentivize/PoolIncentivize.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/PoolIncentivize.tsx
@@ -13,6 +13,7 @@ import { useTokenData } from "@hooks/token/data/use-token-data";
 import { DEVICE_TYPE } from "@styles/media";
 import { checkGnotPath } from "@utils/common";
 import { makeRouteUrl } from "@utils/page.utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import PoolAddIncentivizeContainer from "./containers/pool-add-incentivize-container/PoolAddIncentivizeContainer";
 import PoolIncentivizeContainer from "./containers/pool-incentivize-container/PoolIncentivizeContainer";
@@ -41,7 +42,9 @@ const PoolIncentivize: React.FC = () => {
       base.push({
         title:
           breakpoint === DEVICE_TYPE.WEB || breakpoint === DEVICE_TYPE.MEDIUM_WEB
-            ? `${getGnotPath(tokenA).symbol}/${getGnotPath(tokenB).symbol} (${Number(fee) / 10000}%)`
+            ? `${formatDisplayTokenSymbol(getGnotPath(tokenA).symbol)}/${formatDisplayTokenSymbol(
+                getGnotPath(tokenB).symbol,
+              )} (${Number(fee) / 10000}%)`
             : "...",
         path: makeRouteUrl(PAGE_PATH.POOL, {
           [QUERY_PARAMETER.POOL_PATH]: poolPath,

--- a/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-history/incentivize-pool-history-box/IncentivizePoolHistoryBox.tsx
@@ -11,6 +11,7 @@ import { ExtendedPoolStakingModel } from "@models/pool/pool-staking";
 import { useGetPoolDetailByPath } from "@query/pools";
 import { toNumberFormat } from "@utils/number-utils";
 import { capitalize } from "@utils/string-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import Button, { ButtonHierarchy } from "@components/common/button/Button";
 import DoubleLogo from "@components/common/double-logo/DoubleLogo";
@@ -129,7 +130,7 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
           <div className="label">{t("IncentivizePool:incentiPool.history.label.token")}</div>
           <div className="value">
             <MissingLogo symbol={rewardToken.symbol} width={24} url={rewardToken.logoURI} />
-            <span>{rewardToken.symbol}</span>
+            <span>{formatDisplayTokenSymbol(rewardToken.symbol)}</span>
             <Chip text={capitalize(stakingData.incentiveType)} />
           </div>
         </div>
@@ -138,7 +139,8 @@ const IncentivizePoolHistoryBox = ({ stakingData, poolPath }: IncentivizePoolHis
           <div className="value">
             <DoubleLogo {...doubleLogos} size={24} />
             <span>
-              {doubleLogos.leftSymbol}/{doubleLogos.rightSymbol}
+              {formatDisplayTokenSymbol(doubleLogos.leftSymbol || "")}/
+              {formatDisplayTokenSymbol(doubleLogos.rightSymbol || "")}
             </span>
             <Chip text={feeRateStr} height={24} />
           </div>

--- a/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-modal/IncentivizePoolModal.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/incentivize-pool-modal/IncentivizePoolModal.tsx
@@ -18,6 +18,7 @@ import { DistributionPeriodDate } from "@states/earn";
 import { IncentivizePoolModalWrapper } from "./IncentivizePoolModal.styles";
 import { GnoProvider } from "@common/clients/gno-provider/gno-provider";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 interface Props {
   close: () => void;
@@ -70,7 +71,8 @@ const IncentivizePoolModal: React.FC<Props> = ({ close, onSubmit, date, period, 
                     size={24}
                   />
                   <div className="value">
-                    {pool ? pool?.tokenA.symbol : ""}/{pool ? pool?.tokenB.symbol : ""}
+                    {formatDisplayTokenSymbol(pool?.tokenA.symbol || "")}/
+                    {formatDisplayTokenSymbol(pool?.tokenB.symbol || "")}
                   </div>
                   <Badge type={BADGE_TYPE.DARK_DEFAULT} text={`${Number(pool?.fee) / 10000}%`} />
                 </div>
@@ -84,7 +86,7 @@ const IncentivizePoolModal: React.FC<Props> = ({ close, onSubmit, date, period, 
                     url={getGnotPath(data?.token)?.logoURI || ""}
                   />
                   <div className="value">
-                    {Number(data?.amount).toLocaleString()} {data?.token?.symbol}
+                    {Number(data?.amount).toLocaleString()} {formatDisplayTokenSymbol(data?.token?.symbol || "")}
                   </div>
                 </div>
               </div>
@@ -99,7 +101,7 @@ const IncentivizePoolModal: React.FC<Props> = ({ close, onSubmit, date, period, 
                   <div className="sub-value">
                     {t("IncentivizePool:confirmModal.row.value.period.desc", {
                       amount: Number((Number(data?.amount || 0) / period).toFixed(2)).toLocaleString(),
-                      symbol: data?.token?.symbol,
+                      symbol: formatDisplayTokenSymbol(data?.token?.symbol || ""),
                     })}
                   </div>
                 </div>

--- a/packages/web/src/layouts/pool/pool-increase-liquidity/PoolIncreaseLiquidity.tsx
+++ b/packages/web/src/layouts/pool/pool-increase-liquidity/PoolIncreaseLiquidity.tsx
@@ -11,6 +11,7 @@ import { useWindowSize } from "@hooks/common/use-window-size";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { DeviceSize } from "@styles/media";
 import { makeRouteUrl } from "@utils/page.utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 import { useGetPoolDetailByPath } from "src/react-query/pools";
 
 import IncreaseLiquidityContainer from "./containers/increase-liquidity-container/IncreaseLiquidityContainer";
@@ -31,7 +32,9 @@ const PoolIncreaseLiquidity: React.FC = () => {
       {
         title:
           width > DeviceSize.mediumWeb
-            ? `${getGnotPath(data?.tokenA).symbol}/${getGnotPath(data?.tokenB).symbol} (${Number(data?.fee) / 10000}%)`
+            ? `${formatDisplayTokenSymbol(getGnotPath(data?.tokenA).symbol)}/${formatDisplayTokenSymbol(
+                getGnotPath(data?.tokenB).symbol,
+              )} (${Number(data?.fee) / 10000}%)`
             : "...",
         path: makeRouteUrl(PAGE_PATH.POOL, {
           [QUERY_PARAMETER.POOL_PATH]: poolPath,

--- a/packages/web/src/layouts/pool/pool-remove/PoolRemove.tsx
+++ b/packages/web/src/layouts/pool/pool-remove/PoolRemove.tsx
@@ -11,6 +11,7 @@ import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { DeviceSize } from "@styles/media";
 import { useGetPoolDetailByPath } from "src/react-query/pools";
 import { PAGE_PATH } from "@constants/page.constant";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import PoolRemoveLayout from "./PoolRemoveLayout";
 import RemoveLiquidityContainer from "./containers/remove-liquidity-container/RemoveLiquidityContainer";
@@ -32,7 +33,9 @@ const PoolRemove: React.FC = () => {
       {
         title:
           width > DeviceSize.mediumWeb
-            ? `${getGnotPath(data?.tokenA).symbol}/${getGnotPath(data?.tokenB).symbol} (${Number(data?.fee) / 10000}%)`
+            ? `${formatDisplayTokenSymbol(getGnotPath(data?.tokenA).symbol)}/${formatDisplayTokenSymbol(
+                getGnotPath(data?.tokenB).symbol,
+              )} (${Number(data?.fee) / 10000}%)`
             : "...",
         path: `/earn/pool?poolPath=${poolPath}`,
       },

--- a/packages/web/src/layouts/pool/pool-remove/components/remove-liquidity/remove-liquidity-select-list/remove-liquidity-select-list-item/RemoveLiquiditySelectListItem.tsx
+++ b/packages/web/src/layouts/pool/pool-remove/components/remove-liquidity/remove-liquidity-select-list/remove-liquidity-select-list-item/RemoveLiquiditySelectListItem.tsx
@@ -14,6 +14,7 @@ import { PoolPositionModel } from "@models/position/pool-position-model";
 import { TokenModel } from "@models/token/token-model";
 import { formatOtherPrice } from "@utils/new-number-utils";
 import { makeSwapFeeTier } from "@utils/swap-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import {
   RemoveLiquiditySelectListItemWrapper,
@@ -46,7 +47,7 @@ const TooltipContent: React.FC<TooltipProps> = ({ position, disabled }) => {
       <TokenValueWrapper>
         <div className="value">
           <MissingLogo url={getGnotPath(token).logoURI} symbol={getGnotPath(token).symbol} width={20} />
-          {token.symbol}
+          {formatDisplayTokenSymbol(token.symbol)}
         </div>
         <div className="value">{tokenBalanceByTokenDecimal}</div>
       </TokenValueWrapper>
@@ -125,7 +126,11 @@ const RemoveLiquiditySelectListItem: React.FC<RemoveLiquiditySelectListItemProps
               leftSymbol={tokenA.symbol}
               rightSymbol={tokenB.symbol}
             />
-            {width > 768 && <span className="token-id">{`${tokenA.symbol}/${tokenB.symbol}`}</span>}
+            {width > 768 && (
+              <span className="token-id">{`${formatDisplayTokenSymbol(tokenA.symbol)}/${formatDisplayTokenSymbol(
+                tokenB.symbol,
+              )}`}</span>
+            )}
             <Badge text={feeStr} type={BADGE_TYPE.DARK_DEFAULT} />
           </div>
         </Tooltip>

--- a/packages/web/src/layouts/pool/pool-remove/components/remove-liquidity/remove-liquidity-select-result/RemoveLiquiditySelectResult.tsx
+++ b/packages/web/src/layouts/pool/pool-remove/components/remove-liquidity/remove-liquidity-select-result/RemoveLiquiditySelectResult.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { formatPoolPairAmount } from "@utils/new-number-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { usePositionsRewards } from "@hooks/pool/data/use-positions-rewards";
 
@@ -33,7 +34,7 @@ const RemoveLiquiditySelectResult: React.FC<RemoveLiquiditySelectResultProps> = 
                 mobileWidth={24}
               />
               <p>
-                {t("RemovePosition:overview.pooled")} {pooledTokenInfo.token.symbol}
+                {t("RemovePosition:overview.pooled")} {formatDisplayTokenSymbol(pooledTokenInfo.token.symbol)}
               </p>
               <strong>
                 {formatPoolPairAmount(pooledTokenInfo.amount, {

--- a/packages/web/src/layouts/pool/pool-remove/components/remove-position-modal/RemovePositionModal.tsx
+++ b/packages/web/src/layouts/pool/pool-remove/components/remove-position-modal/RemovePositionModal.tsx
@@ -13,6 +13,7 @@ import WarningCard from "@components/common/warning-card/WarningCard";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { useGetWithdrawalFee } from "@query/pools";
 import { formatOtherPrice, formatPoolPairAmount, formatRate } from "@utils/new-number-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { GnoProvider } from "@common/clients/gno-provider/gno-provider";
 
@@ -131,7 +132,7 @@ const RemovePositionModal: React.FC<Props> = ({ selectedPositions, close, onSubm
                             mobileWidth={24}
                             className="image-logo"
                           />
-                          <div>{rewardInfo.token.symbol}</div>
+                          <div>{formatDisplayTokenSymbol(rewardInfo.token.symbol)}</div>
                         </div>
                         <div className="value">
                           {formatPoolPairAmount(rewardInfo.amount, {

--- a/packages/web/src/layouts/pool/pool-reposition/PoolReposition.tsx
+++ b/packages/web/src/layouts/pool/pool-reposition/PoolReposition.tsx
@@ -11,6 +11,7 @@ import { useWindowSize } from "@hooks/common/use-window-size";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { DeviceSize } from "@styles/media";
 import { makeRouteUrl } from "@utils/page.utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 import { useGetPoolDetailByPath } from "src/react-query/pools";
 
 import RepositionContainer from "./containers/reposition-container/RepositionContainer";
@@ -31,7 +32,9 @@ const PoolReposition: React.FC = () => {
       {
         title:
           width > DeviceSize.mediumWeb
-            ? `${getGnotPath(data?.tokenA).symbol}/${getGnotPath(data?.tokenB).symbol} (${Number(data?.fee) / 10000}%)`
+            ? `${formatDisplayTokenSymbol(getGnotPath(data?.tokenA).symbol)}/${formatDisplayTokenSymbol(
+                getGnotPath(data?.tokenB).symbol,
+              )} (${Number(data?.fee) / 10000}%)`
             : "...",
         path: makeRouteUrl(PAGE_PATH.POOL, {
           [QUERY_PARAMETER.POOL_PATH]: poolPath,

--- a/packages/web/src/layouts/pool/pool-reposition/components/balance-change/BalanceChange.tsx
+++ b/packages/web/src/layouts/pool/pool-reposition/components/balance-change/BalanceChange.tsx
@@ -8,6 +8,7 @@ import { SelectPool } from "@hooks/pool/data/use-select-pool";
 import { TokenModel } from "@models/token/token-model";
 import { DEVICE_TYPE } from "@styles/media";
 import { numberToFormat } from "@utils/string-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { BalanceChangeWrapper } from "./BalanceChange.styles";
 
@@ -118,13 +119,15 @@ const BalanceChange: React.FC<BalanceChangeProps> = ({
 
           <div className="table-balance-change">
             <p className="value">
-              <MissingLogo symbol={tokenA?.symbol || ""} url={tokenA?.logoURI} width={24} /> {tokenA?.symbol}
+              <MissingLogo symbol={tokenA?.symbol || ""} url={tokenA?.logoURI} width={24} />{" "}
+              {formatDisplayTokenSymbol(tokenA?.symbol || "")}
             </p>
             <p className="value right dimmed">{withLoading(currentTokenAAmount)}</p>
           </div>
           <div className="table-balance-change">
             <p className="value">
-              <MissingLogo symbol={tokenB?.symbol || ""} url={tokenB?.logoURI} width={24} /> {tokenB?.symbol}
+              <MissingLogo symbol={tokenB?.symbol || ""} url={tokenB?.logoURI} width={24} />{" "}
+              {formatDisplayTokenSymbol(tokenB?.symbol || "")}
             </p>
             <p className="value right dimmed">{withLoading(currentTokenBAmount)}</p>
           </div>
@@ -139,14 +142,16 @@ const BalanceChange: React.FC<BalanceChangeProps> = ({
 
         <div className="table-balance-change">
           <p className="value">
-            <MissingLogo symbol={tokenA?.symbol || ""} url={tokenA?.logoURI} width={24} /> {tokenA?.symbol}
+            <MissingLogo symbol={tokenA?.symbol || ""} url={tokenA?.logoURI} width={24} />{" "}
+            {formatDisplayTokenSymbol(tokenA?.symbol || "")}
           </p>
           {!isMobile && <p className="value right dimmed">{withLoading(currentTokenAAmount)}</p>}
           <p className="value right">{withLoading(repositionTokenAAmount ?? "-")}</p>
         </div>
         <div className="table-balance-change">
           <p className="value">
-            <MissingLogo symbol={tokenB?.symbol || ""} url={tokenB?.logoURI} width={24} /> {tokenB?.symbol}
+            <MissingLogo symbol={tokenB?.symbol || ""} url={tokenB?.logoURI} width={24} />{" "}
+            {formatDisplayTokenSymbol(tokenB?.symbol || "")}
           </p>
           {!isMobile && <p className="value right dimmed">{withLoading(currentTokenBAmount)}</p>}
           <p className="value right">{withLoading(repositionTokenBAmount ?? "-")}</p>

--- a/packages/web/src/layouts/pool/pool-reposition/components/reposition-select-position/RepositionSelectPosition.tsx
+++ b/packages/web/src/layouts/pool/pool-reposition/components/reposition-select-position/RepositionSelectPosition.tsx
@@ -10,6 +10,7 @@ import { PoolPositionModel } from "@models/position/pool-position-model";
 import { TokenModel } from "@models/token/token-model";
 import { DEVICE_TYPE } from "@styles/media";
 import { formatPrice } from "@utils/new-number-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { IPriceRange } from "@hooks/pool/data/use-reposition-handle";
 
@@ -50,7 +51,7 @@ const RepositionSelectPosition: React.FC<RepositionSelectPositionProps> = ({
 
     return (
       <>
-        {tokenA?.symbol}/{tokenB?.symbol}
+        {formatDisplayTokenSymbol(tokenA?.symbol || "")}/{formatDisplayTokenSymbol(tokenB?.symbol || "")}
         <Badge text={fee} type={BADGE_TYPE.DARK_DEFAULT} />
       </>
     );

--- a/packages/web/src/layouts/pool/pool-stake/PoolStake.tsx
+++ b/packages/web/src/layouts/pool/pool-stake/PoolStake.tsx
@@ -13,6 +13,7 @@ import { useVideoGuide } from "@hooks/common/use-video-guide";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { DeviceSize } from "@styles/media";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 import { isValidVideoGuideType } from "@utils/video-guide.utils";
 import { useGetPoolDetailByPathWithEmptyPath } from "src/react-query/pools";
 
@@ -44,7 +45,9 @@ const PoolStake: React.FC = () => {
       breadcrumbs.push({
         title:
           width >= DeviceSize.mediumWeb
-            ? `${getGnotPath(data?.tokenA).symbol}/${getGnotPath(data?.tokenB).symbol} (${Number(data?.fee) / 10000}%)`
+            ? `${formatDisplayTokenSymbol(getGnotPath(data?.tokenA).symbol)}/${formatDisplayTokenSymbol(
+                getGnotPath(data?.tokenB).symbol,
+              )} (${Number(data?.fee) / 10000}%)`
             : "...",
         path: `/earn/pool?poolPath=${poolPath}`,
       });

--- a/packages/web/src/layouts/pool/pool-stake/components/available-staking-pools/AvailableStakingPools.tsx
+++ b/packages/web/src/layouts/pool/pool-stake/components/available-staking-pools/AvailableStakingPools.tsx
@@ -12,7 +12,7 @@ import { usePrefetchNavigation } from "@hooks/common/use-prefetch-navigation";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { IncentivizePoolCardInfo } from "@models/pool/info/pool-card-info";
 import { formatRate } from "@utils/new-number-utils";
-import { getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
+import { formatDisplayTokenSymbol, getUniqueRewardTokensWithMultipleRewardTypes } from "@utils/token-utils";
 
 import { wrapper } from "./AvailableStakingPools.styles";
 
@@ -117,7 +117,7 @@ const AvailableStakingPoolRow: React.FC<AvailableStakingPoolRowProps> = ({ pool,
           size={20}
         />
         <span className="pair">
-          {pool.tokenA.symbol}/{pool.tokenB.symbol}
+          {formatDisplayTokenSymbol(pool.tokenA.symbol)}/{formatDisplayTokenSymbol(pool.tokenB.symbol)}
         </span>
         <span className="fee">{feeRateStr}</span>
       </div>

--- a/packages/web/src/layouts/pool/pool-stake/components/stake-position-modal/StakePositionModal.tsx
+++ b/packages/web/src/layouts/pool/pool-stake/components/stake-position-modal/StakePositionModal.tsx
@@ -11,6 +11,7 @@ import Tooltip from "@components/common/tooltip/Tooltip";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { formatOtherPrice, formatRate } from "@utils/new-number-utils";
 import { isInRangePosition } from "@utils/stake-position-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { Divider, StakePositionModalWrapper, ToolTipContentWrapper } from "./StakePositionModal.styles";
 import { useWindowSize } from "@hooks/common/use-window-size";
@@ -107,7 +108,9 @@ const StakePositionModal: React.FC<Props> = ({ positions, close, onSubmit }) => 
                       rightSymbol={position.pool.tokenB.symbol}
                     />
                     {breakpoint !== DEVICE_TYPE.MOBILE && (
-                      <div>{`${position.pool.tokenA.symbol}/${position.pool.tokenB.symbol}`}</div>
+                      <div>{`${formatDisplayTokenSymbol(position.pool.tokenA.symbol)}/${formatDisplayTokenSymbol(
+                        position.pool.tokenB.symbol,
+                      )}`}</div>
                     )}
                     <Badge
                       className="position-bar"

--- a/packages/web/src/layouts/pool/pool-stake/components/stake-position/select-liquidity/select-liquidity-list/select-lilquidity-list-item/SelectLiquidityListItem.tsx
+++ b/packages/web/src/layouts/pool/pool-stake/components/stake-position/select-liquidity/select-liquidity-list/select-lilquidity-list-item/SelectLiquidityListItem.tsx
@@ -13,6 +13,7 @@ import { PoolPositionModel } from "@models/position/pool-position-model";
 import { TokenModel } from "@models/token/token-model";
 import { formatOtherPrice } from "@utils/new-number-utils";
 import { isInRangePosition } from "@utils/stake-position-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { TokenTitleWrapper, TokenValueWrapper, tooltipWrapper, wrapper } from "./SelectLiquidityListItem.styles";
 
@@ -37,7 +38,7 @@ const TooltipContent: React.FC<{
       <TokenValueWrapper>
         <div className="value">
           <MissingLogo url={getGnotPath(token).logoURI} symbol={getGnotPath(token).symbol} width={20} />
-          {token.symbol}
+          {formatDisplayTokenSymbol(token.symbol)}
         </div>
         <div className="value">{tokenBalanceByTokenDecimal}</div>
       </TokenValueWrapper>
@@ -109,7 +110,9 @@ const SelectLiquidityListItem: React.FC<SelectLiquidityListItemProps> = ({
               rightSymbol={tokenB.symbol}
             />
             {width > 768 && (
-              <span className="token-id">{`${position.pool.tokenA.symbol}/${position.pool.tokenB.symbol}`}</span>
+              <span className="token-id">{`${formatDisplayTokenSymbol(
+                position.pool.tokenA.symbol,
+              )}/${formatDisplayTokenSymbol(position.pool.tokenB.symbol)}`}</span>
             )}
             <Badge text={`${Number(position.pool.fee) / 10000}%`} type={BADGE_TYPE.DARK_DEFAULT} />
             <RangeBadge status={inRange ? "IN" : "OUT"} />

--- a/packages/web/src/layouts/pool/pool-stake/components/stake-position/select-stake-result/SelectStakeResult.tsx
+++ b/packages/web/src/layouts/pool/pool-stake/components/stake-position/select-stake-result/SelectStakeResult.tsx
@@ -10,6 +10,7 @@ import { PoolPositionModel } from "@models/position/pool-position-model";
 import { TokenModel } from "@models/token/token-model";
 import { checkGnotPath } from "@utils/common";
 import { formatOtherPrice, formatPoolPairAmount, formatRate } from "@utils/new-number-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { HoverTextWrapper, wrapper } from "./SelectStakeResult.styles";
 
@@ -109,7 +110,7 @@ const SelectStakeResult: React.FC<SelectStakeResultProps> = ({ positions, isHidd
             <div className="main-info">
               <MissingLogo symbol={entry.token.symbol} url={entry.token.logoURI} width={24} mobileWidth={24} />
               <p>
-                {t("StakePosition:overview.pooled")} {entry.token.symbol}
+                {t("StakePosition:overview.pooled")} {formatDisplayTokenSymbol(entry.token.symbol)}
               </p>
               <strong>
                 {formatPoolPairAmount(entry.amount, {

--- a/packages/web/src/layouts/pool/pool-unstake/PoolUnstake.tsx
+++ b/packages/web/src/layouts/pool/pool-unstake/PoolUnstake.tsx
@@ -11,6 +11,7 @@ import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
 import { DeviceSize } from "@styles/media";
 import { useGetPoolDetailByPath } from "src/react-query/pools";
 import { PAGE_PATH } from "@constants/page.constant";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import UnstakeLiquidityContainer from "./containers/unstake-position-container/UnstakePositionContainer";
 import UnstakeLiquidityLayout from "./UnstakeLiquidityLayout";
@@ -30,7 +31,9 @@ const PoolUnstake: React.FC = () => {
       {
         title:
           width > DeviceSize.mediumWeb
-            ? `${getGnotPath(data?.tokenA).symbol}/${getGnotPath(data?.tokenB).symbol} (${Number(data?.fee) / 10000}%)`
+            ? `${formatDisplayTokenSymbol(getGnotPath(data?.tokenA).symbol)}/${formatDisplayTokenSymbol(
+                getGnotPath(data?.tokenB).symbol,
+              )} (${Number(data?.fee) / 10000}%)`
             : "...",
         path: `/earn/pool?poolPath=${poolPath}`,
       },

--- a/packages/web/src/layouts/pool/pool-unstake/components/unstake-liquidity/select-liquidity/select-liquidity-item/SelectLiquidityItem.tsx
+++ b/packages/web/src/layouts/pool/pool-unstake/components/unstake-liquidity/select-liquidity/select-liquidity-item/SelectLiquidityItem.tsx
@@ -13,6 +13,7 @@ import { PoolPositionModel } from "@models/position/pool-position-model";
 import { TokenModel } from "@models/token/token-model";
 import { formatOtherPrice } from "@utils/new-number-utils";
 import { isInRangePosition } from "@utils/stake-position-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { TokenTitleWrapper, TokenValueWrapper, tooltipWrapper, wrapper } from "./SelectLiquidityItem.styles";
 
@@ -34,7 +35,7 @@ const TooltipContent: React.FC<{ position: PoolPositionModel }> = ({ position })
       <TokenValueWrapper>
         <div className="value">
           <MissingLogo url={getGnotPath(token).logoURI} symbol={getGnotPath(token).symbol} width={20} />
-          {token.symbol}
+          {formatDisplayTokenSymbol(token.symbol)}
         </div>
         <div className="value">{tokenBalanceByTokenDecimal}</div>
       </TokenValueWrapper>
@@ -103,7 +104,11 @@ const SelectLiquidityItem: React.FC<SelectLiquidityItemProps> = ({
               leftSymbol={tokenA.symbol}
               rightSymbol={tokenB.symbol}
             />
-            {width > 768 && <span className="token-id">{`${tokenA.symbol}/${tokenB.symbol}`}</span>}
+            {width > 768 && (
+              <span className="token-id">{`${formatDisplayTokenSymbol(tokenA.symbol)}/${formatDisplayTokenSymbol(
+                tokenB.symbol,
+              )}`}</span>
+            )}
             <Badge text={`${Number(position.pool.fee) / 10000}%`} type={BADGE_TYPE.DARK_DEFAULT} />
             <RangeBadge status={inRange ? "IN" : "OUT"} />
           </div>

--- a/packages/web/src/layouts/pool/pool-unstake/components/unstake-liquidity/select-unstake-result/SelectUnstakeResult.tsx
+++ b/packages/web/src/layouts/pool/pool-unstake/components/unstake-liquidity/select-unstake-result/SelectUnstakeResult.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { formatPoolPairAmount } from "@utils/new-number-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { usePositionsRewards } from "@hooks/pool/data/use-positions-rewards";
 
@@ -31,7 +32,7 @@ const SelectUnstakeResult: React.FC<SelectUnstakeResultProps> = ({ positions }) 
                 mobileWidth={24}
               />
               <p>
-                {t("UnstakePosition:overview.pooled")} {pooledTokenInfo.token.symbol}
+                {t("UnstakePosition:overview.pooled")} {formatDisplayTokenSymbol(pooledTokenInfo.token.symbol)}
               </p>
               <strong>{pooledTokenInfo.amount}</strong>
             </div>

--- a/packages/web/src/layouts/pool/pool-unstake/components/unstake-position-modal/UnstakePositionModal.tsx
+++ b/packages/web/src/layouts/pool/pool-unstake/components/unstake-position-modal/UnstakePositionModal.tsx
@@ -15,6 +15,7 @@ import { PoolPositionModel } from "@models/position/pool-position-model";
 import { useGetUnstakingFee } from "@query/pools";
 import { formatOtherPrice, formatPoolPairAmount, formatRate } from "@utils/new-number-utils";
 import { isInRangePosition } from "@utils/stake-position-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { usePositionsRewards } from "@hooks/pool/data/use-positions-rewards";
 import { GnoProvider } from "@common/clients/gno-provider/gno-provider";
@@ -107,7 +108,9 @@ const UnstakePositionModal: React.FC<Props> = ({ positions, close, onSubmit }) =
                       rightSymbol={position.pool.tokenB.symbol}
                     />
                     {breakpoint !== DEVICE_TYPE.MOBILE && (
-                      <div>{`${position.pool.tokenA.symbol}/${position.pool.tokenB.symbol}`}</div>
+                      <div>{`${formatDisplayTokenSymbol(position.pool.tokenA.symbol)}/${formatDisplayTokenSymbol(
+                        position.pool.tokenB.symbol,
+                      )}`}</div>
                     )}
                     <Badge
                       className="unstake-bar"
@@ -140,7 +143,9 @@ const UnstakePositionModal: React.FC<Props> = ({ positions, close, onSubmit }) =
                           width={24}
                           mobileWidth={24}
                         />
-                        <RewardLogoSymbolWrapper>{rewardInfo.token.symbol}</RewardLogoSymbolWrapper>
+                        <RewardLogoSymbolWrapper>
+                          {formatDisplayTokenSymbol(rewardInfo.token.symbol)}
+                        </RewardLogoSymbolWrapper>
                       </div>
                       <div className="value">
                         {formatPoolPairAmount(rewardInfo.amount, {

--- a/packages/web/src/layouts/swap/components/swap-info-chart/swap-token-info/SwapTokenHeader.tsx
+++ b/packages/web/src/layouts/swap/components/swap-info-chart/swap-token-info/SwapTokenHeader.tsx
@@ -17,7 +17,7 @@ import { SwapTokenHeaderWrapper } from "./SwapTokenHeader.styles";
 import IconOpenLink from "@components/common/icons/IconOpenLink";
 import { nullish } from "@utils/nullish-utils";
 import useCustomRouter from "@hooks/common/use-custom-router";
-import { formatTokenPath } from "@utils/token-utils";
+import { formatDisplayTokenSymbol, formatTokenPath } from "@utils/token-utils";
 
 import PriceWarning from "@components/common/price-warning/PriceWarning";
 
@@ -121,7 +121,7 @@ const SwapTokenHeader = ({
               <IconOpenLink size="10px" fill={theme.color.text04} className="path-link-icon" />
             </button>
           </div>
-          <div className="symbol">{tokenInfo.symbol}</div>
+          <div className="symbol">{formatDisplayTokenSymbol(tokenInfo.symbol)}</div>
         </div>
       </div>
       <div className="right">

--- a/packages/web/src/layouts/swap/components/swap-liquidity/SwapLiquidity.tsx
+++ b/packages/web/src/layouts/swap/components/swap-liquidity/SwapLiquidity.tsx
@@ -12,6 +12,7 @@ import { SwapFeeTierType } from "@constants/option.constant";
 import { PAGE_PATH, QUERY_PARAMETER } from "@constants/page.constant";
 import { TokenModel } from "@models/token/token-model";
 import { formatRate } from "@utils/new-number-utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { SwapLiquidityWrapper } from "./SwapLiquidity.styles";
 
@@ -113,7 +114,7 @@ const SwapLiquidity: React.FC<SwapLiquidityProps> = ({ liquiditys, tokenA, token
           </div>
         </div>
         <span>
-          {tokenA.symbol}/{tokenB.symbol}
+          {formatDisplayTokenSymbol(tokenA.symbol)}/{formatDisplayTokenSymbol(tokenB.symbol)}
         </span>
       </div>
       {liquiditys.length === 0 ? (

--- a/packages/web/src/layouts/token-detail/components/best-pools/BestPools.tsx
+++ b/packages/web/src/layouts/token-detail/components/best-pools/BestPools.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 
 import BestPoolCardList, { BestPool } from "./best-pool-card-list/BestPoolCardList";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { wrapper } from "./BestPools.styles";
 
@@ -18,7 +19,7 @@ const BestPools: React.FC<BestPoolsProps> = ({ titleSymbol, cardList, loading })
     <div css={wrapper}>
       <h2>
         {t("TokenDetails:bestPool.title", {
-          symbol: titleSymbol,
+          symbol: formatDisplayTokenSymbol(titleSymbol),
         })}
       </h2>
       <BestPoolCardList list={cardList} loading={loading} />

--- a/packages/web/src/layouts/token-detail/components/gainer-and-loser/gainer-card-list/GainerCardList.tsx
+++ b/packages/web/src/layouts/token-detail/components/gainer-and-loser/gainer-card-list/GainerCardList.tsx
@@ -8,6 +8,7 @@ import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import { MATH_NEGATIVE_TYPE } from "@constants/option.constant";
 import { TokenChangeInfo } from "@models/token/token-change-info";
 import { makeTokenRouteUrl } from "@utils/page.utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { cardStyle, loadingWrapper, NameSectionWrapper } from "../CardListCommonStyle.styles";
 
@@ -45,7 +46,7 @@ const GainerCardList: React.FC<GainerCardListProps> = ({ gainers = [], loadingGa
                   mobileWidth={20}
                 />
                 <span className="name">{gainer.name}</span>
-                <span className="symbol">{gainer.symbol}</span>
+                <span className="symbol">{formatDisplayTokenSymbol(gainer.symbol)}</span>
               </NameSectionWrapper>
               <span className="price">{gainer.price}</span>
               <span

--- a/packages/web/src/layouts/token-detail/components/gainer-and-loser/loser-card-list/LoserCardList.tsx
+++ b/packages/web/src/layouts/token-detail/components/gainer-and-loser/loser-card-list/LoserCardList.tsx
@@ -8,6 +8,7 @@ import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import { MATH_NEGATIVE_TYPE } from "@constants/option.constant";
 import { TokenChangeInfo } from "@models/token/token-change-info";
 import { makeTokenRouteUrl } from "@utils/page.utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { cardStyle, loadingWrapper, NameSectionWrapper } from "../CardListCommonStyle.styles";
 
@@ -39,7 +40,7 @@ const LoserCard: React.FC<LoserCardListProps> = ({ losers = [], loadingLose }) =
               <NameSectionWrapper>
                 <MissingLogo symbol={loser.symbol} url={loser.logoURI} className="logo" width={20} mobileWidth={20} />
                 <span className="name">{loser.name}</span>
-                <span className="symbol">{loser.symbol}</span>
+                <span className="symbol">{formatDisplayTokenSymbol(loser.symbol)}</span>
               </NameSectionWrapper>
               <span className="price">{loser.price}</span>
               <span

--- a/packages/web/src/layouts/token-detail/components/token-chart/token-chart-info/TokenChartInfo.tsx
+++ b/packages/web/src/layouts/token-detail/components/token-chart/token-chart-info/TokenChartInfo.tsx
@@ -11,6 +11,7 @@ import { TOKEN_PRICE_GRADE_TYPE } from "@models/token/token-price-grade";
 import PriceWarning from "@components/common/price-warning/PriceWarning";
 import { cx } from "@emotion/css";
 import { useTokenPriceInfo } from "@hooks/token/data/use-token-price-info";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 export interface TokenChartInfoProps {
   token: {
@@ -82,7 +83,7 @@ const TokenChartInfo: React.FC<TokenChartInfoProps> = ({ token, priceInfo, loadi
           {!loading && (
             <div>
               <span className="token-name">{token.name}</span>
-              <span className="token-symbol">{token.symbol}</span>
+              <span className="token-symbol">{formatDisplayTokenSymbol(token.symbol)}</span>
             </div>
           )}
         </div>

--- a/packages/web/src/layouts/token-detail/components/token-description/TokenDescription.tsx
+++ b/packages/web/src/layouts/token-detail/components/token-description/TokenDescription.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 
 import { pulseSkeletonStyle } from "@constants/skeleton.constant";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import TokenDescriptionContent from "./token-description-content/TokenDescriptionContent";
 import TokenDescriptionLinks from "./token-description-links/TokenDescriptionLinks";
@@ -36,7 +37,7 @@ const TokenDescription: React.FC<TokenDescriptionProps> = ({
       {!loading && (
         <h2>
           {t("TokenDetails:description.title", {
-            name: `${tokenName} (${tokenSymbol})`,
+            name: `${tokenName} (${formatDisplayTokenSymbol(tokenSymbol)})`,
           })}
         </h2>
       )}

--- a/packages/web/src/layouts/token-detail/components/trending-crypto-card-list/trending-crypto-card/TrendingCryptoCard.tsx
+++ b/packages/web/src/layouts/token-detail/components/trending-crypto-card-list/trending-crypto-card/TrendingCryptoCard.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import { MATH_NEGATIVE_TYPE } from "@constants/option.constant";
 import { makeTokenRouteUrl } from "@utils/page.utils";
+import { formatDisplayTokenSymbol } from "@utils/token-utils";
 
 import { NameSectionWrapper, wrapper } from "./TrendingCryptoCard.styles";
 
@@ -31,7 +32,7 @@ const TrendingCryptoCard: React.FC<TrendingCryptoCardProps> = ({ item }) => {
         <NameSectionWrapper>
           <MissingLogo symbol={item.symbol} url={item.logoURI} className="logo" width={20} mobileWidth={20} />
           <span className="name">{item.name}</span>
-          <span className="symbol">{item.symbol}</span>
+          <span className="symbol">{formatDisplayTokenSymbol(item.symbol)}</span>
         </NameSectionWrapper>
         <span className="price">{item.price}</span>
         <span

--- a/packages/web/src/utils/string-utils.ts
+++ b/packages/web/src/utils/string-utils.ts
@@ -3,6 +3,7 @@ import { TokenModel } from "@models/token/token-model";
 import BigNumber from "bignumber.js";
 import { tickToPrice, tickToPriceStr } from "./swap-utils";
 import { isNumber, removeTrailingZeros } from "./number-utils";
+import { formatDisplayTokenSymbol } from "./token-utils";
 
 /**
  * Shortens an address by N characters.
@@ -20,14 +21,14 @@ export function formatAddress(address: string, num?: number): string {
 }
 
 export function tokenPairSymbolToOneCharacter(tokenPair: TokenPairInfo): string {
-  const symbol0 = tokenPair.tokenA.symbol;
-  const symbol1 = tokenPair.tokenB.symbol;
+  const symbol0 = formatDisplayTokenSymbol(tokenPair.tokenA.symbol);
+  const symbol1 = formatDisplayTokenSymbol(tokenPair.tokenB.symbol);
   return `${symbol0}/${symbol1}`;
 }
 
 export function makePairName({ tokenA, tokenB }: { tokenA: TokenModel; tokenB: TokenModel }): string {
-  const symbolA = tokenA.symbol;
-  const symbolB = tokenB.symbol;
+  const symbolA = formatDisplayTokenSymbol(tokenA.symbol);
+  const symbolB = formatDisplayTokenSymbol(tokenB.symbol);
   return `${symbolA}/${symbolB}`;
 }
 

--- a/packages/web/src/utils/swap-utils.ts
+++ b/packages/web/src/utils/swap-utils.ts
@@ -13,6 +13,7 @@ import {
 import { tickToSqrtPriceX96 } from "./math.utils";
 import { toNumberFormat } from "./number-utils";
 import { convertToKMB } from "./stake-position-utils";
+import { formatDisplayTokenSymbol } from "./token-utils";
 
 const LOG10001 = Math.log(1.0001);
 
@@ -297,7 +298,7 @@ export function formatRouterFeeStr(swapSummaryInfo: SwapSummaryInfo | null, swap
 
   const feeAmount = BigNumber(tokenAmount).multipliedBy(feeRate).toNumber();
   const decimals = tokenDecimals || 6;
-  return `${toNumberFormat(feeAmount, decimals)} ${tokenSymbol || ""}`;
+  return `${toNumberFormat(feeAmount, decimals)} ${formatDisplayTokenSymbol(tokenSymbol || "")}`;
 }
 
 export type BroadcastMessageData = {

--- a/packages/web/src/utils/token-utils.spec.ts
+++ b/packages/web/src/utils/token-utils.spec.ts
@@ -1,7 +1,10 @@
 import { GNOT_TOKEN } from "@common/values/token-constant";
 import { TokenModel } from "@models/token/token-model";
 import {
+  formatDisplayTokenSymbol,
   formatTokenBalanceDisplay,
+  formatTokenModelPath,
+  formatTokenPath,
   isNativeTokenPath,
   makeDisplayTokenAmount,
   makeRawTokenAmount,
@@ -150,6 +153,39 @@ describe("format token balance display", () => {
       expect(formatTokenBalanceDisplay("999999999999.99", true)).toBe("999,999,999,999.99");
       expect(formatTokenBalanceDisplay("999999999999.999999", true)).toBe("999,999,999,999.99");
     });
+  });
+});
+
+describe("format display token symbol", () => {
+  it("should keep token symbols with 9 or fewer characters", () => {
+    expect(formatDisplayTokenSymbol("GNOT")).toBe("GNOT");
+    expect(formatDisplayTokenSymbol("123456789")).toBe("123456789");
+  });
+
+  it("should shorten token symbols longer than 9 characters", () => {
+    expect(formatDisplayTokenSymbol("ibc/488D610A5FB7878660703092A35BC4E7D0C88E2EA71174337AA317A22C05177F")).toBe(
+      "ibc/488D6...",
+    );
+  });
+
+  it("should keep non-native token paths unshortened after removing gno.land prefix", () => {
+    expect(formatTokenPath("gno.land/r/gnoswap/gns", false)).toBe("r/gnoswap/gns");
+    expect(formatTokenPath("ibc/488D610A5FB7878660703092A35BC4E7D0C88E2EA71174337AA317A22C05177F", false)).toBe(
+      "ibc/488D610A5FB7878660703092A35BC4E7D0C88E2EA71174337AA317A22C05177F",
+    );
+  });
+
+  it("should keep native token path display unchanged", () => {
+    expect(formatTokenPath(GNOT_TOKEN.path, true)).toBe("Native Coin");
+  });
+
+  it("should keep token model paths unshortened", () => {
+    expect(
+      formatTokenModelPath({
+        ...DEFAULT_TOKEN,
+        path: "ibc/488D610A5FB7878660703092A35BC4E7D0C88E2EA71174337AA317A22C05177F",
+      }),
+    ).toBe("ibc/488D610A5FB7878660703092A35BC4E7D0C88E2EA71174337AA317A22C05177F");
   });
 });
 

--- a/packages/web/src/utils/token-utils.ts
+++ b/packages/web/src/utils/token-utils.ts
@@ -8,6 +8,14 @@ import BigNumber from "bignumber.js";
 import { formatOtherPrice } from "./new-number-utils";
 import { roundDownDecimalNumber } from "./regex";
 
+export const TOKEN_DISPLAY_MAX_LENGTH = 9;
+
+export function formatDisplayTokenSymbol(symbol: string): string {
+  if (symbol.length <= TOKEN_DISPLAY_MAX_LENGTH) return symbol;
+
+  return `${symbol.slice(0, TOKEN_DISPLAY_MAX_LENGTH)}...`;
+}
+
 export interface RewardTokenModelWithMultipleTypes extends Omit<RewardTokenModel, "rewardType"> {
   rewardType: RewardType | RewardType[];
 }
@@ -92,12 +100,10 @@ export function formatTokenPath(path: string, isNative: boolean): string {
  * @param getGnotPath GNOT path conversion function
  */
 export function getUniqueRewardTokensByPath<
-  T extends { path?: string; name?: string; logoURI?: string; symbol?: string }
+  T extends { path?: string; name?: string; logoURI?: string; symbol?: string },
 >(
   rewardTokens: RewardTokenModel[],
-  getGnotPath: (
-    token: T | null | undefined,
-  ) => {
+  getGnotPath: (token: T | null | undefined) => {
     path: string;
     name: string;
     symbol: string;
@@ -106,14 +112,14 @@ export function getUniqueRewardTokensByPath<
   },
 ) {
   return rewardTokens.reduce((acc, current) => {
-    const existToken = acc.some(item => item.path === getGnotPath((current as unknown) as T).path);
+    const existToken = acc.some(item => item.path === getGnotPath(current as unknown as T).path);
 
     if (!existToken) {
       acc.push({
         ...current,
-        logoURI: getGnotPath((current as unknown) as T).logoURI,
-        symbol: getGnotPath((current as unknown) as T).symbol,
-        path: getGnotPath((current as unknown) as T).path,
+        logoURI: getGnotPath(current as unknown as T).logoURI,
+        symbol: getGnotPath(current as unknown as T).symbol,
+        path: getGnotPath(current as unknown as T).path,
       });
     }
 
@@ -130,12 +136,10 @@ export function getUniqueRewardTokensByPath<
  * @param getGnotPath GNOT path conversion function
  */
 export function getUniqueRewardTokensWithMultipleRewardTypes<
-  T extends { path?: string; name?: string; logoURI?: string; symbol?: string }
+  T extends { path?: string; name?: string; logoURI?: string; symbol?: string },
 >(
   rewardTokens: RewardTokenModel[],
-  getGnotPath: (
-    token: T | null | undefined,
-  ) => {
+  getGnotPath: (token: T | null | undefined) => {
     path: string;
     name: string;
     symbol: string;
@@ -147,24 +151,27 @@ export function getUniqueRewardTokensWithMultipleRewardTypes<
     return [];
   }
 
-  const tokensByPath = rewardTokens.reduce((acc, current) => {
-    const tokenInfo = getGnotPath((current as unknown) as T);
+  const tokensByPath = rewardTokens.reduce(
+    (acc, current) => {
+      const tokenInfo = getGnotPath(current as unknown as T);
 
-    const convertedToken = {
-      ...current,
-      logoURI: tokenInfo.logoURI,
-      symbol: tokenInfo.symbol,
-      path: tokenInfo.path,
-    };
+      const convertedToken = {
+        ...current,
+        logoURI: tokenInfo.logoURI,
+        symbol: tokenInfo.symbol,
+        path: tokenInfo.path,
+      };
 
-    const path = convertedToken.path;
-    if (!acc[path]) {
-      acc[path] = [];
-    }
-    acc[path].push(convertedToken);
+      const path = convertedToken.path;
+      if (!acc[path]) {
+        acc[path] = [];
+      }
+      acc[path].push(convertedToken);
 
-    return acc;
-  }, {} as Record<string, RewardTokenModel[]>);
+      return acc;
+    },
+    {} as Record<string, RewardTokenModel[]>,
+  );
 
   return Object.values(tokensByPath).map(tokens => {
     const baseToken = tokens[0];


### PR DESCRIPTION
## Summary
- Add a shared token symbol display formatter that truncates symbols longer than 9 characters with `...`.
- Apply the formatter across token, pool, swap, earn, staking, and token detail UI symbol displays.
- Keep Realm/Contract path formatting unchanged; paths are not truncated.

## Verification
- `yarn workspace @gnoswap-labs/web jest --runTestsByPath src/utils/token-utils.spec.ts --ci`
- `yarn build`

## Notes
- Full `next lint` has existing unrelated project warnings/errors, but the pre-commit lint-staged hook passed for this commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token symbols longer than 9 characters are now shortened with an ellipsis (...) for consistent display across pools, tokens, swaps, positions and related UIs.
* **Tests**
  * Added unit tests covering the new symbol-formatting behavior and related token-path formatting.
* **Chores**
  * Introduced a shared token-display utility and constant to standardize symbol rendering across the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap-interface/pull/898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->