### PR TITLE
fix(token-list): sync graph status with rendered data

### DIFF
--- a/packages/web/src/containers/token-list-container/TokenListContainer.tsx
+++ b/packages/web/src/containers/token-list-container/TokenListContainer.tsx
@@ -15,7 +15,7 @@ import { useLoading } from "@hooks/common/use-loading";
 import { MAIN_TOKEN_LIST_SIZE } from "@constants/table.constant";
 import { formatOtherPrice, formatPrice } from "@utils/new-number-utils";
 import { TOKEN_PRICE_GRADE_TYPE } from "@models/token/token-price-grade";
-import { getLast7dGraphStatusFromPrices } from "./token-list-graph-status";
+import { getLast7dGraphStatus } from "./token-list-graph-status";
 
 interface NegativeStatusType {
   status: MATH_NEGATIVE_TYPE;
@@ -236,7 +236,7 @@ const TokenListContainer: React.FC = () => {
             .map(item => Number(item.price || 0)),
           ...(transferData?.pricesBefore?.latestPrice ? [Number(transferData?.pricesBefore?.latestPrice)] : []),
         ];
-        const graphStatus = getLast7dGraphStatusFromPrices(last7days);
+        const graphStatus = getLast7dGraphStatus(last7days);
 
         const data30D = checkPositivePrice(transferData.pricesBefore?.latestPrice, transferData.pricesBefore?.price30d);
 

--- a/packages/web/src/containers/token-list-container/TokenListContainer.tsx
+++ b/packages/web/src/containers/token-list-container/TokenListContainer.tsx
@@ -15,7 +15,7 @@ import { useLoading } from "@hooks/common/use-loading";
 import { MAIN_TOKEN_LIST_SIZE } from "@constants/table.constant";
 import { formatOtherPrice, formatPrice } from "@utils/new-number-utils";
 import { TOKEN_PRICE_GRADE_TYPE } from "@models/token/token-price-grade";
-import { getLast7dGraphStatus } from "./token-list-graph-status";
+import { getLast7dGraphStatusFromPrices } from "./token-list-graph-status";
 
 interface NegativeStatusType {
   status: MATH_NEGATIVE_TYPE;
@@ -230,7 +230,13 @@ const TokenListContainer: React.FC = () => {
         const data1day = checkPositivePrice(transferData.pricesBefore?.latestPrice, transferData.pricesBefore?.price1d);
 
         const data7day = checkPositivePrice(transferData.pricesBefore?.latestPrice, transferData.pricesBefore?.price7d);
-        const graphStatus = getLast7dGraphStatus(transferData.last7d);
+        const last7days = [
+          ...[...(transferData?.last7d || [])]
+            .sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime())
+            .map(item => Number(item.price || 0)),
+          ...(transferData?.pricesBefore?.latestPrice ? [Number(transferData?.pricesBefore?.latestPrice)] : []),
+        ];
+        const graphStatus = getLast7dGraphStatusFromPrices(last7days);
 
         const data30D = checkPositivePrice(transferData.pricesBefore?.latestPrice, transferData.pricesBefore?.price30d);
 
@@ -269,12 +275,7 @@ const TokenListContainer: React.FC = () => {
                 feeRate: splitMostLiquidity.length > 1 ? `${SwapFeeTierInfoMap[swapFeeType].rateStr}` : "0.02%",
               }
             : undefined,
-          last7days: [
-            ...[...(transferData?.last7d || [])]
-              .sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime())
-              .map(item => Number(item.price || 0)),
-            ...(transferData?.pricesBefore?.latestPrice ? [Number(transferData?.pricesBefore?.latestPrice)] : []),
-          ],
+          last7days,
           marketCap: transferData.marketCap
             ? `$${Math.floor(
                 Number((isGnot ? 1000000000 * Number(transferData.usd) : transferData.marketCap) || 0),

--- a/packages/web/src/containers/token-list-container/token-list-graph-status.spec.ts
+++ b/packages/web/src/containers/token-list-container/token-list-graph-status.spec.ts
@@ -1,77 +1,38 @@
 import { MATH_NEGATIVE_TYPE } from "@constants/option.constant";
-import { type Last7dPricePoint } from "@models/token/token-price-model";
-import { getLast7dGraphStatus, getLast7dGraphStatusFromPrices } from "./token-list-graph-status";
+import { getLast7dGraphStatus } from "./token-list-graph-status";
 
 describe("getLast7dGraphStatus", () => {
-  it("returns NEGATIVE when chronological first price is greater than last price", () => {
-    const last7d: Last7dPricePoint[] = [
-      { time: "2026-01-01T00:00:00Z", price: "10.000000000000000001" },
-      { time: "2026-01-02T00:00:00Z", price: "10.000000000000000000" },
-    ];
-
-    expect(getLast7dGraphStatus(last7d)).toBe(MATH_NEGATIVE_TYPE.NEGATIVE);
-  });
-
-  it("returns POSITIVE when chronological first price is less than last price", () => {
-    const last7d: Last7dPricePoint[] = [
-      { time: "2026-01-01T00:00:00Z", price: "1.25" },
-      { time: "2026-01-02T00:00:00Z", price: "2.5" },
-    ];
-
-    expect(getLast7dGraphStatus(last7d)).toBe(MATH_NEGATIVE_TYPE.POSITIVE);
-  });
-
-  it("returns POSITIVE when chronological first price equals last price", () => {
-    const last7d: Last7dPricePoint[] = [
-      { time: "2026-01-01T00:00:00Z", price: "3.000" },
-      { time: "2026-01-02T00:00:00Z", price: "3" },
-    ];
-
-    expect(getLast7dGraphStatus(last7d)).toBe(MATH_NEGATIVE_TYPE.POSITIVE);
-  });
-
-  it("sorts by time before comparing and does not mutate the input", () => {
-    const last7d: Last7dPricePoint[] = [
-      { time: "2026-01-03T00:00:00Z", price: "5" },
-      { time: "2026-01-01T00:00:00Z", price: "10" },
-      { time: "2026-01-02T00:00:00Z", price: "7" },
-    ];
-    const originalOrder = last7d.map(item => item.time);
-
-    expect(getLast7dGraphStatus(last7d)).toBe(MATH_NEGATIVE_TYPE.NEGATIVE);
-    expect(last7d.map(item => item.time)).toEqual(originalOrder);
-  });
-
-  it("returns NONE for empty last7d data", () => {
-    expect(getLast7dGraphStatus([])).toBe(MATH_NEGATIVE_TYPE.NONE);
-  });
-
-  it("returns NONE when last7d has no usable prices", () => {
-    const last7d: Last7dPricePoint[] = [
-      { time: "2026-01-01T00:00:00Z", price: "" },
-      { time: "2026-01-02T00:00:00Z", price: "not-a-number" },
-    ];
-
-    expect(getLast7dGraphStatus(last7d)).toBe(MATH_NEGATIVE_TYPE.NONE);
-  });
-});
-
-describe("getLast7dGraphStatusFromPrices", () => {
   it("returns NEGATIVE when appended latest price makes the rendered graph end lower", () => {
     const renderedPrices = [10, 12, 11, 8];
 
-    expect(getLast7dGraphStatusFromPrices(renderedPrices)).toBe(MATH_NEGATIVE_TYPE.NEGATIVE);
+    expect(getLast7dGraphStatus(renderedPrices)).toBe(MATH_NEGATIVE_TYPE.NEGATIVE);
   });
 
   it("returns POSITIVE when appended latest price makes the rendered graph end higher", () => {
     const renderedPrices = [10, 8, 9, 12];
 
-    expect(getLast7dGraphStatusFromPrices(renderedPrices)).toBe(MATH_NEGATIVE_TYPE.POSITIVE);
+    expect(getLast7dGraphStatus(renderedPrices)).toBe(MATH_NEGATIVE_TYPE.POSITIVE);
+  });
+
+  it("returns POSITIVE when first price equals final price", () => {
+    const renderedPrices = [3, 2, 3];
+
+    expect(getLast7dGraphStatus(renderedPrices)).toBe(MATH_NEGATIVE_TYPE.POSITIVE);
+  });
+
+  it("returns NONE for empty rendered prices", () => {
+    expect(getLast7dGraphStatus([])).toBe(MATH_NEGATIVE_TYPE.NONE);
+  });
+
+  it("returns NONE when rendered prices have no usable values", () => {
+    const renderedPrices = [Number.NaN, Number.POSITIVE_INFINITY];
+
+    expect(getLast7dGraphStatus(renderedPrices)).toBe(MATH_NEGATIVE_TYPE.NONE);
   });
 
   it("ignores unusable rendered prices before comparing the first and final usable values", () => {
     const renderedPrices = [Number.NaN, 5, Number.POSITIVE_INFINITY, 3];
 
-    expect(getLast7dGraphStatusFromPrices(renderedPrices)).toBe(MATH_NEGATIVE_TYPE.NEGATIVE);
+    expect(getLast7dGraphStatus(renderedPrices)).toBe(MATH_NEGATIVE_TYPE.NEGATIVE);
   });
 });

--- a/packages/web/src/containers/token-list-container/token-list-graph-status.spec.ts
+++ b/packages/web/src/containers/token-list-container/token-list-graph-status.spec.ts
@@ -1,6 +1,6 @@
 import { MATH_NEGATIVE_TYPE } from "@constants/option.constant";
 import { type Last7dPricePoint } from "@models/token/token-price-model";
-import { getLast7dGraphStatus } from "./token-list-graph-status";
+import { getLast7dGraphStatus, getLast7dGraphStatusFromPrices } from "./token-list-graph-status";
 
 describe("getLast7dGraphStatus", () => {
   it("returns NEGATIVE when chronological first price is greater than last price", () => {
@@ -53,5 +53,25 @@ describe("getLast7dGraphStatus", () => {
     ];
 
     expect(getLast7dGraphStatus(last7d)).toBe(MATH_NEGATIVE_TYPE.NONE);
+  });
+});
+
+describe("getLast7dGraphStatusFromPrices", () => {
+  it("returns NEGATIVE when appended latest price makes the rendered graph end lower", () => {
+    const renderedPrices = [10, 12, 11, 8];
+
+    expect(getLast7dGraphStatusFromPrices(renderedPrices)).toBe(MATH_NEGATIVE_TYPE.NEGATIVE);
+  });
+
+  it("returns POSITIVE when appended latest price makes the rendered graph end higher", () => {
+    const renderedPrices = [10, 8, 9, 12];
+
+    expect(getLast7dGraphStatusFromPrices(renderedPrices)).toBe(MATH_NEGATIVE_TYPE.POSITIVE);
+  });
+
+  it("ignores unusable rendered prices before comparing the first and final usable values", () => {
+    const renderedPrices = [Number.NaN, 5, Number.POSITIVE_INFINITY, 3];
+
+    expect(getLast7dGraphStatusFromPrices(renderedPrices)).toBe(MATH_NEGATIVE_TYPE.NEGATIVE);
   });
 });

--- a/packages/web/src/containers/token-list-container/token-list-graph-status.ts
+++ b/packages/web/src/containers/token-list-container/token-list-graph-status.ts
@@ -1,13 +1,5 @@
 import { MATH_NEGATIVE_TYPE } from "@constants/option.constant";
-import { type Last7dPricePoint } from "@models/token/token-price-model";
 import BigNumber from "bignumber.js";
-
-const isUsablePricePoint = (item: Last7dPricePoint) => {
-  const time = new Date(item.time).getTime();
-  const price = BigNumber(item.price);
-
-  return Number.isFinite(time) && item.price !== "" && !price.isNaN() && price.isFinite();
-};
 
 const isUsablePrice = (priceValue: BigNumber.Value) => {
   const price = BigNumber(priceValue);
@@ -15,7 +7,7 @@ const isUsablePrice = (priceValue: BigNumber.Value) => {
   return !price.isNaN() && price.isFinite();
 };
 
-export const getLast7dGraphStatusFromPrices = (prices?: readonly BigNumber.Value[] | null): MATH_NEGATIVE_TYPE => {
+export const getLast7dGraphStatus = (prices?: readonly BigNumber.Value[] | null): MATH_NEGATIVE_TYPE => {
   const usablePrices = (prices ?? []).filter(isUsablePrice);
 
   if (usablePrices.length === 0) {
@@ -26,13 +18,4 @@ export const getLast7dGraphStatusFromPrices = (prices?: readonly BigNumber.Value
   const lastPrice = BigNumber(usablePrices[usablePrices.length - 1]);
 
   return firstPrice.isGreaterThan(lastPrice) ? MATH_NEGATIVE_TYPE.NEGATIVE : MATH_NEGATIVE_TYPE.POSITIVE;
-};
-
-export const getLast7dGraphStatus = (last7d?: readonly Last7dPricePoint[] | null): MATH_NEGATIVE_TYPE => {
-  const sortedLast7d = [...(last7d ?? [])].sort(
-    (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime(),
-  );
-  const usableLast7d = sortedLast7d.filter(isUsablePricePoint);
-
-  return getLast7dGraphStatusFromPrices(usableLast7d.map(item => item.price));
 };

--- a/packages/web/src/containers/token-list-container/token-list-graph-status.ts
+++ b/packages/web/src/containers/token-list-container/token-list-graph-status.ts
@@ -9,18 +9,30 @@ const isUsablePricePoint = (item: Last7dPricePoint) => {
   return Number.isFinite(time) && item.price !== "" && !price.isNaN() && price.isFinite();
 };
 
+const isUsablePrice = (priceValue: BigNumber.Value) => {
+  const price = BigNumber(priceValue);
+
+  return !price.isNaN() && price.isFinite();
+};
+
+export const getLast7dGraphStatusFromPrices = (prices?: readonly BigNumber.Value[] | null): MATH_NEGATIVE_TYPE => {
+  const usablePrices = (prices ?? []).filter(isUsablePrice);
+
+  if (usablePrices.length === 0) {
+    return MATH_NEGATIVE_TYPE.NONE;
+  }
+
+  const firstPrice = BigNumber(usablePrices[0]);
+  const lastPrice = BigNumber(usablePrices[usablePrices.length - 1]);
+
+  return firstPrice.isGreaterThan(lastPrice) ? MATH_NEGATIVE_TYPE.NEGATIVE : MATH_NEGATIVE_TYPE.POSITIVE;
+};
+
 export const getLast7dGraphStatus = (last7d?: readonly Last7dPricePoint[] | null): MATH_NEGATIVE_TYPE => {
   const sortedLast7d = [...(last7d ?? [])].sort(
     (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime(),
   );
   const usableLast7d = sortedLast7d.filter(isUsablePricePoint);
 
-  if (usableLast7d.length === 0) {
-    return MATH_NEGATIVE_TYPE.NONE;
-  }
-
-  const firstPrice = BigNumber(usableLast7d[0].price);
-  const lastPrice = BigNumber(usableLast7d[usableLast7d.length - 1].price);
-
-  return firstPrice.isGreaterThan(lastPrice) ? MATH_NEGATIVE_TYPE.NEGATIVE : MATH_NEGATIVE_TYPE.POSITIVE;
+  return getLast7dGraphStatusFromPrices(usableLast7d.map(item => item.price));
 };


### PR DESCRIPTION
## Summary
- Compute token list graph status from the same rendered Last 7 Days data passed to `SimpleLineGraph`.
- Include the appended `pricesBefore.latestPrice` point when deciding positive/negative graph color.
- Add focused tests for rendered-price status calculation.

## Verification
- `yarn jest --runInBand src/containers/token-list-container/token-list-graph-status.spec.ts`
- `yarn next lint --file src/containers/token-list-container/TokenListContainer.tsx --file src/containers/token-list-container/token-list-graph-status.ts`
- LSP diagnostics clean for changed files
- `GIT_MASTER=1 git diff --check`

## Note
- `yarn tsc -p tsconfig.json --noEmit` still fails on existing unrelated spec type errors outside this change.