### PR TITLE
fix: restore token page navigation

### DIFF
--- a/packages/web/src/components/common/header/Header.tsx
+++ b/packages/web/src/components/common/header/Header.tsx
@@ -120,7 +120,7 @@ const Header: React.FC<HeaderProps> = ({
   const [isShowDepositModal, setIsShowDepositModal] = useState(false);
   const { t } = useTranslation();
   const { saveCurrentScrollHeight } = useScrollData();
-  const { handleNavigation } = useNavigation();
+  const { getNavigationPath, handleNavigation } = useNavigation();
   const { removeReferrerFromUrl, refreshReferralData } = useReferral();
 
   const { isSupportedFaucetGRC20 } = useFaucetGRC20();
@@ -177,7 +177,7 @@ const Header: React.FC<HeaderProps> = ({
       <HeaderWrapper>
         <HeaderContainer>
           <LeftSection>
-            <Link className="link" href={"/"} onClick={e => handleNavigation(e, "/")}>
+            <Link className="link" href={getNavigationPath("/")} onClick={handleNavigation}>
               <LogoLink>
                 <IconHeaderLogo className="header-main-logo" />
               </LogoLink>
@@ -187,7 +187,7 @@ const Header: React.FC<HeaderProps> = ({
                 <React.Fragment>
                   <ul>
                     {navigationItems.map(item => (
-                      <Link href={item.path} key={item.title} onClick={e => handleNavigation(e, item.path)}>
+                      <Link href={getNavigationPath(item.path)} key={item.title} onClick={handleNavigation}>
                         <li
                           key={t(item.title)}
                           className={
@@ -205,6 +205,7 @@ const Header: React.FC<HeaderProps> = ({
                   </ul>
                   <SubMenuButton
                     onNavigation={handleNavigation}
+                    getNavigationPath={getNavigationPath}
                     sideMenuToggle={sideMenuToggle}
                     onSideMenuToggle={onSideMenuToggle}
                     isCollapseNav={isCollapseNav}
@@ -271,7 +272,7 @@ const Header: React.FC<HeaderProps> = ({
                     pathname === item.path || (item.subPath || []).some(_ => pathname.includes(_)) ? "selected" : ""
                   }
                 >
-                  <Link href={item.path} onClick={e => handleNavigation(e, item.path)}>
+                  <Link href={getNavigationPath(item.path)} onClick={handleNavigation}>
                     {t(item.title)}
                   </Link>
                 </BottomNavItem>
@@ -281,6 +282,7 @@ const Header: React.FC<HeaderProps> = ({
                 onSideMenuToggle={onSideMenuToggle}
                 isCollapseNav={isCollapseNav}
                 onNavigation={handleNavigation}
+                getNavigationPath={getNavigationPath}
                 isBottomNav={true}
               />
             </BottomNavContainer>

--- a/packages/web/src/components/common/header/sub-menu-button/SubMenuButton.tsx
+++ b/packages/web/src/components/common/header/sub-menu-button/SubMenuButton.tsx
@@ -13,7 +13,8 @@ interface SubMenuButtonProps {
   sideMenuToggle: boolean;
   isCollapseNav: boolean;
   onSideMenuToggle: (value: boolean) => void;
-  onNavigation: (e: React.MouseEvent, path: string) => void;
+  onNavigation: (e: React.MouseEvent) => void;
+  getNavigationPath: (path: string) => string;
   isBottomNav: boolean;
 }
 
@@ -22,6 +23,7 @@ const SubMenuButton: React.FC<SubMenuButtonProps> = ({
   isCollapseNav,
   onSideMenuToggle,
   onNavigation,
+  getNavigationPath,
   isBottomNav,
 }) => {
   const theme = useTheme();
@@ -61,8 +63,8 @@ const SubMenuButton: React.FC<SubMenuButtonProps> = ({
       ? IconStrokeArrowDown
       : IconStrokeArrowUp
     : sideMenuToggle
-    ? IconStrokeArrowUp
-    : IconStrokeArrowDown;
+      ? IconStrokeArrowUp
+      : IconStrokeArrowDown;
 
   return (
     <SubMenuButtonWrapper ref={buttonRef} className={`${sideMenuToggle ? "selected" : ""}`}>
@@ -75,6 +77,7 @@ const SubMenuButton: React.FC<SubMenuButtonProps> = ({
           <FakeSpaceWrapper></FakeSpaceWrapper>
           <SubMenu
             onNavigation={onNavigation}
+            getNavigationPath={getNavigationPath}
             isCollapseNav={isCollapseNav}
             onSideMenuToggle={() => onSideMenuToggle(false)}
           />

--- a/packages/web/src/components/common/header/sub-menu-button/sub-menu/SubMenu.tsx
+++ b/packages/web/src/components/common/header/sub-menu-button/sub-menu/SubMenu.tsx
@@ -26,10 +26,16 @@ import { TABLET_HIDDEN_NAV_PATHS } from "@constants/page.constant";
 interface HeaderSideMenuModalProps {
   isCollapseNav: boolean;
   onSideMenuToggle: () => void;
-  onNavigation: (e: React.MouseEvent, path: string) => void;
+  onNavigation: (e: React.MouseEvent) => void;
+  getNavigationPath: (path: string) => string;
 }
 
-const SubMenu: React.FC<HeaderSideMenuModalProps> = ({ isCollapseNav, onSideMenuToggle, onNavigation }) => {
+const SubMenu: React.FC<HeaderSideMenuModalProps> = ({
+  isCollapseNav,
+  onSideMenuToggle,
+  onNavigation,
+  getNavigationPath,
+}) => {
   const router = useCustomRouter();
   const menuRef = useRef<HTMLDivElement | null>(null);
   const { t } = useTranslation();
@@ -78,7 +84,7 @@ const SubMenu: React.FC<HeaderSideMenuModalProps> = ({ isCollapseNav, onSideMenu
           {navigationItems.length > 0 && (
             <>
               {navigationItems.map((item, index) => (
-                <Link href={`${item.path}`} key={index} onClick={e => onNavigation(e, item.path)}>
+                <Link href={getNavigationPath(item.path)} key={index} onClick={onNavigation}>
                   <li
                     className="header-side-menu-item"
                     onClick={() => {

--- a/packages/web/src/hooks/common/use-gnoscan-url.tsx
+++ b/packages/web/src/hooks/common/use-gnoscan-url.tsx
@@ -1,4 +1,5 @@
 import { useAtomValue } from "jotai";
+import { useCallback, useMemo } from "react";
 
 import { CommonState } from "@states/index";
 import { GNOSCAN_OFFICIAL_CHAIN_IDS } from "@constants/environment.constant";
@@ -17,45 +18,63 @@ const TEMP_INDEXER_URL = "https%3A%2F%2Findexer-gnoswap.in.onbloc.xyz";
 export const useGnoscanUrl = () => {
   const network = useAtomValue(CommonState.network);
 
-  const getGnoscanUrl = (type: GnoscanDataType | "" = "", params = ""): string => {
-    const chainId = network.chainId || "";
-    const baseUrl = network.scannerUrl || "";
-    let chainParams = "";
-    if (GNOSCAN_OFFICIAL_CHAIN_IDS.includes(chainId)) {
-      chainParams = `chainId=${chainId}`;
-    } else {
-      chainParams = "type=custom";
-      if (TEMP_RPC_URL) chainParams = chainParams.concat(`&rpcUrl=${TEMP_RPC_URL}`);
-      if (TEMP_INDEXER_URL) chainParams = chainParams.concat(`&indexerUrl=${TEMP_INDEXER_URL}`);
-    }
-    chainParams = `${params?.includes("?") ? "&" : "?"}${chainParams}`;
+  const getGnoscanUrl = useCallback(
+    (type: GnoscanDataType | "" = "", params = ""): string => {
+      const chainId = network.chainId || "";
+      const baseUrl = network.scannerUrl || "";
+      let chainParams = "";
+      if (GNOSCAN_OFFICIAL_CHAIN_IDS.includes(chainId)) {
+        chainParams = `chainId=${chainId}`;
+      } else {
+        chainParams = "type=custom";
+        if (TEMP_RPC_URL) chainParams = chainParams.concat(`&rpcUrl=${TEMP_RPC_URL}`);
+        if (TEMP_INDEXER_URL) chainParams = chainParams.concat(`&indexerUrl=${TEMP_INDEXER_URL}`);
+      }
+      chainParams = `${params?.includes("?") ? "&" : "?"}${chainParams}`;
 
-    const targetUrl = `${baseUrl}${type || ""}/${params}${chainParams}`;
+      const targetUrl = `${baseUrl}${type || ""}/${params}${chainParams}`;
 
-    return targetUrl;
-  };
+      return targetUrl;
+    },
+    [network.chainId, network.scannerUrl],
+  );
 
-  const getTxUrl = (txHash: string) => {
-    return getGnoscanUrl(GnoscanDataType.Transactions, `details?txhash=${txHash}`);
-  };
+  const getTxUrl = useCallback(
+    (txHash: string) => {
+      return getGnoscanUrl(GnoscanDataType.Transactions, `details?txhash=${txHash}`);
+    },
+    [getGnoscanUrl],
+  );
 
-  const getRealmUrl = (realmPath: string) => {
-    return getGnoscanUrl(GnoscanDataType.Realms, `details?path=${realmPath}`);
-  };
+  const getRealmUrl = useCallback(
+    (realmPath: string) => {
+      return getGnoscanUrl(GnoscanDataType.Realms, `details?path=${realmPath}`);
+    },
+    [getGnoscanUrl],
+  );
 
-  const getTokenUrl = (tokenId: string) => {
-    return getGnoscanUrl(GnoscanDataType.Tokens, `${tokenId}`);
-  };
+  const getTokenUrl = useCallback(
+    (tokenId: string) => {
+      return getGnoscanUrl(GnoscanDataType.Tokens, `${tokenId}`);
+    },
+    [getGnoscanUrl],
+  );
 
-  const getAccountUrl = (address: string) => {
-    return getGnoscanUrl(GnoscanDataType.Account, `${address}`);
-  };
+  const getAccountUrl = useCallback(
+    (address: string) => {
+      return getGnoscanUrl(GnoscanDataType.Account, `${address}`);
+    },
+    [getGnoscanUrl],
+  );
 
-  return {
-    getGnoscanUrl,
-    getTxUrl,
-    getRealmUrl,
-    getTokenUrl,
-    getAccountUrl,
-  };
+  return useMemo(
+    () => ({
+      getGnoscanUrl,
+      getTxUrl,
+      getRealmUrl,
+      getTokenUrl,
+      getAccountUrl,
+    }),
+    [getAccountUrl, getGnoscanUrl, getRealmUrl, getTokenUrl, getTxUrl],
+  );
 };

--- a/packages/web/src/hooks/common/use-navigation.ts
+++ b/packages/web/src/hooks/common/use-navigation.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import useCustomRouter from "@hooks/common/use-custom-router";
 import useScrollData from "@hooks/common/use-scroll-data";
+import { makeRouteUrl } from "@utils/page.utils";
 
 /**
  * A custom hook to handle navigation with support for:
@@ -23,24 +24,28 @@ export const useNavigation = () => {
   /**
    * Handles navigation with support for opening in new tab
    * @param e Mouse event
-   * @param path Target path
    */
   const handleNavigation = useCallback(
-    (e: React.MouseEvent, path: string) => {
+    (e: React.MouseEvent) => {
       if (shouldOpenInNewTab(e)) {
-        // Let the default behavior handle opening in new tab
         return;
       }
 
-      e.preventDefault();
       saveCurrentScrollHeight(window?.location?.pathname);
-      router.push(path);
     },
-    [router, saveCurrentScrollHeight, shouldOpenInNewTab],
+    [saveCurrentScrollHeight, shouldOpenInNewTab],
+  );
+
+  const getNavigationPath = useCallback(
+    (path: string) => {
+      return makeRouteUrl(path, router.getParamsWithReferrer());
+    },
+    [router],
   );
 
   return {
     handleNavigation,
+    getNavigationPath,
     shouldOpenInNewTab,
   };
 };


### PR DESCRIPTION
## Summary
- Restore top navigation after visiting token detail pages.
- Let Next.js `Link` handle header navigation instead of cancelling the click and pushing manually.
- Stabilize GnoScan URL helper identities so token-detail effects do not re-run indefinitely after PR #906.

## Verification
- Local browser: `/token?path=gno.land/r/gnoswap/test_token/test_dai` → Portfolio renders `/portfolio`, title `Portfolio | GnoSwap`, routeChangeComplete observed.
- `yarn workspace @gnoswap-labs/web exec prettier --check ...`
- `yarn workspace @gnoswap-labs/web lint --file ...`
- `yarn workspace @gnoswap-labs/web build`