### PR TITLE
chore: remove native faucet URL

### DIFF
--- a/packages/web/src/repositories/faucet/resources/faucet-api.json
+++ b/packages/web/src/repositories/faucet/resources/faucet-api.json
@@ -5,6 +5,6 @@
   },
   "test-13": {
     "grc20": "https://beta.faucet.adena.app",
-    "native": "https://test13.faucet.adena.app"
+    "native": ""
   }
 }

--- a/packages/web/src/repositories/faucet/resources/faucet-api.json
+++ b/packages/web/src/repositories/faucet/resources/faucet-api.json
@@ -5,6 +5,6 @@
   },
   "test-13": {
     "grc20": "https://beta.faucet.adena.app",
-    "native": ""
+    "native": null
   }
 }


### PR DESCRIPTION
## Descriptions

- Remove native faucet URL.
- Since the Faucet accounts were identical, an issue arose where the account indexes overlapped, so they were created via a multi-message on the Gnoswap Faucet.