### PR TITLE
feat(token): add token page links

### DIFF
--- a/packages/web/src/layouts/token-detail/components/token-description/TokenDescription.stories.tsx
+++ b/packages/web/src/layouts/token-detail/components/token-description/TokenDescription.stories.tsx
@@ -18,7 +18,10 @@ export const Default: Story = {
     content: "description",
     links: {
       Website: "https://gnoswap.io",
-      Gnoscan: "https://gnoscan.io/tokens/r/demo/wugnot",
+      X: "https://x.com/gnoswaplabs",
+      Discord: "https://discord.com/invite/u4bdGHStb2",
+      Docs: "https://docs.gnoswap.io",
+      GnoScan: "https://gnoscan.io/tokens/r/demo/wugnot",
     },
   },
 };

--- a/packages/web/src/layouts/token-detail/components/token-description/TokenDescription.tsx
+++ b/packages/web/src/layouts/token-detail/components/token-description/TokenDescription.tsx
@@ -12,7 +12,7 @@ interface TokenDescriptionProps {
   tokenName: string;
   tokenSymbol: string;
   content: string;
-  links: { [key: string]: string };
+  links: Record<string, string>;
   loading: boolean;
   copied: boolean;
   copyClick: () => void;

--- a/packages/web/src/layouts/token-detail/components/token-description/token-description-links/TokenDescriptionLinks.spec.tsx
+++ b/packages/web/src/layouts/token-detail/components/token-description/token-description-links/TokenDescriptionLinks.spec.tsx
@@ -6,6 +6,8 @@ import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapTheme
 import TokenDescriptionLinks from "./TokenDescriptionLinks";
 
 describe("TokenDescriptionLinks", () => {
+  const originalCanParse = URL.canParse;
+
   beforeAll(() => {
     Object.defineProperty(URL, "canParse", {
       configurable: true,
@@ -17,6 +19,13 @@ describe("TokenDescriptionLinks", () => {
           return false;
         }
       },
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(URL, "canParse", {
+      configurable: true,
+      value: originalCanParse,
     });
   });
 

--- a/packages/web/src/layouts/token-detail/components/token-description/token-description-links/TokenDescriptionLinks.spec.tsx
+++ b/packages/web/src/layouts/token-detail/components/token-description/token-description-links/TokenDescriptionLinks.spec.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { Provider as JotaiProvider } from "jotai";
+
+import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
+
+import TokenDescriptionLinks from "./TokenDescriptionLinks";
+
+describe("TokenDescriptionLinks", () => {
+  beforeAll(() => {
+    Object.defineProperty(URL, "canParse", {
+      configurable: true,
+      value: (url: string) => {
+        try {
+          new URL(url);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+    });
+  });
+
+  const renderComponent = () => {
+    return render(
+      <JotaiProvider>
+        <GnoswapThemeProvider>
+          <TokenDescriptionLinks
+            links={{
+              Website: "https://gnoswap.io",
+              X: "https://x.com/gnoswaplabs",
+              Discord: "https://discord.com/invite/u4bdGHStb2",
+              Docs: "https://docs.gnoswap.io",
+              GnoScan: "https://gnoscan.io/tokens/r/demo/wugnot",
+              Unsafe: "javascript:alert(1)",
+              Invalid: "not-a-url",
+            }}
+            copied={false}
+            copyClick={jest.fn()}
+            path="gno.land/r/demo/wugnot"
+            isLoading={false}
+          />
+        </GnoswapThemeProvider>
+      </JotaiProvider>,
+    );
+  };
+
+  it("renders safe token links only", () => {
+    renderComponent();
+
+    expect(screen.getByRole("button", { name: /Website/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /X/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Discord/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Docs/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /GnoScan/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Unsafe/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Invalid/i })).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/layouts/token-detail/components/token-description/token-description-links/TokenDescriptionLinks.stories.tsx
+++ b/packages/web/src/layouts/token-detail/components/token-description/token-description-links/TokenDescriptionLinks.stories.tsx
@@ -15,7 +15,10 @@ export const Default: Story = {
   args: {
     links: {
       Website: "https://gnoswap.io",
-      Gnoscan: "https://gnoscan.io/tokens/r/demo/wugnot",
+      X: "https://x.com/gnoswaplabs",
+      Discord: "https://discord.com/invite/u4bdGHStb2",
+      Docs: "https://docs.gnoswap.io",
+      GnoScan: "https://gnoscan.io/tokens/r/demo/wugnot",
     },
   },
 };

--- a/packages/web/src/layouts/token-detail/components/token-description/token-description-links/TokenDescriptionLinks.styles.ts
+++ b/packages/web/src/layouts/token-detail/components/token-description/token-description-links/TokenDescriptionLinks.styles.ts
@@ -78,6 +78,7 @@ export const wrapper = (theme: Theme) => css`
   }
   .group-button {
     ${mixins.flexbox("row", "flex-start", "flex-start")};
+    flex-wrap: wrap;
     gap: 4px;
   }
   ${media.mobile} {

--- a/packages/web/src/layouts/token-detail/components/token-description/token-description-links/TokenDescriptionLinks.tsx
+++ b/packages/web/src/layouts/token-detail/components/token-description/token-description-links/TokenDescriptionLinks.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import IconCopy from "@components/common/icons/IconCopy";
@@ -20,13 +20,13 @@ interface TokenDescriptionLinksProps {
 const TokenDescriptionLinks: React.FC<TokenDescriptionLinksProps> = ({ links, copied, copyClick, path, isLoading }) => {
   const { t } = useTranslation();
 
-  const onClickLink = (link: string) => {
-    openExternalUrl(link);
-  };
-
-  const safeLinks = Object.entries(links)
-    .map(([label, url]) => [label, getSafeExternalUrl(url.trim())] as const)
-    .filter((entry): entry is readonly [string, string] => entry[1] !== null);
+  const safeLinks = useMemo(
+    () =>
+      Object.entries(links)
+        .map(([label, url]) => [label, getSafeExternalUrl(url.trim())] as const)
+        .filter((entry): entry is readonly [string, string] => entry[1] !== null),
+    [links],
+  );
 
   return (
     <div css={wrapper}>
@@ -56,14 +56,12 @@ const TokenDescriptionLinks: React.FC<TokenDescriptionLinksProps> = ({ links, co
         <h3>{t("TokenDetails:description.links")}</h3>
         {!isLoading && (
           <div className="group-button">
-            {safeLinks.map(([link, url]) =>
-              url ? (
-                <button key={link} onClick={() => onClickLink(url)}>
-                  <span>{link}</span>
-                  <IconOpenLink className="link-icon" />
-                </button>
-              ) : null,
-            )}
+            {safeLinks.map(([link, url]) => (
+              <button key={link} onClick={() => openExternalUrl(url)}>
+                <span>{link}</span>
+                <IconOpenLink className="link-icon" />
+              </button>
+            ))}
           </div>
         )}
         {isLoading && <div css={pulseSkeletonStyle({ w: "150px", h: 20 })} />}

--- a/packages/web/src/layouts/token-detail/components/token-description/token-description-links/TokenDescriptionLinks.tsx
+++ b/packages/web/src/layouts/token-detail/components/token-description/token-description-links/TokenDescriptionLinks.tsx
@@ -5,12 +5,12 @@ import IconCopy from "@components/common/icons/IconCopy";
 import IconOpenLink from "@components/common/icons/IconOpenLink";
 import IconPolygon from "@components/common/icons/IconPolygon";
 import { pulseSkeletonStyle } from "@constants/skeleton.constant";
-import { openExternalUrl } from "@utils/url-utils";
+import { getSafeExternalUrl, openExternalUrl } from "@utils/url-utils";
 
 import { copyTooltip, wrapper } from "./TokenDescriptionLinks.styles";
 
 interface TokenDescriptionLinksProps {
-  links: { [key: string]: string };
+  links: Record<string, string>;
   copied: boolean;
   copyClick: () => void;
   path: string;
@@ -23,6 +23,11 @@ const TokenDescriptionLinks: React.FC<TokenDescriptionLinksProps> = ({ links, co
   const onClickLink = (link: string) => {
     openExternalUrl(link);
   };
+
+  const safeLinks = Object.entries(links)
+    .map(([label, url]) => [label, getSafeExternalUrl(url.trim())] as const)
+    .filter((entry): entry is readonly [string, string] => entry[1] !== null);
+
   return (
     <div css={wrapper}>
       {path && (
@@ -51,9 +56,9 @@ const TokenDescriptionLinks: React.FC<TokenDescriptionLinksProps> = ({ links, co
         <h3>{t("TokenDetails:description.links")}</h3>
         {!isLoading && (
           <div className="group-button">
-            {Object.keys(links)?.map((link, idx) =>
-              links[link] ? (
-                <button key={idx} onClick={() => onClickLink(links[link])}>
+            {safeLinks.map(([link, url]) =>
+              url ? (
+                <button key={link} onClick={() => onClickLink(url)}>
                   <span>{link}</span>
                   <IconOpenLink className="link-icon" />
                 </button>

--- a/packages/web/src/layouts/token-detail/containers/token-description-container/TokenDescriptionContainer.tsx
+++ b/packages/web/src/layouts/token-detail/containers/token-description-container/TokenDescriptionContainer.tsx
@@ -12,17 +12,14 @@ import TokenDescription from "../../components/token-description/TokenDescriptio
 
 export interface DescriptionInfo {
   token: TokenModel;
-  links: {
-    Website: string;
-    Gnoscan: string;
-  };
+  links: Record<string, string>;
 }
 
 export const descriptionInit: DescriptionInfo = {
   token: GNS_TOKEN,
   links: {
     Website: "https://gnoswap.io",
-    Gnoscan: "https://gnoscan.io/tokens/r/demo/wugnot",
+    GnoScan: "https://gnoscan.io/tokens/r/demo/wugnot",
   },
 };
 
@@ -62,7 +59,10 @@ const TokenDescriptionContainer: React.FC = () => {
         },
         links: {
           Website: tokenB.websiteURL || "",
-          Gnoscan: tokenB.path === "ugnot" ? getGnoscanUrl() : getTokenUrl(tokenB.tokenId),
+          X: tokenB.twitterURL || "",
+          Discord: tokenB.discordURL || "",
+          Docs: tokenB.docsURL || "",
+          GnoScan: tokenB.path === "ugnot" ? getGnoscanUrl() : getTokenUrl(tokenB.tokenId),
         },
       }));
     }

--- a/packages/web/src/models/token/token-model.ts
+++ b/packages/web/src/models/token/token-model.ts
@@ -36,6 +36,12 @@ export interface TokenModel {
 
   websiteURL?: string;
 
+  twitterURL?: string;
+
+  discordURL?: string;
+
+  docsURL?: string;
+
   wrappedPath?: string;
 
   denom?: string;

--- a/packages/web/src/repositories/token/response/token-list-response.ts
+++ b/packages/web/src/repositories/token/response/token-list-response.ts
@@ -19,6 +19,9 @@ export interface ITokenResponse {
   priceId: string;
   description: string;
   websiteURL: string;
+  twitterURL: string;
+  discordURL: string;
+  docsURL: string;
   displayPath: string;
   wrappedPath: string;
 }


### PR DESCRIPTION
## Summary

Adds all available token social/resource links to the Token detail page so it matches Launchpad link exposure.

## Changes

- Extend token response/model types with twitterURL, discordURL, and docsURL
- Render Website, X, Discord, Docs, and GnoScan links in the Token description section
- Filter invalid or unsafe link URLs before rendering link buttons
- Add focused TokenDescriptionLinks coverage for safe links and unsafe URL filtering
- Update Storybook examples with the expanded link set


## Verification

- yarn install
- LSP diagnostics: modified TypeScript files passed
- yarn prettier --check on modified frontend files
- yarn workspace @gnoswap-labs/web test:ci --runTestsByPath src/layouts/token-detail/components/token-description/token-description-links/TokenDescriptionLinks.spec.tsx
- yarn workspace @gnoswap-labs/web build
- yarn workspace @gnoswap-labs/web lint --file ... on modified production files passed; full lint still has pre-existing unrelated errors in src/hooks/common/use-click-outside.tsx and src/hooks/common/use-delay-loading.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for social media and documentation links (X, Discord, Docs) on token detail pages.

* **Tests**
  * Added tests verifying link rendering and safety checks to ensure unsafe or invalid URLs are not shown.

* **Refactor**
  * Standardized link data shape and centralized URL sanitization for consistent behavior.

* **Style**
  * Buttons/links now wrap to multiple lines when space is constrained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->