### PR TITLE
fix(pool): truncate earn add token symbols

### DIFF
--- a/packages/web/src/components/common/select-tab/SelectTab.spec.tsx
+++ b/packages/web/src/components/common/select-tab/SelectTab.spec.tsx
@@ -23,8 +23,8 @@ describe("SelectTab Component", () => {
           <SelectTab
             selectType="LONGTOKEN01"
             list={[
-              { value: "LONGTOKEN01", display: "LONGTOKEN..." },
-              { value: "ANOTHERLONGTOKEN", display: "ANOTHERLO..." },
+              { display: "LONGTOKEN...", key: "LONGTOKEN01" },
+              { display: "ANOTHERLO...", key: "ANOTHERLONGTOKEN" },
             ]}
             onClick={(type: string) => {
               clickedType = type;

--- a/packages/web/src/components/common/select-tab/SelectTab.spec.tsx
+++ b/packages/web/src/components/common/select-tab/SelectTab.spec.tsx
@@ -1,5 +1,5 @@
 import SelectTab from "./SelectTab";
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
 import { Provider as JotaiProvider } from "jotai";
 
@@ -12,5 +12,30 @@ describe("SelectTab Component", () => {
         </GnoswapThemeProvider>
       </JotaiProvider>,
     );
+  });
+
+  it("renders display labels while preserving raw values for clicks", () => {
+    let clickedType = "";
+
+    render(
+      <JotaiProvider>
+        <GnoswapThemeProvider>
+          <SelectTab
+            selectType="LONGTOKEN01"
+            list={[
+              { value: "LONGTOKEN01", display: "LONGTOKEN…" },
+              { value: "ANOTHERLONGTOKEN", display: "ANOTHERLO…" },
+            ]}
+            onClick={(type: string) => {
+              clickedType = type;
+            }}
+          />
+        </GnoswapThemeProvider>
+      </JotaiProvider>,
+    );
+
+    expect((screen.getByText("LONGTOKEN…") as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(screen.getByText("ANOTHERLO…"));
+    expect(clickedType).toBe("ANOTHERLONGTOKEN");
   });
 });

--- a/packages/web/src/components/common/select-tab/SelectTab.spec.tsx
+++ b/packages/web/src/components/common/select-tab/SelectTab.spec.tsx
@@ -23,8 +23,8 @@ describe("SelectTab Component", () => {
           <SelectTab
             selectType="LONGTOKEN01"
             list={[
-              { value: "LONGTOKEN01", display: "LONGTOKEN…" },
-              { value: "ANOTHERLONGTOKEN", display: "ANOTHERLO…" },
+              { value: "LONGTOKEN01", display: "LONGTOKEN..." },
+              { value: "ANOTHERLONGTOKEN", display: "ANOTHERLO..." },
             ]}
             onClick={(type: string) => {
               clickedType = type;
@@ -34,8 +34,8 @@ describe("SelectTab Component", () => {
       </JotaiProvider>,
     );
 
-    expect((screen.getByText("LONGTOKEN…") as HTMLButtonElement).disabled).toBe(true);
-    fireEvent.click(screen.getByText("ANOTHERLO…"));
+    expect((screen.getByText("LONGTOKEN...") as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(screen.getByText("ANOTHERLO..."));
     expect(clickedType).toBe("ANOTHERLONGTOKEN");
   });
 });

--- a/packages/web/src/components/common/select-tab/SelectTab.tsx
+++ b/packages/web/src/components/common/select-tab/SelectTab.tsx
@@ -2,13 +2,13 @@ import { SelectButton, SelectTabWrapper } from "./SelectTab.styles";
 import { cx } from "@emotion/css";
 import { useTranslation } from "react-i18next";
 export interface SelectTabItem {
-  value: string;
   display: string;
+  key: string;
 }
 
 interface SelectTabProps {
   selectType: string;
-  list: Array<string | SelectTabItem>;
+  list: string[] | SelectTabItem[];
   onClick: (type: string) => void;
   buttonClassName?: string;
 }
@@ -19,7 +19,7 @@ const SelectTab: React.FC<SelectTabProps> = ({ selectType, list, onClick, button
   return (
     <SelectTabWrapper className="select-tab-wrapper">
       {list.map((item, idx) => {
-        const value = typeof item === "string" ? item : item.value;
+        const value = typeof item === "string" ? item : item.key;
         const display = typeof item === "string" ? t(item) : item.display;
 
         return (

--- a/packages/web/src/components/common/select-tab/SelectTab.tsx
+++ b/packages/web/src/components/common/select-tab/SelectTab.tsx
@@ -1,9 +1,14 @@
 import { SelectButton, SelectTabWrapper } from "./SelectTab.styles";
 import { cx } from "@emotion/css";
 import { useTranslation } from "react-i18next";
+export interface SelectTabItem {
+  value: string;
+  display: string;
+}
+
 interface SelectTabProps {
   selectType: string;
-  list: string[];
+  list: Array<string | SelectTabItem>;
   onClick: (type: string) => void;
   buttonClassName?: string;
 }
@@ -13,19 +18,24 @@ const SelectTab: React.FC<SelectTabProps> = ({ selectType, list, onClick, button
 
   return (
     <SelectTabWrapper className="select-tab-wrapper">
-      {list.map((type, idx) => (
-        <SelectButton
-          key={idx}
-          className={cx({
-            selected: type === selectType,
-            [`${buttonClassName}`]: buttonClassName !== undefined,
-          })}
-          onClick={() => onClick(type)}
-          disabled={type === selectType}
-        >
-          {t(type)}
-        </SelectButton>
-      ))}
+      {list.map((item, idx) => {
+        const value = typeof item === "string" ? item : item.value;
+        const display = typeof item === "string" ? t(item) : item.display;
+
+        return (
+          <SelectButton
+            key={idx}
+            className={cx({
+              selected: value === selectType,
+              [`${buttonClassName}`]: buttonClassName !== undefined,
+            })}
+            onClick={() => onClick(value)}
+            disabled={value === selectType}
+          >
+            {display}
+          </SelectButton>
+        );
+      })}
     </SelectTabWrapper>
   );
 };

--- a/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
@@ -328,8 +328,8 @@ export const usePoolAddLiquidityConfirmModal = ({
 
     broadcastLoading(
       getMessage(DexEvent.ADD, "pending", {
-        tokenASymbol: tokenA?.symbol,
-        tokenBSymbol: tokenB?.symbol,
+        tokenASymbol: tokenA?.displaySymbol,
+        tokenBSymbol: tokenB?.displaySymbol,
         tokenAAmount: Number(tokenAAmount).toLocaleString("en-US", {
           maximumFractionDigits: tokenA.decimals,
         }),
@@ -370,8 +370,8 @@ export const usePoolAddLiquidityConfirmModal = ({
             formatData: response => {
               if (!response) {
                 return {
-                  tokenASymbol: tokenA?.symbol,
-                  tokenBSymbol: tokenB?.symbol,
+                  tokenASymbol: tokenA?.displaySymbol,
+                  tokenBSymbol: tokenB?.displaySymbol,
                   tokenAAmount: Number(tokenAAmount).toLocaleString("en-US", {
                     maximumFractionDigits: tokenA.decimals,
                   }),
@@ -382,8 +382,8 @@ export const usePoolAddLiquidityConfirmModal = ({
               }
 
               return {
-                tokenASymbol: tokenA?.symbol,
-                tokenBSymbol: tokenB?.symbol,
+                tokenASymbol: tokenA?.displaySymbol,
+                tokenBSymbol: tokenB?.displaySymbol,
                 tokenAAmount: Number(tokenAAmount).toLocaleString("en-US", {
                   maximumFractionDigits: tokenA.decimals,
                 }),
@@ -410,8 +410,8 @@ export const usePoolAddLiquidityConfirmModal = ({
               DexEvent.ADD,
               "success",
               {
-                tokenASymbol: tokenA?.symbol || "",
-                tokenBSymbol: tokenB?.symbol || "",
+                tokenASymbol: tokenA?.displaySymbol || "",
+                tokenBSymbol: tokenB?.displaySymbol || "",
                 tokenAAmount: Number(tokenAAmount).toLocaleString("en-US", {
                   maximumFractionDigits: tokenA.decimals,
                 }),
@@ -429,8 +429,8 @@ export const usePoolAddLiquidityConfirmModal = ({
         ) {
           broadcastRejected(
             getMessage(DexEvent.ADD, "error", {
-              tokenASymbol: tokenA?.symbol,
-              tokenBSymbol: tokenB?.symbol,
+              tokenASymbol: tokenA?.displaySymbol,
+              tokenBSymbol: tokenB?.displaySymbol,
               tokenAAmount: Number(tokenAAmount).toLocaleString("en-US", {
                 maximumFractionDigits: tokenA.decimals,
               }),

--- a/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustom.tsx
+++ b/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustom.tsx
@@ -294,11 +294,17 @@ const SelectPriceRangeCustom = forwardRef<SelectPriceRangeCustomHandle, SelectPr
 
     const selectTokenPair = useMemo(() => {
       if (!isKeepToken) {
-        return [getGnotPath(tokenB).symbol, getGnotPath(tokenA).symbol];
+        return [
+          { value: getGnotPath(tokenB).symbol, display: getGnotPath(tokenB).displaySymbol },
+          { value: getGnotPath(tokenA).symbol, display: getGnotPath(tokenA).displaySymbol },
+        ];
       }
 
-      return [getGnotPath(tokenA).symbol, getGnotPath(tokenB).symbol];
-    }, [tokenA, tokenB, isKeepToken]);
+      return [
+        { value: getGnotPath(tokenA).symbol, display: getGnotPath(tokenA).displaySymbol },
+        { value: getGnotPath(tokenB).symbol, display: getGnotPath(tokenB).displaySymbol },
+      ];
+    }, [getGnotPath, tokenA, tokenB, isKeepToken]);
 
     const decimalsRatio = useMemo(() => {
       return tokenA.decimals - tokenB.decimals;
@@ -316,8 +322,8 @@ const SelectPriceRangeCustom = forwardRef<SelectPriceRangeCustomHandle, SelectPr
       <>
         {selectPool.isCreate && (
           <StartingPrice
-            tokenASymbol={tokenA.symbol || ""}
-            tokenBSymbol={tokenB.symbol || ""}
+            tokenASymbol={tokenA.displaySymbol || ""}
+            tokenBSymbol={tokenB.displaySymbol || ""}
             isEmptyLiquidity={isEmptyLiquidity}
             defaultPrice={defaultPrice}
             startingPriceValue={startingPriceValue}
@@ -431,8 +437,8 @@ const SelectPriceRangeCustom = forwardRef<SelectPriceRangeCustomHandle, SelectPr
                       <PriceSteps
                         title={t("AddPosition:form.priceRange.minPrice")}
                         current={selectPool.minPrice}
-                        token0Symbol={tokenA.symbol}
-                        token1Symbol={tokenB.symbol}
+                        token0Symbol={tokenA.displaySymbol}
+                        token1Symbol={tokenB.displaySymbol}
                         tickSpacing={selectPool.tickSpacing}
                         feeTier={selectPool.feeTier || "NONE"}
                         selectedFullRange={selectPool.selectedFullRange}
@@ -447,8 +453,8 @@ const SelectPriceRangeCustom = forwardRef<SelectPriceRangeCustomHandle, SelectPr
                       <PriceSteps
                         title={t("AddPosition:form.priceRange.maxPrice")}
                         current={selectPool.maxPrice}
-                        token0Symbol={tokenA.symbol}
-                        token1Symbol={tokenB.symbol}
+                        token0Symbol={tokenA.displaySymbol}
+                        token1Symbol={tokenB.displaySymbol}
                         tickSpacing={selectPool.tickSpacing}
                         feeTier={selectPool.feeTier || "NONE"}
                         selectedFullRange={selectPool.selectedFullRange}

--- a/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustom.tsx
+++ b/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustom.tsx
@@ -295,14 +295,14 @@ const SelectPriceRangeCustom = forwardRef<SelectPriceRangeCustomHandle, SelectPr
     const selectTokenPair = useMemo(() => {
       if (!isKeepToken) {
         return [
-          { value: getGnotPath(tokenB).symbol, display: getGnotPath(tokenB).displaySymbol },
-          { value: getGnotPath(tokenA).symbol, display: getGnotPath(tokenA).displaySymbol },
+          { display: getGnotPath(tokenB).displaySymbol, key: getGnotPath(tokenB).symbol },
+          { display: getGnotPath(tokenA).displaySymbol, key: getGnotPath(tokenA).symbol },
         ];
       }
 
       return [
-        { value: getGnotPath(tokenA).symbol, display: getGnotPath(tokenA).displaySymbol },
-        { value: getGnotPath(tokenB).symbol, display: getGnotPath(tokenB).displaySymbol },
+        { display: getGnotPath(tokenA).displaySymbol, key: getGnotPath(tokenA).symbol },
+        { display: getGnotPath(tokenB).displaySymbol, key: getGnotPath(tokenB).symbol },
       ];
     }, [getGnotPath, tokenA, tokenB, isKeepToken]);
 

--- a/packages/web/src/layouts/pool/pool-add/components/additional-info/exchange-rate-graph/pair-ratio/PairRatio.tsx
+++ b/packages/web/src/layouts/pool/pool-add/components/additional-info/exchange-rate-graph/pair-ratio/PairRatio.tsx
@@ -65,7 +65,7 @@ export function PairRatio({
     <PairRatioWrapper>
       {!loading && (
         <MissingLogo
-          symbol={!isSwap ? pool.tokenA?.symbol : pool.tokenB?.symbol}
+          symbol={replaceGnotSymbol(!isSwap ? pool.tokenA?.symbol : pool.tokenB?.symbol)}
           url={!isSwap ? pool.tokenA?.logoURI : pool.tokenB?.logoURI}
           width={20}
           className="image-logo"

--- a/packages/web/src/layouts/pool/pool-add/components/additional-info/exchange-rate-graph/pair-ratio/PairRatio.tsx
+++ b/packages/web/src/layouts/pool/pool-add/components/additional-info/exchange-rate-graph/pair-ratio/PairRatio.tsx
@@ -36,12 +36,12 @@ export function PairRatio({
   overrideValue,
 }: PairRatioProps) {
   const displayTokenSymbol = useMemo(
-    () => replaceGnotSymbol(!isSwap ? pool.tokenA?.symbol : pool.tokenB?.symbol),
-    [isSwap, pool.tokenA?.symbol, pool.tokenB?.symbol],
+    () => replaceGnotSymbol(!isSwap ? pool.tokenA?.displaySymbol : pool.tokenB?.displaySymbol),
+    [isSwap, pool.tokenA?.displaySymbol, pool.tokenB?.displaySymbol],
   );
   const secondTokenSymbol = useMemo(
-    () => replaceGnotSymbol(isSwap ? pool.tokenA?.symbol : pool.tokenB?.symbol),
-    [isSwap, pool.tokenA?.symbol, pool.tokenB?.symbol],
+    () => replaceGnotSymbol(isSwap ? pool.tokenA?.displaySymbol : pool.tokenB?.displaySymbol),
+    [isSwap, pool.tokenA?.displaySymbol, pool.tokenB?.displaySymbol],
   );
 
   function formatExchangeRate(value: number, options?: { feeTier?: SwapFeeTierType }) {
@@ -65,7 +65,7 @@ export function PairRatio({
     <PairRatioWrapper>
       {!loading && (
         <MissingLogo
-          symbol={displayTokenSymbol}
+          symbol={!isSwap ? pool.tokenA?.symbol : pool.tokenB?.symbol}
           url={!isSwap ? pool.tokenA?.logoURI : pool.tokenB?.logoURI}
           width={20}
           className="image-logo"

--- a/packages/web/src/layouts/pool/pool-add/components/additional-info/quick-pool-info/QuickPoolInfo.tsx
+++ b/packages/web/src/layouts/pool/pool-add/components/additional-info/quick-pool-info/QuickPoolInfo.tsx
@@ -218,7 +218,7 @@ const QuickPoolInfo: React.FC<Props> = ({
     <QuickPoolInfoWrapper>
       <div className="token-pair">
         <OverlapTokenLogo tokens={[tokenA, tokenB]} size={24} />
-        <span className="token-name">{`${tokenA?.symbol}/${tokenB?.symbol}`}</span>
+        <span className="token-name">{`${tokenA?.displaySymbol}/${tokenB?.displaySymbol}`}</span>
       </div>
       {renderPositionInfo()}
       {(isStakable || canUnstake) && !isLoadingPool && <Divider />}

--- a/packages/web/src/layouts/pool/pool-add/containers/earn-add-liquidity-container/EarnAddLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-add/containers/earn-add-liquidity-container/EarnAddLiquidityContainer.tsx
@@ -133,8 +133,8 @@ const EarnAddLiquidityContainer: React.FC = () => {
     let estimatedApr: string = formatRate(selectPool.estimatedAPR) ?? "-";
 
     if (selectPool.selectedFullRange) {
-      const tokenASymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenA?.symbol : tokenB?.symbol;
-      const tokenBSymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenB?.symbol : tokenA?.symbol;
+      const tokenASymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenA?.displaySymbol : tokenB?.displaySymbol;
+      const tokenBSymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenB?.displaySymbol : tokenA?.displaySymbol;
       depositRatio = `50.0% ${tokenASymbol} / 50.0% ${tokenBSymbol}`;
       return {
         depositRatio,
@@ -147,8 +147,8 @@ const EarnAddLiquidityContainer: React.FC = () => {
     if (tokenAdepositRatio !== null) {
       const tokenARatioStr = BigNumber(tokenAdepositRatio).toFixed(1);
       const tokenBRatioStr = BigNumber(100 - tokenAdepositRatio).toFixed(1);
-      const tokenASymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenA?.symbol : tokenB?.symbol;
-      const tokenBSymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenB?.symbol : tokenA?.symbol;
+      const tokenASymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenA?.displaySymbol : tokenB?.displaySymbol;
+      const tokenBSymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenB?.displaySymbol : tokenA?.displaySymbol;
       depositRatio = `${tokenARatioStr}% ${tokenASymbol} / ${tokenBRatioStr}% ${tokenBSymbol}`;
     }
     if (tokenAdepositRatio === 0 || tokenAdepositRatio === 100) {
@@ -168,7 +168,8 @@ const EarnAddLiquidityContainer: React.FC = () => {
     selectPool.feeBoost,
     selectPool.selectedFullRange,
     tokenA?.symbol,
-    tokenB?.symbol,
+    tokenA?.displaySymbol,
+    tokenB?.displaySymbol,
     selectPool.estimatedAPR,
   ]);
 
@@ -537,8 +538,8 @@ const EarnAddLiquidityContainer: React.FC = () => {
     if (!initialized) {
       setInitialized(true);
       const query = router.query;
-      const currentTokenA = tokens.find(token => token.path === query.tokenA) || null;
-      const currentTokenB = tokens.find(token => token.path === query.tokenB) || null;
+      const currentTokenA = tokens.find((token: TokenModel) => token.path === query.tokenA) || null;
+      const currentTokenB = tokens.find((token: TokenModel) => token.path === query.tokenB) || null;
 
       setSwapValue({
         tokenA: currentTokenA,

--- a/packages/web/src/layouts/pool/pool-add/containers/pool-add-liquidity-container/PoolAddLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-add/containers/pool-add-liquidity-container/PoolAddLiquidityContainer.tsx
@@ -126,8 +126,8 @@ const PoolAddLiquidityContainer: React.FC = () => {
     let estimatedApr: string = formatRate(selectPool.estimatedAPR) ?? "-";
 
     if (selectPool.selectedFullRange) {
-      const tokenASymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenA?.symbol : tokenB?.symbol;
-      const tokenBSymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenB?.symbol : tokenA?.symbol;
+      const tokenASymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenA?.displaySymbol : tokenB?.displaySymbol;
+      const tokenBSymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenB?.displaySymbol : tokenA?.displaySymbol;
       depositRatio = `50.0% ${tokenASymbol} / 50.0% ${tokenBSymbol}`;
       return {
         depositRatio,
@@ -140,8 +140,8 @@ const PoolAddLiquidityContainer: React.FC = () => {
     if (tokenAdepositRatio !== null) {
       const tokenARatioStr = BigNumber(tokenAdepositRatio).toFixed(1);
       const tokenBRatioStr = BigNumber(100 - tokenAdepositRatio).toFixed(1);
-      const tokenASymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenA?.symbol : tokenB?.symbol;
-      const tokenBSymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenB?.symbol : tokenA?.symbol;
+      const tokenASymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenA?.displaySymbol : tokenB?.displaySymbol;
+      const tokenBSymbol = tokenA?.symbol === selectPool.compareToken?.symbol ? tokenB?.displaySymbol : tokenA?.displaySymbol;
       depositRatio = `${tokenARatioStr}% ${tokenASymbol} / ${tokenBRatioStr}% ${tokenBSymbol}`;
     }
     if (tokenAdepositRatio === 0 || tokenAdepositRatio === 100) {
@@ -161,7 +161,8 @@ const PoolAddLiquidityContainer: React.FC = () => {
     selectPool.feeBoost,
     selectPool.selectedFullRange,
     tokenA?.symbol,
-    tokenB?.symbol,
+    tokenA?.displaySymbol,
+    tokenB?.displaySymbol,
     selectPool.estimatedAPR,
   ]);
 
@@ -449,8 +450,8 @@ const PoolAddLiquidityContainer: React.FC = () => {
 
       const poolPath = router.getPoolPath() || "";
       const splitPath: string[] = poolPath.split(":") || [];
-      const currentTokenA = tokens.find(token => token.path === splitPath[0]) || null;
-      const currentTokenB = tokens.find(token => token.path === splitPath[1]) || null;
+      const currentTokenA = tokens.find((token: TokenModel) => token.path === splitPath[0]) || null;
+      const currentTokenB = tokens.find((token: TokenModel) => token.path === splitPath[1]) || null;
       const feeTier = makeSwapFeeTier(splitPath[2]);
       setSwapFeeTier(feeTier);
       setSwapValue(prev => ({

--- a/packages/web/src/utils/token-utils.spec.ts
+++ b/packages/web/src/utils/token-utils.spec.ts
@@ -27,16 +27,15 @@ const DEFAULT_TOKEN: TokenModel = {
 };
 
 describe("format display token symbol", () => {
-  it("should keep token symbols with 10 or fewer characters", () => {
+  it("should keep token symbols with 9 or fewer characters", () => {
     expect(formatDisplayTokenSymbol("GNOT")).toBe("GNOT");
     expect(formatDisplayTokenSymbol("123456789")).toBe("123456789");
-    expect(formatDisplayTokenSymbol("1234567890")).toBe("1234567890");
   });
 
-  it("should shorten token symbols longer than 10 characters", () => {
-    expect(formatDisplayTokenSymbol("12345678901")).toBe("123456789…");
+  it("should shorten token symbols longer than 9 characters", () => {
+    expect(formatDisplayTokenSymbol("1234567890")).toBe("123456789...");
     expect(formatDisplayTokenSymbol("ibc/488D610A5FB7878660703092A35BC4E7D0C88E2EA71174337AA317A22C05177F")).toBe(
-      "ibc/488D6…",
+      "ibc/488D6...",
     );
   });
 });

--- a/packages/web/src/utils/token-utils.spec.ts
+++ b/packages/web/src/utils/token-utils.spec.ts
@@ -27,14 +27,16 @@ const DEFAULT_TOKEN: TokenModel = {
 };
 
 describe("format display token symbol", () => {
-  it("should keep token symbols with 9 or fewer characters", () => {
+  it("should keep token symbols with 10 or fewer characters", () => {
     expect(formatDisplayTokenSymbol("GNOT")).toBe("GNOT");
     expect(formatDisplayTokenSymbol("123456789")).toBe("123456789");
+    expect(formatDisplayTokenSymbol("1234567890")).toBe("1234567890");
   });
 
-  it("should shorten token symbols longer than 9 characters", () => {
+  it("should shorten token symbols longer than 10 characters", () => {
+    expect(formatDisplayTokenSymbol("12345678901")).toBe("123456789…");
     expect(formatDisplayTokenSymbol("ibc/488D610A5FB7878660703092A35BC4E7D0C88E2EA71174337AA317A22C05177F")).toBe(
-      "ibc/488D6...",
+      "ibc/488D6…",
     );
   });
 });

--- a/packages/web/src/utils/token-utils.ts
+++ b/packages/web/src/utils/token-utils.ts
@@ -12,12 +12,12 @@ export interface RewardTokenModelWithMultipleTypes extends Omit<RewardTokenModel
   rewardType: RewardType | RewardType[];
 }
 
-export const TOKEN_DISPLAY_MAX_LENGTH = 10;
+export const TOKEN_DISPLAY_MAX_LENGTH = 9;
 
 export function formatDisplayTokenSymbol(symbol: string): string {
   if (symbol.length <= TOKEN_DISPLAY_MAX_LENGTH) return symbol;
 
-  return `${symbol.slice(0, TOKEN_DISPLAY_MAX_LENGTH - 1)}…`;
+  return `${symbol.slice(0, TOKEN_DISPLAY_MAX_LENGTH)}...`;
 }
 
 export function makeRawTokenAmount(token: TokenModel, amount: string | number) {

--- a/packages/web/src/utils/token-utils.ts
+++ b/packages/web/src/utils/token-utils.ts
@@ -12,12 +12,12 @@ export interface RewardTokenModelWithMultipleTypes extends Omit<RewardTokenModel
   rewardType: RewardType | RewardType[];
 }
 
-export const TOKEN_DISPLAY_MAX_LENGTH = 9;
+export const TOKEN_DISPLAY_MAX_LENGTH = 10;
 
 export function formatDisplayTokenSymbol(symbol: string): string {
   if (symbol.length <= TOKEN_DISPLAY_MAX_LENGTH) return symbol;
 
-  return `${symbol.slice(0, TOKEN_DISPLAY_MAX_LENGTH)}...`;
+  return `${symbol.slice(0, TOKEN_DISPLAY_MAX_LENGTH - 1)}…`;
 }
 
 export function makeRawTokenAmount(token: TokenModel, amount: string | number) {


### PR DESCRIPTION
## Summary
- Keep the existing token display cutoff behavior: symbols longer than 9 characters are truncated to 9 characters plus plain `...`.
- Apply `displaySymbol` across `/earn/add` pool info, starting/current price, token switch labels, min/max price, deposit ratio, and add-liquidity broadcast messages.
- Preserve raw token symbols for selection values, comparisons, token identity, logo lookup, and transaction logic.

## Tests
- `yarn workspace @gnoswap-labs/web test:ci --runInBand packages/web/src/utils/token-utils.spec.ts packages/web/src/components/common/select-tab/SelectTab.spec.tsx`
- `yarn workspace @gnoswap-labs/web test:ci --runInBand`
- `yarn build`
- `yarn workspace @gnoswap-labs/web lint --file ...` (changed files only; warnings only)

## Notes
- Full `yarn workspace @gnoswap-labs/web lint` is currently blocked by existing unrelated lint errors in `src/hooks/common/use-click-outside.tsx` and `src/hooks/common/use-delay-loading.tsx`.