### PR TITLE
fix(token): use ugnot market cap from API

### DIFF
--- a/packages/web/src/containers/token-list-container/TokenListContainer.tsx
+++ b/packages/web/src/containers/token-list-container/TokenListContainer.tsx
@@ -221,7 +221,8 @@ const TokenListContainer: React.FC = () => {
         const isGnot = item.path === "ugnot";
         const tempTokenPrice: TokenPriceModel = tokenPrices[isGnot ? wugnotPath : item.path] ?? {};
         const tempWuGnot: TokenPriceModel = tokenPrices[wugnotPath] ?? {};
-        const transferData = isGnot ? tempWuGnot : tempTokenPrice;
+        const tempGnot = tokenPrices.ugnot;
+        const transferData = isGnot ? { ...tempWuGnot, marketCap: tempGnot?.marketCap } : tempTokenPrice;
         const splitMostLiquidity: string[] = tempTokenPrice?.mostLiquidityPool?.split(":") || [];
         const swapFeeType: SwapFeeTierType = `FEE_${splitMostLiquidity[2]}` as SwapFeeTierType;
         const tempTokenA = tokens.filter((_item: TokenModel) => _item.path === splitMostLiquidity[0]);
@@ -277,9 +278,7 @@ const TokenListContainer: React.FC = () => {
             : undefined,
           last7days,
           marketCap: transferData.marketCap
-            ? `$${Math.floor(
-                Number((isGnot ? 1000000000 * Number(transferData.usd) : transferData.marketCap) || 0),
-              ).toLocaleString()}`
+            ? `$${Math.floor(Number(transferData.marketCap || 0)).toLocaleString()}`
             : "-",
           liquidity: formatOtherPrice(transferData.lockedTokensUsd, {
             decimals: 0,

--- a/packages/web/src/containers/token-list-container/TokenListContainer.tsx
+++ b/packages/web/src/containers/token-list-container/TokenListContainer.tsx
@@ -219,31 +219,31 @@ const TokenListContainer: React.FC = () => {
       .filter((token: TokenModel) => token.path !== wugnotPath)
       .map((item: TokenModel) => {
         const isGnot = item.path === "ugnot";
-        const tempTokenPrice: TokenPriceModel = tokenPrices[isGnot ? wugnotPath : item.path] ?? {};
-        const tempWuGnot: TokenPriceModel = tokenPrices[wugnotPath] ?? {};
-        const tempGnot = tokenPrices.ugnot;
-        const transferData = isGnot ? { ...tempWuGnot, marketCap: tempGnot?.marketCap } : tempTokenPrice;
-        const splitMostLiquidity: string[] = tempTokenPrice?.mostLiquidityPool?.split(":") || [];
+        const priceDataPath = isGnot ? wugnotPath : item.path;
+        const selectedPriceData: TokenPriceModel = tokenPrices[priceDataPath] ?? {};
+        const gnotPriceData = tokenPrices.ugnot;
+        const rowMarketCap = isGnot ? gnotPriceData?.marketCap : selectedPriceData.marketCap;
+        const splitMostLiquidity: string[] = selectedPriceData.mostLiquidityPool?.split(":") || [];
         const swapFeeType: SwapFeeTierType = `FEE_${splitMostLiquidity[2]}` as SwapFeeTierType;
         const tempTokenA = tokens.filter((_item: TokenModel) => _item.path === splitMostLiquidity[0]);
         const tempTokenB = tokens.filter((_item: TokenModel) => _item.path === splitMostLiquidity[1]);
 
-        const data1day = checkPositivePrice(transferData.pricesBefore?.latestPrice, transferData.pricesBefore?.price1d);
+        const data1day = checkPositivePrice(selectedPriceData.pricesBefore?.latestPrice, selectedPriceData.pricesBefore?.price1d);
 
-        const data7day = checkPositivePrice(transferData.pricesBefore?.latestPrice, transferData.pricesBefore?.price7d);
+        const data7day = checkPositivePrice(selectedPriceData.pricesBefore?.latestPrice, selectedPriceData.pricesBefore?.price7d);
         const last7days = [
-          ...[...(transferData?.last7d || [])]
+          ...[...(selectedPriceData.last7d || [])]
             .sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime())
             .map(item => Number(item.price || 0)),
-          ...(transferData?.pricesBefore?.latestPrice ? [Number(transferData?.pricesBefore?.latestPrice)] : []),
+          ...(selectedPriceData.pricesBefore?.latestPrice ? [Number(selectedPriceData.pricesBefore.latestPrice)] : []),
         ];
         const graphStatus = getLast7dGraphStatus(last7days);
 
-        const data30D = checkPositivePrice(transferData.pricesBefore?.latestPrice, transferData.pricesBefore?.price30d);
+        const data30D = checkPositivePrice(selectedPriceData.pricesBefore?.latestPrice, selectedPriceData.pricesBefore?.price30d);
 
         return {
-          ...transferData,
-          priceGradeType: transferData.priceGradeType,
+          ...selectedPriceData,
+          priceGradeType: selectedPriceData.priceGradeType,
           token: {
             path: item.path,
             tokenId: item.tokenId,
@@ -252,7 +252,7 @@ const TokenListContainer: React.FC = () => {
             displaySymbol: item.displaySymbol,
             logoURI: item.logoURI,
           },
-          mostLiquidPool: tempTokenPrice?.mostLiquidityPool
+          mostLiquidPool: selectedPriceData.mostLiquidityPool
             ? {
                 poolId: Math.floor(Math.random() * 50 + 1).toString(),
                 tokenPair: {
@@ -277,18 +277,16 @@ const TokenListContainer: React.FC = () => {
               }
             : undefined,
           last7days,
-          marketCap: transferData.marketCap
-            ? `$${Math.floor(Number(transferData.marketCap || 0)).toLocaleString()}`
-            : "-",
-          liquidity: formatOtherPrice(transferData.lockedTokensUsd, {
+          marketCap: rowMarketCap ? `$${Math.floor(Number(rowMarketCap || 0)).toLocaleString()}` : "-",
+          liquidity: formatOtherPrice(selectedPriceData.lockedTokensUsd, {
             decimals: 0,
             isKMB: false,
           }),
-          volume24h: formatOtherPrice(transferData.volumeUsd24h, {
+          volume24h: formatOtherPrice(selectedPriceData.volumeUsd24h, {
             decimals: 0,
             isKMB: false,
           }),
-          price: transferData.usd ? formatPrice(transferData.usd, { isKMB: false, forcedDecimals: true }) : "--",
+          price: selectedPriceData.usd ? formatPrice(selectedPriceData.usd, { isKMB: false, forcedDecimals: true }) : "--",
           priceOf1d: {
             status: data1day.status,
             value:

--- a/packages/web/src/layouts/token-detail/containers/token-info-content-container/TokenInfoContentContainer.tsx
+++ b/packages/web/src/layouts/token-detail/containers/token-info-content-container/TokenInfoContentContainer.tsx
@@ -31,32 +31,33 @@ const priceChangeDetailInit = {
 const TokenInfoContentContainer: React.FC = () => {
   const router = useCustomRouter();
   const path = router.getTokenPath();
+  const isGnot = path === "ugnot";
+  const tokenDataPath = isGnot ? WRAPPED_GNOT_PATH : (path as string);
   const {
     data: { market = marketInformationInit } = {},
     isLoading,
     isStale: isStaleTokenDetails,
-  } = useGetTokenDetails(path === "ugnot" ? WRAPPED_GNOT_PATH : (path as string), {
+  } = useGetTokenDetails(tokenDataPath, {
     enabled: !!path,
   });
   const {
     data: { usd: currentPrice = "0", feeUsd24h, pricesBefore = priceChangeDetailInit, marketCap } = {},
     isStale: isStaleTokenPrices,
-  } = useGetTokenPrices(path === "ugnot" ? WRAPPED_GNOT_PATH : (path as string), { enabled: !!path });
-  const { data: tokenPrices = {}, isLoading: isLoadingAllTokenPrices } = useGetAllTokenPrices({ enabled: path === "ugnot" });
+  } = useGetTokenPrices(tokenDataPath, { enabled: !!path });
+  const { data: tokenPrices = {}, isLoading: isLoadingAllTokenPrices } = useGetAllTokenPrices({ enabled: isGnot });
+  const isLoadingGnotMarketCap = isGnot && isLoadingAllTokenPrices;
   const gnotMarketCap = tokenPrices.ugnot?.marketCap;
   const { isLoading: isLoadingCommon } = useLoading();
   const { t } = useTranslation();
 
   const marketInformation = useMemo(() => {
-    const isGnot = path === "ugnot";
-
     return {
       popularity: formatOtherPrice(isGnot ? gnotMarketCap : marketCap),
       lockedTokensUsd: formatOtherPrice(market.lockedTokensUsd),
       volumeUsd24h: formatOtherPrice(market.volumeUsd24h),
       feesUsd24h: formatOtherPrice(feeUsd24h),
     };
-  }, [path, gnotMarketCap, marketCap, market.lockedTokensUsd, market.volumeUsd24h, feeUsd24h]);
+  }, [isGnot, gnotMarketCap, marketCap, market.lockedTokensUsd, market.volumeUsd24h, feeUsd24h]);
 
   const priceInfomation = useMemo(() => {
     const data1H = checkPositivePrice(currentPrice, pricesBefore.price1h);
@@ -163,7 +164,7 @@ const TokenInfoContentContainer: React.FC = () => {
       marketInfo={marketInformation}
       loadingPricePerform={isLoading || isLoadingCommon}
       loadingPriceInfo={isLoading || isLoadingCommon}
-      loadingMarketInfo={isLoading || isLoadingCommon || isLoadingAllTokenPrices}
+      loadingMarketInfo={isLoading || isLoadingCommon || isLoadingGnotMarketCap}
     />
   );
 };

--- a/packages/web/src/layouts/token-detail/containers/token-info-content-container/TokenInfoContentContainer.tsx
+++ b/packages/web/src/layouts/token-detail/containers/token-info-content-container/TokenInfoContentContainer.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { WRAPPED_GNOT_PATH } from "@constants/environment.constant";
 import useCustomRouter from "@hooks/common/use-custom-router";
 import { useLoading } from "@hooks/common/use-loading";
-import { useGetAllTokenPrices, useGetTokenDetails, useGetTokenPrices } from "@query/token";
+import { useGetTokenDetails, useGetTokenPrices } from "@query/token";
 import { checkPositivePrice } from "@utils/common";
 import { formatOtherPrice } from "@utils/new-number-utils";
 
@@ -44,9 +44,11 @@ const TokenInfoContentContainer: React.FC = () => {
     data: { usd: currentPrice = "0", feeUsd24h, pricesBefore = priceChangeDetailInit, marketCap } = {},
     isStale: isStaleTokenPrices,
   } = useGetTokenPrices(tokenDataPath, { enabled: !!path });
-  const { data: tokenPrices = {}, isLoading: isLoadingAllTokenPrices } = useGetAllTokenPrices({ enabled: isGnot });
-  const isLoadingGnotMarketCap = isGnot && isLoadingAllTokenPrices;
-  const gnotMarketCap = tokenPrices.ugnot?.marketCap;
+  const {
+    data: { marketCap: gnotMarketCap } = {},
+    isLoading: isLoadingNativeGnotMarketCap,
+  } = useGetTokenPrices("ugnot", { enabled: isGnot });
+  const isLoadingGnotMarketCap = isGnot && isLoadingNativeGnotMarketCap;
   const { isLoading: isLoadingCommon } = useLoading();
   const { t } = useTranslation();
 

--- a/packages/web/src/layouts/token-detail/containers/token-info-content-container/TokenInfoContentContainer.tsx
+++ b/packages/web/src/layouts/token-detail/containers/token-info-content-container/TokenInfoContentContainer.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { WRAPPED_GNOT_PATH } from "@constants/environment.constant";
 import useCustomRouter from "@hooks/common/use-custom-router";
 import { useLoading } from "@hooks/common/use-loading";
-import { useGetTokenDetails, useGetTokenPrices } from "@query/token";
+import { useGetAllTokenPrices, useGetTokenDetails, useGetTokenPrices } from "@query/token";
 import { checkPositivePrice } from "@utils/common";
 import { formatOtherPrice } from "@utils/new-number-utils";
 
@@ -42,6 +42,8 @@ const TokenInfoContentContainer: React.FC = () => {
     data: { usd: currentPrice = "0", feeUsd24h, pricesBefore = priceChangeDetailInit, marketCap } = {},
     isStale: isStaleTokenPrices,
   } = useGetTokenPrices(path === "ugnot" ? WRAPPED_GNOT_PATH : (path as string), { enabled: !!path });
+  const { data: tokenPrices = {}, isLoading: isLoadingAllTokenPrices } = useGetAllTokenPrices({ enabled: path === "ugnot" });
+  const gnotMarketCap = tokenPrices.ugnot?.marketCap;
   const { isLoading: isLoadingCommon } = useLoading();
   const { t } = useTranslation();
 
@@ -49,12 +51,12 @@ const TokenInfoContentContainer: React.FC = () => {
     const isGnot = path === "ugnot";
 
     return {
-      popularity: formatOtherPrice(isGnot ? 1_000_000_000 * Number(currentPrice) : marketCap),
+      popularity: formatOtherPrice(isGnot ? gnotMarketCap : marketCap),
       lockedTokensUsd: formatOtherPrice(market.lockedTokensUsd),
       volumeUsd24h: formatOtherPrice(market.volumeUsd24h),
       feesUsd24h: formatOtherPrice(feeUsd24h),
     };
-  }, [path, currentPrice, marketCap, market.lockedTokensUsd, market.volumeUsd24h, feeUsd24h]);
+  }, [path, gnotMarketCap, marketCap, market.lockedTokensUsd, market.volumeUsd24h, feeUsd24h]);
 
   const priceInfomation = useMemo(() => {
     const data1H = checkPositivePrice(currentPrice, pricesBefore.price1h);
@@ -161,7 +163,7 @@ const TokenInfoContentContainer: React.FC = () => {
       marketInfo={marketInformation}
       loadingPricePerform={isLoading || isLoadingCommon}
       loadingPriceInfo={isLoading || isLoadingCommon}
-      loadingMarketInfo={isLoading || isLoadingCommon}
+      loadingMarketInfo={isLoading || isLoadingCommon || isLoadingAllTokenPrices}
     />
   );
 };


### PR DESCRIPTION
## Summary
- Use the existing all-token prices response for UGNOT market cap instead of the hardcoded supply calculation.
- Apply the same UGNOT market cap source on token detail and token list surfaces.

## Changes
- Fetch `/v1/tokens/prices?grade=NONE` data for UGNOT detail market information.
- Use `tokenPrices.ugnot?.marketCap` for UGNOT market cap display.
- Remove the `price * 1,000,000,000` market cap calculation.

## Validation
- LSP diagnostics clean for changed files.
- Confirmed no remaining hardcoded UGNOT supply calculation with search.
- Confirmed local `/v1/tokens/prices?grade=NONE` returns `ugnot.marketCap`.
- Ran `yarn workspace @gnoswap-labs/web lint` (existing hook warnings only).
- Ran `yarn workspace @gnoswap-labs/web test:ci --runTestsByPath src/repositories/token/token-repository.spec.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured market cap and price fields for gnot/ugnot are sourced consistently so market cap, liquidity, volume and price display correctly across lists and details.
  * Improved token detail market data retrieval and loading handling so ugnot popularity/market-cap metrics show accurate values and loading states are reflected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->