### PR TITLE
fix: use token decimals for modal minimum amounts

### DIFF
--- a/packages/web/src/hooks/swap/data/use-swap-handler.spec.ts
+++ b/packages/web/src/hooks/swap/data/use-swap-handler.spec.ts
@@ -1,0 +1,33 @@
+import { TokenModel } from "@models/token/token-model";
+
+import { handleAmount } from "./use-swap-handler.utils";
+
+const token = (decimals: number): TokenModel => ({
+  chainId: "dev",
+  createdAt: "2023-10-10T08:48:46+09:00",
+  name: "Token",
+  address: "g1sqaft388ruvsseu97r04w4rr4szxkh4nn6xpax",
+  path: "gno.land/r/token",
+  decimals,
+  symbol: "TOKEN",
+  displaySymbol: "TOKEN",
+  logoURI: "",
+  type: "GRC20",
+  priceID: "gno.land/r/token",
+});
+
+describe("handleAmount", () => {
+  it("keeps over-precision input editable when decimal places are reduced", () => {
+    expect(handleAmount("0.0000000", token(6), "0.00000001")).toEqual({
+      isValid: true,
+      value: "0.0000000",
+    });
+  });
+
+  it("keeps rejecting newly added over-precision decimal places", () => {
+    expect(handleAmount("0.00000001", token(6), "0.0000000")).toEqual({
+      isValid: false,
+      value: "0.00000001",
+    });
+  });
+});

--- a/packages/web/src/hooks/swap/data/use-swap-handler.tsx
+++ b/packages/web/src/hooks/swap/data/use-swap-handler.tsx
@@ -37,6 +37,7 @@ import { matchInputNumber } from "@utils/number-utils";
 import { isAmountLessThanTokenMinimum, makeDisplayTokenAmount } from "@utils/token-utils";
 import { isEmptyObject } from "@utils/validation-utils";
 
+import { handleAmount } from "./use-swap-handler.utils";
 import { BROADCAST_ERROR_VALUE } from "@common/errors/broadcast/broadcast-error";
 import { useTransactionEventStore } from "@hooks/common/use-transaction-event-store";
 import { TOKEN_PRICE_GRADE_TYPE } from "@models/token/token-price-grade";
@@ -123,36 +124,6 @@ function compareAmountFn(amountA: string | number | bigint, amountB: string | nu
   }
 
   return amountValueA.isGreaterThan(amountValueB) ? 1 : -1;
-}
-
-function handleAmount(changed: string, token: TokenModel | null) {
-  let value = changed;
-  const decimals = token?.decimals;
-
-  if (decimals === undefined) {
-    return { isValid: false, value: changed };
-  }
-
-  // Check if input exceeds decimal places
-  if (changed.includes(".") && changed.split(".")[1].length > decimals) {
-    // Signal invalid input
-    return { isValid: false, value: changed };
-  }
-
-  if (!value || BigNumber(value).isZero()) {
-    value = changed;
-  } else {
-    value = BigNumber(value).toFixed(decimals, 1);
-  }
-
-  if (BigNumber(changed).isEqualTo(value)) {
-    const dotIndex = changed.indexOf(".");
-    if (dotIndex === -1 || changed.length - dotIndex - 1 < decimals) {
-      value = changed;
-    }
-  }
-
-  return { isValid: true, value };
 }
 
 export const useSwapHandler = () => {
@@ -780,7 +751,7 @@ export const useSwapHandler = () => {
 
   const changeTokenAAmount = useCallback(
     (changed: string, none?: boolean) => {
-      const result = handleAmount(changed, tokenA);
+      const result = handleAmount(changed, tokenA, tokenAAmount);
 
       // If invalid decimal places, don't update or trigger loading
       if (!result.isValid) {
@@ -821,7 +792,7 @@ export const useSwapHandler = () => {
       updateSwapAmount(result.value);
       setTokenAAmount(result.value);
     },
-    [isSameToken, setSwapValue, tokenA, tokenB?.symbol],
+    [isSameToken, setSwapValue, tokenA, tokenAAmount, tokenB?.symbol],
   );
 
   useEffect(() => {
@@ -834,7 +805,7 @@ export const useSwapHandler = () => {
 
   const changeTokenBAmount = useCallback(
     (changed: string, none?: boolean) => {
-      const result = handleAmount(changed, tokenB);
+      const result = handleAmount(changed, tokenB, tokenBAmount);
 
       if (!result.isValid) {
         setIsLoading(false);
@@ -875,7 +846,7 @@ export const useSwapHandler = () => {
       updateSwapAmount(result.value);
       setTokenBAmount(result.value);
     },
-    [isSameToken, tokenA, tokenB],
+    [isSameToken, tokenA, tokenB, tokenBAmount],
   );
 
   const isSameTokenFn = useCallback((tokenA_: TokenModel | null, tokenB_: TokenModel | null) => {

--- a/packages/web/src/hooks/swap/data/use-swap-handler.tsx
+++ b/packages/web/src/hooks/swap/data/use-swap-handler.tsx
@@ -34,7 +34,7 @@ import { checkGnotPath, isGNOTPath, toNativePath } from "@utils/common";
 import { formatPrice } from "@utils/new-number-utils";
 import { nullish } from "@utils/nullish-utils";
 import { matchInputNumber } from "@utils/number-utils";
-import { makeDisplayTokenAmount } from "@utils/token-utils";
+import { isAmountLessThanTokenMinimum, makeDisplayTokenAmount } from "@utils/token-utils";
 import { isEmptyObject } from "@utils/validation-utils";
 
 import { BROADCAST_ERROR_VALUE } from "@common/errors/broadcast/broadcast-error";
@@ -424,8 +424,8 @@ export const useSwapHandler = () => {
       return "ENTER_AMOUNT";
     }
     if (
-      (Number(tokenAAmount) < 0.000001 && type === "EXACT_IN") ||
-      (Number(tokenBAmount) < 0.000001 && type === "EXACT_OUT") ||
+      (type === "EXACT_IN" && isAmountLessThanTokenMinimum(tokenA, tokenAAmount)) ||
+      (type === "EXACT_OUT" && isAmountLessThanTokenMinimum(tokenB, tokenBAmount)) ||
       (isGNOTPath(toNativePath(tokenA.path)) && BigNumber(tokenAAmount).isLessThan(MINIMUM_GNOT_SWAP_AMOUNT))
     ) {
       return "AMOUNT_TOO_LOW";

--- a/packages/web/src/hooks/swap/data/use-swap-handler.utils.ts
+++ b/packages/web/src/hooks/swap/data/use-swap-handler.utils.ts
@@ -1,0 +1,50 @@
+import BigNumber from "bignumber.js";
+
+import { TokenModel } from "@models/token/token-model";
+
+function getDecimalLength(value: string) {
+  return value.includes(".") ? value.split(".")[1].length : 0;
+}
+
+function isReducingOverPrecision(changed: string, previous: string | undefined, decimals: number) {
+  if (!previous) {
+    return false;
+  }
+
+  const previousDecimalLength = getDecimalLength(previous);
+  const changedDecimalLength = getDecimalLength(changed);
+
+  return previousDecimalLength > decimals && changedDecimalLength < previousDecimalLength;
+}
+
+export function handleAmount(changed: string, token: TokenModel | null, previous?: string) {
+  let value = changed;
+  const decimals = token?.decimals;
+
+  if (decimals === undefined) {
+    return { isValid: false, value: changed };
+  }
+
+  if (changed.includes(".") && changed.split(".")[1].length > decimals) {
+    if (isReducingOverPrecision(changed, previous, decimals)) {
+      return { isValid: true, value: changed };
+    }
+
+    return { isValid: false, value: changed };
+  }
+
+  if (!value || BigNumber(value).isZero()) {
+    value = changed;
+  } else {
+    value = BigNumber(value).toFixed(decimals, 1);
+  }
+
+  if (BigNumber(changed).isEqualTo(value)) {
+    const dotIndex = changed.indexOf(".");
+    if (dotIndex === -1 || changed.length - dotIndex - 1 < decimals) {
+      value = changed;
+    }
+  }
+
+  return { isValid: true, value };
+}

--- a/packages/web/src/layouts/portfolio/components/asset-send-modal/AssetSendModal.spec.tsx
+++ b/packages/web/src/layouts/portfolio/components/asset-send-modal/AssetSendModal.spec.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Provider as JotaiProvider } from "jotai";
+
+import { TokenModel } from "@models/token/token-model";
+import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
+import { DEVICE_TYPE } from "@styles/media";
+
+import AssetSendModal from "./AssetSendModal";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("@hooks/common/use-esc-close-modal", () => jest.fn());
+
+jest.mock("@hooks/wallet/ui/use-position-modal", () => ({
+  usePositionModal: jest.fn(),
+}));
+
+jest.mock("@hooks/token/data/use-token-data", () => ({
+  useTokenData: jest.fn(),
+}));
+
+jest.mock("@hooks/wallet/data/use-wallet", () => ({
+  useWallet: jest.fn(),
+}));
+
+jest.mock("@components/common/select-pair-button/SelectPairButton", () => ({
+  __esModule: true,
+  default: ({ token }: { token: TokenModel | null }) => <span>{token?.displaySymbol ?? "Select"}</span>,
+}));
+
+const { useTokenData } = jest.requireMock("@hooks/token/data/use-token-data") as {
+  useTokenData: jest.Mock;
+};
+const { useWallet } = jest.requireMock("@hooks/wallet/data/use-wallet") as {
+  useWallet: jest.Mock;
+};
+
+const validAddress = "g1sqaft388ruvsseu97r04w4rr4szxkh4nn6xpax";
+
+const token: TokenModel = {
+  chainId: "dev",
+  createdAt: "2023-10-10T08:48:46+09:00",
+  name: "Gnoswap",
+  address: validAddress,
+  path: "gno.land/r/gns",
+  decimals: 4,
+  symbol: "GNS",
+  displaySymbol: "GNS",
+  logoURI: "https://raw.githubusercontent.com/onbloc/gno-token-resource/main/grc20/images/gno_land_r_gns.svg",
+  type: "GRC20",
+  priceID: "gno.land/r/gns",
+};
+
+describe("AssetSendModal", () => {
+  const renderModal = ({ amount, handleSubmit = jest.fn() }: { amount: string; handleSubmit?: jest.Mock }) => {
+    const setAmount = jest.fn();
+
+    useTokenData.mockReturnValue({
+      tokenPrices: {},
+      displayBalanceMap: {
+        [token.path]: 10,
+      },
+    });
+    useWallet.mockReturnValue({
+      account: {
+        address: validAddress,
+      },
+    });
+
+    render(
+      <JotaiProvider>
+        <GnoswapThemeProvider>
+          <AssetSendModal
+            amount={amount}
+            setAmount={setAmount}
+            isConfirm={false}
+            breakpoint={DEVICE_TYPE.WEB}
+            withdrawInfo={token}
+            avgBlockTime={2.2}
+            connected={true}
+            close={jest.fn()}
+            changeToken={jest.fn()}
+            handleSubmit={handleSubmit}
+            setIsConfirm={jest.fn()}
+          />
+        </GnoswapThemeProvider>
+      </JotaiProvider>,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Wallet:assetSendModal.enterAddr.input"), {
+      target: { value: validAddress },
+    });
+
+    return { handleSubmit, setAmount };
+  };
+
+  it("disables send when the amount is below one raw token unit", () => {
+    const { handleSubmit } = renderModal({ amount: "0.00001" });
+
+    const button = screen.getByRole("button", { name: "Wallet:assetSendModal.btn.lowAmt" });
+
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it("allows send when the amount equals one raw token unit", () => {
+    const { handleSubmit } = renderModal({ amount: "0.0001" });
+
+    const button = screen.getByRole("button", { name: "Wallet:assets.col.assetSend" });
+
+    expect(button).not.toBeDisabled();
+    fireEvent.click(button);
+    expect(handleSubmit).toHaveBeenCalledWith("0.0001", validAddress);
+  });
+});

--- a/packages/web/src/layouts/portfolio/components/asset-send-modal/AssetSendModal.tsx
+++ b/packages/web/src/layouts/portfolio/components/asset-send-modal/AssetSendModal.tsx
@@ -22,6 +22,7 @@ import { TokenModel } from "@models/token/token-model";
 import { DEVICE_TYPE } from "@styles/media";
 import { formatPrice } from "@utils/new-number-utils";
 import { capitalize } from "@utils/string-utils";
+import { isAmountLessThanTokenMinimum } from "@utils/token-utils";
 import { isValidAddress } from "@utils/validation-utils";
 
 import IconWallet from "@components/common/icons/IconWallet";
@@ -126,7 +127,7 @@ const AssetSendModal: React.FC<Props> = ({
 
       setAmount(value.replace(/^0+(?=\d)|(\.\d*)$/g, "$1"));
     },
-    [setAmount, withdrawInfo?.decimals],
+    [setAmount, withdrawInfo],
   );
 
   const onChangeAddress = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -156,6 +157,8 @@ const AssetSendModal: React.FC<Props> = ({
     if (!address || !isValidAddress(address)) return true;
 
     if (!withdrawInfo) return true;
+
+    if (isAmountLessThanTokenMinimum(withdrawInfo, amount)) return true;
 
     if (!isBalanceSufficient(amount, currentAvailableBalance ?? "0")) return true;
 
@@ -201,7 +204,7 @@ const AssetSendModal: React.FC<Props> = ({
     if (amount === "") {
       return t("Wallet:assetSendModal.btn.enterAmt");
     }
-    if (Number(amount) < 0.000001) {
+    if (isAmountLessThanTokenMinimum(withdrawInfo, amount)) {
       return t("Wallet:assetSendModal.btn.lowAmt");
     }
     if (

--- a/packages/web/src/utils/token-utils.spec.ts
+++ b/packages/web/src/utils/token-utils.spec.ts
@@ -6,6 +6,7 @@ import {
   formatTokenModelPath,
   formatTokenPath,
   isNativeTokenPath,
+  isAmountLessThanTokenMinimum,
   makeDisplayTokenAmount,
   makeRawTokenAmount,
 } from "./token-utils";
@@ -116,6 +117,49 @@ describe("make token display price", () => {
     };
     const result = makeDisplayTokenAmount(token, "123000000");
     expect(result).toBe(1.23);
+  });
+});
+
+describe("is amount less than token minimum", () => {
+  test("uses 6-decimal minimum display amount", () => {
+    const token = {
+      ...DEFAULT_TOKEN,
+      decimals: 6,
+    };
+
+    expect(isAmountLessThanTokenMinimum(token, "0.0000009")).toBe(true);
+    expect(isAmountLessThanTokenMinimum(token, "0.000001")).toBe(false);
+  });
+
+  test("uses 8-decimal minimum display amount", () => {
+    const token = {
+      ...DEFAULT_TOKEN,
+      decimals: 8,
+    };
+
+    expect(isAmountLessThanTokenMinimum(token, "0.000000009")).toBe(true);
+    expect(isAmountLessThanTokenMinimum(token, "0.00000001")).toBe(false);
+  });
+
+  test("uses integer minimum for 0-decimal tokens", () => {
+    const token = {
+      ...DEFAULT_TOKEN,
+      decimals: 0,
+    };
+
+    expect(isAmountLessThanTokenMinimum(token, "0.9")).toBe(true);
+    expect(isAmountLessThanTokenMinimum(token, "1")).toBe(false);
+  });
+
+  test("does not treat empty, zero, or invalid input as below minimum", () => {
+    const token = {
+      ...DEFAULT_TOKEN,
+      decimals: 6,
+    };
+
+    expect(isAmountLessThanTokenMinimum(token, "")).toBe(false);
+    expect(isAmountLessThanTokenMinimum(token, "0")).toBe(false);
+    expect(isAmountLessThanTokenMinimum(token, "abc")).toBe(false);
   });
 });
 

--- a/packages/web/src/utils/token-utils.ts
+++ b/packages/web/src/utils/token-utils.ts
@@ -47,6 +47,18 @@ export function makeDisplayTokenAmount(
   return number.shiftedBy(-token.decimals).toNumber();
 }
 
+export function isAmountLessThanTokenMinimum(
+  token: Pick<TokenModel | OnchainToken, "decimals">,
+  amount: string | number,
+) {
+  const number = BigNumber(amount.toString().replace(/,/g, ""));
+  if (!number.isFinite() || !number.gt(0)) {
+    return false;
+  }
+
+  return number.shiftedBy(token.decimals).lt(1);
+}
+
 export function makeShiftAmount(
   amount: bigint | string | number,
   shift: number,


### PR DESCRIPTION
## Summary
- Fix Swap "Amount Too Low" validation to use each token's decimal precision instead of a fixed 0.000001 threshold.
- Keep Swap inputs editable after changing from a higher-decimal token to a lower-decimal token by allowing decimal places to be reduced from an existing over-precision value.
- Fix Portfolio Send to use the same token-decimal minimum for both button text and disabled state, preventing sub-raw-unit sends that would floor to raw 0.
- Add a shared token minimum amount helper based on one raw smallest unit.
- Add regression tests for token minimum checks, Portfolio Send 4-decimal minimum behavior, and Swap over-precision backspace behavior.

## Context
- Jira: https://onbloc.atlassian.net/browse/GSW-2714
- Related focused comment: https://onbloc.atlassian.net/browse/GSW-2703?focusedCommentId=29666
- The existing GNOT-specific minimum swap amount rule remains unchanged.

## Validation
- Oracle review: completed; core decimal fix accepted, requested direct Swap coverage now added
- LSP diagnostics: clean for modified files
- Focused ESLint: passed with no new errors; existing hook dependency warnings remain in use-swap-handler, existing no-img warning remains in AssetSendModal
- Focused Jest: 42 tests passed
- Full Jest: 117 suites / 534 tests passed
- Production build: passed