### PR TITLE
fix(token-list): derive graph status from last7d

### DIFF
--- a/packages/web/src/containers/token-list-container/TokenListContainer.tsx
+++ b/packages/web/src/containers/token-list-container/TokenListContainer.tsx
@@ -15,6 +15,7 @@ import { useLoading } from "@hooks/common/use-loading";
 import { MAIN_TOKEN_LIST_SIZE } from "@constants/table.constant";
 import { formatOtherPrice, formatPrice } from "@utils/new-number-utils";
 import { TOKEN_PRICE_GRADE_TYPE } from "@models/token/token-price-grade";
+import { getLast7dGraphStatus } from "./token-list-graph-status";
 
 interface NegativeStatusType {
   status: MATH_NEGATIVE_TYPE;
@@ -229,11 +230,7 @@ const TokenListContainer: React.FC = () => {
         const data1day = checkPositivePrice(transferData.pricesBefore?.latestPrice, transferData.pricesBefore?.price1d);
 
         const data7day = checkPositivePrice(transferData.pricesBefore?.latestPrice, transferData.pricesBefore?.price7d);
-        const latestGraphPrice =
-          tempTokenPrice?.last7d?.length > 0
-            ? tempTokenPrice.last7d[tempTokenPrice.last7d.length - 1].price
-            : tempTokenPrice.pricesBefore?.latestPrice;
-        const graphStatus = checkPositivePrice(transferData.pricesBefore?.latestPrice, latestGraphPrice).status;
+        const graphStatus = getLast7dGraphStatus(transferData.last7d);
 
         const data30D = checkPositivePrice(transferData.pricesBefore?.latestPrice, transferData.pricesBefore?.price30d);
 
@@ -273,9 +270,9 @@ const TokenListContainer: React.FC = () => {
               }
             : undefined,
           last7days: [
-            ...(transferData?.last7d
-              ?.sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime())
-              .map(item => Number(item.price || 0)) || []),
+            ...[...(transferData?.last7d || [])]
+              .sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime())
+              .map(item => Number(item.price || 0)),
             ...(transferData?.pricesBefore?.latestPrice ? [Number(transferData?.pricesBefore?.latestPrice)] : []),
           ],
           marketCap: transferData.marketCap

--- a/packages/web/src/containers/token-list-container/token-list-graph-status.spec.ts
+++ b/packages/web/src/containers/token-list-container/token-list-graph-status.spec.ts
@@ -1,5 +1,6 @@
 import { MATH_NEGATIVE_TYPE } from "@constants/option.constant";
-import { getLast7dGraphStatus, type Last7dPricePoint } from "./token-list-graph-status";
+import { type Last7dPricePoint } from "@models/token/token-price-model";
+import { getLast7dGraphStatus } from "./token-list-graph-status";
 
 describe("getLast7dGraphStatus", () => {
   it("returns NEGATIVE when chronological first price is greater than last price", () => {

--- a/packages/web/src/containers/token-list-container/token-list-graph-status.spec.ts
+++ b/packages/web/src/containers/token-list-container/token-list-graph-status.spec.ts
@@ -1,0 +1,56 @@
+import { MATH_NEGATIVE_TYPE } from "@constants/option.constant";
+import { getLast7dGraphStatus, type Last7dPricePoint } from "./token-list-graph-status";
+
+describe("getLast7dGraphStatus", () => {
+  it("returns NEGATIVE when chronological first price is greater than last price", () => {
+    const last7d: Last7dPricePoint[] = [
+      { time: "2026-01-01T00:00:00Z", price: "10.000000000000000001" },
+      { time: "2026-01-02T00:00:00Z", price: "10.000000000000000000" },
+    ];
+
+    expect(getLast7dGraphStatus(last7d)).toBe(MATH_NEGATIVE_TYPE.NEGATIVE);
+  });
+
+  it("returns POSITIVE when chronological first price is less than last price", () => {
+    const last7d: Last7dPricePoint[] = [
+      { time: "2026-01-01T00:00:00Z", price: "1.25" },
+      { time: "2026-01-02T00:00:00Z", price: "2.5" },
+    ];
+
+    expect(getLast7dGraphStatus(last7d)).toBe(MATH_NEGATIVE_TYPE.POSITIVE);
+  });
+
+  it("returns POSITIVE when chronological first price equals last price", () => {
+    const last7d: Last7dPricePoint[] = [
+      { time: "2026-01-01T00:00:00Z", price: "3.000" },
+      { time: "2026-01-02T00:00:00Z", price: "3" },
+    ];
+
+    expect(getLast7dGraphStatus(last7d)).toBe(MATH_NEGATIVE_TYPE.POSITIVE);
+  });
+
+  it("sorts by time before comparing and does not mutate the input", () => {
+    const last7d: Last7dPricePoint[] = [
+      { time: "2026-01-03T00:00:00Z", price: "5" },
+      { time: "2026-01-01T00:00:00Z", price: "10" },
+      { time: "2026-01-02T00:00:00Z", price: "7" },
+    ];
+    const originalOrder = last7d.map(item => item.time);
+
+    expect(getLast7dGraphStatus(last7d)).toBe(MATH_NEGATIVE_TYPE.NEGATIVE);
+    expect(last7d.map(item => item.time)).toEqual(originalOrder);
+  });
+
+  it("returns NONE for empty last7d data", () => {
+    expect(getLast7dGraphStatus([])).toBe(MATH_NEGATIVE_TYPE.NONE);
+  });
+
+  it("returns NONE when last7d has no usable prices", () => {
+    const last7d: Last7dPricePoint[] = [
+      { time: "2026-01-01T00:00:00Z", price: "" },
+      { time: "2026-01-02T00:00:00Z", price: "not-a-number" },
+    ];
+
+    expect(getLast7dGraphStatus(last7d)).toBe(MATH_NEGATIVE_TYPE.NONE);
+  });
+});

--- a/packages/web/src/containers/token-list-container/token-list-graph-status.ts
+++ b/packages/web/src/containers/token-list-container/token-list-graph-status.ts
@@ -1,10 +1,6 @@
 import { MATH_NEGATIVE_TYPE } from "@constants/option.constant";
+import { type Last7dPricePoint } from "@models/token/token-price-model";
 import BigNumber from "bignumber.js";
-
-export interface Last7dPricePoint {
-  time: string;
-  price: string;
-}
 
 const isUsablePricePoint = (item: Last7dPricePoint) => {
   const time = new Date(item.time).getTime();

--- a/packages/web/src/containers/token-list-container/token-list-graph-status.ts
+++ b/packages/web/src/containers/token-list-container/token-list-graph-status.ts
@@ -1,0 +1,30 @@
+import { MATH_NEGATIVE_TYPE } from "@constants/option.constant";
+import BigNumber from "bignumber.js";
+
+export interface Last7dPricePoint {
+  time: string;
+  price: string;
+}
+
+const isUsablePricePoint = (item: Last7dPricePoint) => {
+  const time = new Date(item.time).getTime();
+  const price = BigNumber(item.price);
+
+  return Number.isFinite(time) && item.price !== "" && !price.isNaN() && price.isFinite();
+};
+
+export const getLast7dGraphStatus = (last7d?: readonly Last7dPricePoint[] | null): MATH_NEGATIVE_TYPE => {
+  const sortedLast7d = [...(last7d ?? [])].sort(
+    (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime(),
+  );
+  const usableLast7d = sortedLast7d.filter(isUsablePricePoint);
+
+  if (usableLast7d.length === 0) {
+    return MATH_NEGATIVE_TYPE.NONE;
+  }
+
+  const firstPrice = BigNumber(usableLast7d[0].price);
+  const lastPrice = BigNumber(usableLast7d[usableLast7d.length - 1].price);
+
+  return firstPrice.isGreaterThan(lastPrice) ? MATH_NEGATIVE_TYPE.NEGATIVE : MATH_NEGATIVE_TYPE.POSITIVE;
+};

--- a/packages/web/src/models/token/token-price-model.ts
+++ b/packages/web/src/models/token/token-price-model.ts
@@ -1,6 +1,11 @@
 import { IPricesBefore } from "./token-prices-before";
 import { TOKEN_PRICE_GRADE_TYPE } from "./token-price-grade";
 
+export interface Last7dPricePoint {
+  time: string;
+  price: string;
+}
+
 export interface TokenPriceModel {
   path: string;
   usd: string;
@@ -12,7 +17,7 @@ export interface TokenPriceModel {
   liquidity: string;
   volume: string;
   mostLiquidityPool: string;
-  last7d: { time: string; price: string }[];
+  last7d: Last7dPricePoint[];
   pricesBefore: IPricesBefore;
   volumeUsd24h: string;
   feeUsd24h: string;


### PR DESCRIPTION
## Summary
- Fix Main token list Last 7 Days graph color to compare chronological first and last last7d prices.
- Use transferData.last7d for graph status so GNOT follows the same mapped price source.
- Add focused unit coverage for falling, rising, equal, unsorted, empty, and unusable last7d data.

## Verification
- yarn jest --runInBand src/containers/token-list-container/token-list-graph-status.spec.ts
- yarn next lint --file src/containers/token-list-container/TokenListContainer.tsx --file src/containers/token-list-container/token-list-graph-status.ts --file src/containers/token-list-container/token-list-graph-status.spec.ts
- git diff --check

## Notes
- Full workspace lint still reports pre-existing unrelated errors outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced 7-day price trend calculations for tokens in the token list.
  * Improved price data validation and handling in trend analysis.
  * Added comprehensive test coverage for price trend logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->