### PR TITLE
fix(governance): claim launchpad protocol fees

### DIFF
--- a/packages/web/src/hooks/governance/data/use-governance-tx.tsx
+++ b/packages/web/src/hooks/governance/data/use-governance-tx.tsx
@@ -46,9 +46,7 @@ export const useGovernanceTx = () => {
       target?: string;
       memo0?: string;
     },
-    formatData: (
-      result: string[] | null,
-    ) => {
+    formatData: (result: string[] | null) => {
       tokenASymbol?: string;
       tokenBSymbol?: string;
       tokenAAmount?: string;
@@ -195,7 +193,12 @@ export const useGovernanceTx = () => {
     );
   };
 
-  const collectReward = (usdValue: string, claimLaunchpadProtocolFees: boolean, emitCallback: () => Promise<void>) => {
+  const collectReward = (
+    usdValue: string,
+    claimGovernanceRewards: boolean,
+    claimLaunchpadProtocolFees: boolean,
+    emitCallback: () => Promise<void>,
+  ) => {
     if (!account) {
       return;
     }
@@ -205,7 +208,7 @@ export const useGovernanceTx = () => {
     };
 
     processTx(
-      () => governanceRepository.sendCollectReward(claimLaunchpadProtocolFees),
+      () => governanceRepository.sendCollectReward(claimGovernanceRewards, claimLaunchpadProtocolFees),
       DexEvent.COLLECT_GOV_REWARD,
       messageData,
       () => messageData,

--- a/packages/web/src/hooks/governance/data/use-governance-tx.tsx
+++ b/packages/web/src/hooks/governance/data/use-governance-tx.tsx
@@ -196,7 +196,7 @@ export const useGovernanceTx = () => {
   const collectReward = (
     usdValue: string,
     claimGovernanceRewards: boolean,
-    claimLaunchpadProtocolFees: boolean,
+    claimLaunchpadRewards: boolean,
     emitCallback: () => Promise<void>,
   ) => {
     if (!account) {
@@ -208,7 +208,7 @@ export const useGovernanceTx = () => {
     };
 
     processTx(
-      () => governanceRepository.sendCollectReward(claimGovernanceRewards, claimLaunchpadProtocolFees),
+      () => governanceRepository.sendCollectReward(claimGovernanceRewards, claimLaunchpadRewards),
       DexEvent.COLLECT_GOV_REWARD,
       messageData,
       () => messageData,

--- a/packages/web/src/hooks/governance/data/use-governance-tx.tsx
+++ b/packages/web/src/hooks/governance/data/use-governance-tx.tsx
@@ -195,7 +195,7 @@ export const useGovernanceTx = () => {
     );
   };
 
-  const collectReward = (usdValue: string, emitCallback: () => Promise<void>) => {
+  const collectReward = (usdValue: string, claimLaunchpadProtocolFees: boolean, emitCallback: () => Promise<void>) => {
     if (!account) {
       return;
     }
@@ -205,7 +205,7 @@ export const useGovernanceTx = () => {
     };
 
     processTx(
-      () => governanceRepository.sendCollectReward(),
+      () => governanceRepository.sendCollectReward(claimLaunchpadProtocolFees),
       DexEvent.COLLECT_GOV_REWARD,
       messageData,
       () => messageData,

--- a/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
+++ b/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
@@ -1,3 +1,4 @@
+import BigNumber from "bignumber.js";
 import dayjs from "dayjs";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -47,7 +48,7 @@ interface MyDelegationProps {
   delegateGNS: (toName: string, toAddress: string, amount: string) => void;
   undelegateGNS: (fromName: string, fromAddress: string, amount: string) => void;
   collectUndelegated: (amount: string) => void;
-  collectReward: (usdValue: string) => void;
+  collectReward: (usdValue: string, claimLaunchpadProtocolFees: boolean) => void;
 }
 
 const MyDelegation: React.FC<MyDelegationProps> = ({
@@ -120,7 +121,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
   const hasMyUnDelegates = myUnDelegatesInfo.length > 0;
 
   const rewardInfo = useMemo(() => {
-    return myDelegationInfo.claimableRewards
+    return [...myDelegationInfo.claimableRewards, ...myDelegationInfo.launchpadProtocolFees]
       .map(reward => {
         const tokenInfo = tokens.find(token => token.path === reward.path);
         const displayAmount = rawToDisplayAmount(reward.amount, tokenInfo?.decimals || 0);
@@ -136,7 +137,13 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
         };
       })
       .sort((a, b) => b.usdValue - a.usdValue);
-  }, [myDelegationInfo.claimableRewards, getTokenUSDPrice, tokens, getGnotPath]);
+  }, [myDelegationInfo.claimableRewards, myDelegationInfo.launchpadProtocolFees, getTokenUSDPrice, tokens, getGnotPath]);
+
+  const totalClaimableRewardUsd = useMemo(() => {
+    return BigNumber(myDelegationInfo.claimableRewardUsd || 0)
+      .plus(myDelegationInfo.launchpadProtocolFeeUsd || 0)
+      .toString();
+  }, [myDelegationInfo.claimableRewardUsd, myDelegationInfo.launchpadProtocolFeeUsd]);
 
   const currentDelegatedDisplayAmount = useMemo(() => {
     return rawToDisplayAmount(myDelegationInfo.votingWeight, XGNS_TOKEN.decimals);
@@ -347,7 +354,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
                       <div className="reward-info-total">
                         <span className="label">{t("Governance:myDel.reward.title")}</span>
                         <span className="value">
-                          {formatOtherPrice(myDelegationInfo.claimableRewardUsd, { isKMB: false })}
+                          {formatOtherPrice(totalClaimableRewardUsd, { isKMB: false })}
                         </span>
                       </div>
                       {rewardInfo.map((reward, index) => {
@@ -370,7 +377,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
                   placement="top"
                 >
                   <div className={visibleRewardInfoTooltip ? "value-wrapper-for-hover" : "value-wrapper"}>
-                    {formatOtherPrice(myDelegationInfo.claimableRewardUsd, {
+                    {formatOtherPrice(totalClaimableRewardUsd, {
                       isKMB: false,
                     })}
                   </div>
@@ -383,9 +390,10 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
                       text: t("Governance:myDel.reward.btn"),
                       onClick: () => {
                         collectReward(
-                          formatOtherPrice(myDelegationInfo.claimableRewardUsd, {
+                          formatOtherPrice(totalClaimableRewardUsd, {
                             isKMB: false,
                           }),
+                          myDelegationInfo.launchpadProtocolFees.length > 0,
                         );
                       },
                       disabled: !visibleRewardInfoTooltip,

--- a/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
+++ b/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
@@ -48,7 +48,7 @@ interface MyDelegationProps {
   delegateGNS: (toName: string, toAddress: string, amount: string) => void;
   undelegateGNS: (fromName: string, fromAddress: string, amount: string) => void;
   collectUndelegated: (amount: string) => void;
-  collectReward: (usdValue: string, claimLaunchpadProtocolFees: boolean) => void;
+  collectReward: (usdValue: string, claimGovernanceRewards: boolean, claimLaunchpadProtocolFees: boolean) => void;
 }
 
 const MyDelegation: React.FC<MyDelegationProps> = ({
@@ -137,7 +137,13 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
         };
       })
       .sort((a, b) => b.usdValue - a.usdValue);
-  }, [myDelegationInfo.claimableRewards, myDelegationInfo.launchpadProtocolFees, getTokenUSDPrice, tokens, getGnotPath]);
+  }, [
+    myDelegationInfo.claimableRewards,
+    myDelegationInfo.launchpadProtocolFees,
+    getTokenUSDPrice,
+    tokens,
+    getGnotPath,
+  ]);
 
   const totalClaimableRewardUsd = useMemo(() => {
     return BigNumber(myDelegationInfo.claimableRewardUsd || 0)
@@ -353,9 +359,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
                     <MyDelegationRewardTooltipContent>
                       <div className="reward-info-total">
                         <span className="label">{t("Governance:myDel.reward.title")}</span>
-                        <span className="value">
-                          {formatOtherPrice(totalClaimableRewardUsd, { isKMB: false })}
-                        </span>
+                        <span className="value">{formatOtherPrice(totalClaimableRewardUsd, { isKMB: false })}</span>
                       </div>
                       {rewardInfo.map((reward, index) => {
                         const { tokenInfo } = reward;
@@ -393,6 +397,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
                           formatOtherPrice(totalClaimableRewardUsd, {
                             isKMB: false,
                           }),
+                          myDelegationInfo.claimableRewards.length > 0,
                           myDelegationInfo.launchpadProtocolFees.length > 0,
                         );
                       },

--- a/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
+++ b/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
@@ -48,7 +48,7 @@ interface MyDelegationProps {
   delegateGNS: (toName: string, toAddress: string, amount: string) => void;
   undelegateGNS: (fromName: string, fromAddress: string, amount: string) => void;
   collectUndelegated: (amount: string) => void;
-  collectReward: (usdValue: string, claimGovernanceRewards: boolean, claimLaunchpadProtocolFees: boolean) => void;
+  collectReward: (usdValue: string, claimGovernanceRewards: boolean, claimLaunchpadRewards: boolean) => void;
 }
 
 const MyDelegation: React.FC<MyDelegationProps> = ({
@@ -121,7 +121,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
   const hasMyUnDelegates = myUnDelegatesInfo.length > 0;
 
   const rewardInfo = useMemo(() => {
-    return [...myDelegationInfo.claimableRewards, ...myDelegationInfo.launchpadProtocolFees]
+    return [...myDelegationInfo.claimableGovernanceRewards, ...myDelegationInfo.claimableLaunchpadRewards]
       .map(reward => {
         const tokenInfo = tokens.find(token => token.path === reward.path);
         const displayAmount = rawToDisplayAmount(reward.amount, tokenInfo?.decimals || 0);
@@ -138,18 +138,18 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
       })
       .sort((a, b) => b.usdValue - a.usdValue);
   }, [
-    myDelegationInfo.claimableRewards,
-    myDelegationInfo.launchpadProtocolFees,
+    myDelegationInfo.claimableGovernanceRewards,
+    myDelegationInfo.claimableLaunchpadRewards,
     getTokenUSDPrice,
     tokens,
     getGnotPath,
   ]);
 
   const totalClaimableRewardUsd = useMemo(() => {
-    return BigNumber(myDelegationInfo.claimableRewardUsd || 0)
-      .plus(myDelegationInfo.launchpadProtocolFeeUsd || 0)
+    return BigNumber(myDelegationInfo.claimableGovernanceRewardUsd || 0)
+      .plus(myDelegationInfo.claimableLaunchpadRewardUsd || 0)
       .toString();
-  }, [myDelegationInfo.claimableRewardUsd, myDelegationInfo.launchpadProtocolFeeUsd]);
+  }, [myDelegationInfo.claimableGovernanceRewardUsd, myDelegationInfo.claimableLaunchpadRewardUsd]);
 
   const currentDelegatedDisplayAmount = useMemo(() => {
     return rawToDisplayAmount(myDelegationInfo.votingWeight, XGNS_TOKEN.decimals);
@@ -397,8 +397,8 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
                           formatOtherPrice(totalClaimableRewardUsd, {
                             isKMB: false,
                           }),
-                          myDelegationInfo.claimableRewards.length > 0,
-                          myDelegationInfo.launchpadProtocolFees.length > 0,
+                          myDelegationInfo.claimableGovernanceRewards.length > 0,
+                          myDelegationInfo.claimableLaunchpadRewards.length > 0,
                         );
                       },
                       disabled: !visibleRewardInfoTooltip,

--- a/packages/web/src/repositories/governance/governance-repository-impl.spec.ts
+++ b/packages/web/src/repositories/governance/governance-repository-impl.spec.ts
@@ -1,0 +1,86 @@
+jest.mock("@constants/environment.constant", () => ({
+  DEFAULT_CHAIN_ID: "test-chain",
+  GNS_TOKEN_PATH: "gns_token_path",
+  PACKAGE_GOVERNANCE_PATH: "governance_path",
+  PACKAGE_GOVERNANCE_STAKER_ADDRESS: "governance_staker_address",
+  PACKAGE_GOVERNANCE_STAKER_PATH: "governance_staker_path",
+  PACKAGE_LAUNCHPAD_PATH: "launchpad_path",
+  WRAPPED_GNOT_PATH: "wrapped_gnot_path",
+}));
+
+import { WalletClient } from "@common/clients/wallet-client";
+import { AdenaClient } from "@common/clients/wallet-client/adena/adena-client";
+import { GovernanceRepositoryImpl } from "./governance-repository-impl";
+
+const createWalletClient = () => {
+  const walletClient: WalletClient = new AdenaClient();
+
+  walletClient.getAddress = jest.fn().mockResolvedValue("caller");
+  walletClient.getWalletType = jest.fn().mockReturnValue("ADENA");
+  walletClient.addEstablishedSite = jest.fn().mockResolvedValue({
+    code: 0,
+    status: "success",
+    type: "CONNECTION_SUCCESS",
+    message: "connected",
+    data: {},
+  });
+  walletClient.sendTransaction = jest.fn().mockResolvedValue({
+    code: 0,
+    status: "success",
+    type: "TRANSACTION_SUCCESS",
+    message: "sent",
+    data: { hash: "hash" },
+  });
+
+  return walletClient;
+};
+
+describe("GovernanceRepositoryImpl", () => {
+  describe("sendCollectReward", () => {
+    it("sends only collect protocol fee when governance rewards are not claimed", async () => {
+      const walletClient = createWalletClient();
+      const governanceRepository = new GovernanceRepositoryImpl(null, walletClient, null);
+
+      await governanceRepository.sendCollectReward(false, true);
+
+      expect(walletClient.sendTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: [
+            expect.objectContaining({
+              caller: "caller",
+              pkg_path: "launchpad_path",
+              func: "CollectProtocolFee",
+              args: [],
+            }),
+          ],
+        }),
+      );
+    });
+
+    it("sends both collect reward and collect protocol fee when both are claimed", async () => {
+      const walletClient = createWalletClient();
+      const governanceRepository = new GovernanceRepositoryImpl(null, walletClient, null);
+
+      await governanceRepository.sendCollectReward(true, true);
+
+      expect(walletClient.sendTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: [
+            expect.objectContaining({
+              caller: "caller",
+              pkg_path: "governance_staker_path",
+              func: "CollectReward",
+              args: [],
+            }),
+            expect.objectContaining({
+              caller: "caller",
+              pkg_path: "launchpad_path",
+              func: "CollectProtocolFee",
+              args: [],
+            }),
+          ],
+        }),
+      );
+    });
+  });
+});

--- a/packages/web/src/repositories/governance/governance-repository-impl.ts
+++ b/packages/web/src/repositories/governance/governance-repository-impl.ts
@@ -434,12 +434,12 @@ export class GovernanceRepositoryImpl implements GovernanceRepository {
 
   public sendCollectReward = async (
     claimGovernanceRewards: boolean,
-    claimLaunchpadProtocolFees: boolean,
+    claimLaunchpadRewards: boolean,
   ): Promise<WalletResponse<{ hash: string }>> => {
     const caller = await this.getAddress();
     const messages = [
       ...(claimGovernanceRewards ? makeCollectRewardMessages({ caller }) : []),
-      ...(claimLaunchpadProtocolFees ? makeCollectProtocolFeeMessage({ caller }) : []),
+      ...(claimLaunchpadRewards ? makeCollectProtocolFeeMessage({ caller }) : []),
     ];
 
     const sendTransactionParams = generateSendTransactionParams({ messages, gasFee: DEFAULT_GAS_FEE, memo: "" });

--- a/packages/web/src/repositories/governance/governance-repository-impl.ts
+++ b/packages/web/src/repositories/governance/governance-repository-impl.ts
@@ -70,6 +70,7 @@ import {
   makeUnDelegateMessages,
   makeVoteMessages,
 } from "./governance.message";
+import { makeCollectProtocolFeeMessage } from "../launchpad/launchpad.message";
 
 export class GovernanceRepositoryImpl implements GovernanceRepository {
   private networkClient: NetworkClient | null;
@@ -431,9 +432,12 @@ export class GovernanceRepositoryImpl implements GovernanceRepository {
     });
   };
 
-  public sendCollectReward = async (): Promise<WalletResponse<{ hash: string }>> => {
+  public sendCollectReward = async (claimLaunchpadProtocolFees: boolean): Promise<WalletResponse<{ hash: string }>> => {
     const caller = await this.getAddress();
-    const messages = makeCollectRewardMessages({ caller });
+    const messages = [
+      ...makeCollectRewardMessages({ caller }),
+      ...(claimLaunchpadProtocolFees ? makeCollectProtocolFeeMessage({ caller }) : []),
+    ];
 
     const sendTransactionParams = generateSendTransactionParams({ messages, gasFee: DEFAULT_GAS_FEE, memo: "" });
 

--- a/packages/web/src/repositories/governance/governance-repository-impl.ts
+++ b/packages/web/src/repositories/governance/governance-repository-impl.ts
@@ -432,10 +432,13 @@ export class GovernanceRepositoryImpl implements GovernanceRepository {
     });
   };
 
-  public sendCollectReward = async (claimLaunchpadProtocolFees: boolean): Promise<WalletResponse<{ hash: string }>> => {
+  public sendCollectReward = async (
+    claimGovernanceRewards: boolean,
+    claimLaunchpadProtocolFees: boolean,
+  ): Promise<WalletResponse<{ hash: string }>> => {
     const caller = await this.getAddress();
     const messages = [
-      ...makeCollectRewardMessages({ caller }),
+      ...(claimGovernanceRewards ? makeCollectRewardMessages({ caller }) : []),
       ...(claimLaunchpadProtocolFees ? makeCollectProtocolFeeMessage({ caller }) : []),
     ];
 

--- a/packages/web/src/repositories/governance/governance-repository-mock.ts
+++ b/packages/web/src/repositories/governance/governance-repository-mock.ts
@@ -136,7 +136,7 @@ export class GovernanceRepositoryMock implements GovernanceRepository {
     throw new Error("Mock sendCollectUndelegated");
   };
 
-  public sendCollectReward = async (): Promise<WalletResponse<{ hash: string }>> => {
-    throw new Error("Mock sendCollectUndelegated");
+  public sendCollectReward = async (claimLaunchpadProtocolFees: boolean): Promise<WalletResponse<{ hash: string }>> => {
+    throw new Error(`Mock sendCollectReward : ${claimLaunchpadProtocolFees}`);
   };
 }

--- a/packages/web/src/repositories/governance/governance-repository-mock.ts
+++ b/packages/web/src/repositories/governance/governance-repository-mock.ts
@@ -138,8 +138,8 @@ export class GovernanceRepositoryMock implements GovernanceRepository {
 
   public sendCollectReward = async (
     claimGovernanceRewards: boolean,
-    claimLaunchpadProtocolFees: boolean,
+    claimLaunchpadRewards: boolean,
   ): Promise<WalletResponse<{ hash: string }>> => {
-    throw new Error(`Mock sendCollectReward : ${claimGovernanceRewards}, ${claimLaunchpadProtocolFees}`);
+    throw new Error(`Mock sendCollectReward : ${claimGovernanceRewards}, ${claimLaunchpadRewards}`);
   };
 }

--- a/packages/web/src/repositories/governance/governance-repository-mock.ts
+++ b/packages/web/src/repositories/governance/governance-repository-mock.ts
@@ -136,7 +136,10 @@ export class GovernanceRepositoryMock implements GovernanceRepository {
     throw new Error("Mock sendCollectUndelegated");
   };
 
-  public sendCollectReward = async (claimLaunchpadProtocolFees: boolean): Promise<WalletResponse<{ hash: string }>> => {
-    throw new Error(`Mock sendCollectReward : ${claimLaunchpadProtocolFees}`);
+  public sendCollectReward = async (
+    claimGovernanceRewards: boolean,
+    claimLaunchpadProtocolFees: boolean,
+  ): Promise<WalletResponse<{ hash: string }>> => {
+    throw new Error(`Mock sendCollectReward : ${claimGovernanceRewards}, ${claimLaunchpadProtocolFees}`);
   };
 }

--- a/packages/web/src/repositories/governance/governance-repository.ts
+++ b/packages/web/src/repositories/governance/governance-repository.ts
@@ -68,5 +68,8 @@ export interface GovernanceRepository {
 
   sendCollectUndelegated: () => Promise<WalletResponse<{ hash: string }>>;
 
-  sendCollectReward: (claimLaunchpadProtocolFees: boolean) => Promise<WalletResponse<{ hash: string }>>;
+  sendCollectReward: (
+    claimGovernanceRewards: boolean,
+    claimLaunchpadProtocolFees: boolean,
+  ) => Promise<WalletResponse<{ hash: string }>>;
 }

--- a/packages/web/src/repositories/governance/governance-repository.ts
+++ b/packages/web/src/repositories/governance/governance-repository.ts
@@ -70,6 +70,6 @@ export interface GovernanceRepository {
 
   sendCollectReward: (
     claimGovernanceRewards: boolean,
-    claimLaunchpadProtocolFees: boolean,
+    claimLaunchpadRewards: boolean,
   ) => Promise<WalletResponse<{ hash: string }>>;
 }

--- a/packages/web/src/repositories/governance/governance-repository.ts
+++ b/packages/web/src/repositories/governance/governance-repository.ts
@@ -68,5 +68,5 @@ export interface GovernanceRepository {
 
   sendCollectUndelegated: () => Promise<WalletResponse<{ hash: string }>>;
 
-  sendCollectReward: () => Promise<WalletResponse<{ hash: string }>>;
+  sendCollectReward: (claimLaunchpadProtocolFees: boolean) => Promise<WalletResponse<{ hash: string }>>;
 }

--- a/packages/web/src/repositories/governance/mock/get-my-delegation-response.json
+++ b/packages/web/src/repositories/governance/mock/get-my-delegation-response.json
@@ -15,6 +15,13 @@
     }
   ],
   "claimableRewardUsd": "2751.50",
+  "launchpadProtocolFees": [
+    {
+      "amount": "125.50",
+      "path": "ugnot"
+    }
+  ],
+  "launchpadProtocolFeeUsd": "125.50",
   "unDelegatedAmount": "45000.00",
   "withdrawableAmount": "32500.25",
   "votingWeight": "87.5"

--- a/packages/web/src/repositories/governance/mock/get-my-delegation-response.json
+++ b/packages/web/src/repositories/governance/mock/get-my-delegation-response.json
@@ -1,6 +1,6 @@
 {
   "availableBalance": "125500.75",
-  "claimableRewards": [
+  "claimableGovernanceRewards": [
     {
       "amount": "1250.50",
       "path": "ugnot"
@@ -14,14 +14,14 @@
       "path": "gno.land/r/gnoswap/gns"
     }
   ],
-  "claimableRewardUsd": "2751.50",
-  "launchpadProtocolFees": [
+  "claimableGovernanceRewardUsd": "2751.50",
+  "claimableLaunchpadRewards": [
     {
       "amount": "125.50",
       "path": "ugnot"
     }
   ],
-  "launchpadProtocolFeeUsd": "125.50",
+  "claimableLaunchpadRewardUsd": "125.50",
   "unDelegatedAmount": "45000.00",
   "withdrawableAmount": "32500.25",
   "votingWeight": "87.5"

--- a/packages/web/src/repositories/governance/model/my-delegation-info.ts
+++ b/packages/web/src/repositories/governance/model/my-delegation-info.ts
@@ -1,9 +1,9 @@
 export interface MyDelegationInfo {
   availableBalance: string;
-  claimableRewards: ClaimableRewards[];
-  claimableRewardUsd: string;
-  launchpadProtocolFees: ClaimableRewards[];
-  launchpadProtocolFeeUsd: string;
+  claimableGovernanceRewards: ClaimableRewards[];
+  claimableGovernanceRewardUsd: string;
+  claimableLaunchpadRewards: ClaimableRewards[];
+  claimableLaunchpadRewardUsd: string;
   unDelegatedAmount: string;
   withdrawableAmount: string;
   votingWeight: string;
@@ -16,10 +16,10 @@ export interface ClaimableRewards {
 
 export const nullMyDelegationInfo: MyDelegationInfo = {
   availableBalance: "0",
-  claimableRewards: [],
-  claimableRewardUsd: "0",
-  launchpadProtocolFees: [],
-  launchpadProtocolFeeUsd: "0",
+  claimableGovernanceRewards: [],
+  claimableGovernanceRewardUsd: "0",
+  claimableLaunchpadRewards: [],
+  claimableLaunchpadRewardUsd: "0",
   unDelegatedAmount: "0",
   withdrawableAmount: "0",
   votingWeight: "0",

--- a/packages/web/src/repositories/governance/model/my-delegation-info.ts
+++ b/packages/web/src/repositories/governance/model/my-delegation-info.ts
@@ -2,6 +2,8 @@ export interface MyDelegationInfo {
   availableBalance: string;
   claimableRewards: ClaimableRewards[];
   claimableRewardUsd: string;
+  launchpadProtocolFees: ClaimableRewards[];
+  launchpadProtocolFeeUsd: string;
   unDelegatedAmount: string;
   withdrawableAmount: string;
   votingWeight: string;
@@ -16,6 +18,8 @@ export const nullMyDelegationInfo: MyDelegationInfo = {
   availableBalance: "0",
   claimableRewards: [],
   claimableRewardUsd: "0",
+  launchpadProtocolFees: [],
+  launchpadProtocolFeeUsd: "0",
   unDelegatedAmount: "0",
   withdrawableAmount: "0",
   votingWeight: "0",

--- a/packages/web/src/repositories/governance/response/get-my-delegation-response.ts
+++ b/packages/web/src/repositories/governance/response/get-my-delegation-response.ts
@@ -4,6 +4,8 @@ export interface GetMyDelegationResponse {
   availableBalance: string;
   claimableRewards: ClaimableRewards[];
   claimableRewardUsd: string;
+  launchpadProtocolFees: ClaimableRewards[];
+  launchpadProtocolFeeUsd: string;
   unDelegatedAmount: string;
   withdrawableAmount: string;
   votingWeight: string;

--- a/packages/web/src/repositories/governance/response/get-my-delegation-response.ts
+++ b/packages/web/src/repositories/governance/response/get-my-delegation-response.ts
@@ -2,10 +2,10 @@ import { ClaimableRewards } from "../model";
 
 export interface GetMyDelegationResponse {
   availableBalance: string;
-  claimableRewards: ClaimableRewards[];
-  claimableRewardUsd: string;
-  launchpadProtocolFees: ClaimableRewards[];
-  launchpadProtocolFeeUsd: string;
+  claimableGovernanceRewards: ClaimableRewards[];
+  claimableGovernanceRewardUsd: string;
+  claimableLaunchpadRewards: ClaimableRewards[];
+  claimableLaunchpadRewardUsd: string;
   unDelegatedAmount: string;
   withdrawableAmount: string;
   votingWeight: string;

--- a/packages/web/src/repositories/launchpad/launchpad.message.spec.ts
+++ b/packages/web/src/repositories/launchpad/launchpad.message.spec.ts
@@ -4,7 +4,10 @@ jest.mock("@constants/environment.constant", () => ({
   PACKAGE_LAUNCHPAD_PATH: "launchpad_path",
 }));
 
-import { makeDepositGNSMessageWithApproves } from "@repositories/launchpad/launchpad.message";
+import {
+  makeCollectProtocolFeeMessage,
+  makeDepositGNSMessageWithApproves,
+} from "@repositories/launchpad/launchpad.message";
 
 describe("launchpad.message.ts", () => {
   it("approves launchpad deposits with the exact deposit amount", async () => {
@@ -27,6 +30,21 @@ describe("launchpad.message.ts", () => {
       pkg_path: "launchpad_path",
       func: "DepositGns",
       args: ["pool-1", "456000000", ""],
+    });
+  });
+
+  it("builds a collect protocol fee message", () => {
+    const caller = "caller";
+
+    const messages = makeCollectProtocolFeeMessage({ caller });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      caller,
+      pkg_path: "launchpad_path",
+      send: "",
+      func: "CollectProtocolFee",
+      args: [],
     });
   });
 });

--- a/packages/web/src/repositories/launchpad/launchpad.message.ts
+++ b/packages/web/src/repositories/launchpad/launchpad.message.ts
@@ -10,6 +10,7 @@ enum TransactionMessageFunctionType {
   DepositGns = "DepositGns",
   CollectRewardByDepositId = "CollectRewardByDepositId",
   CollectDepositGns = "CollectDepositGns",
+  CollectProtocolFee = "CollectProtocolFee",
 }
 
 export function makeDepositGNSMessageWithApproves(
@@ -134,4 +135,16 @@ export function makeCollectRewardWithDepositBydepositIDMessage({
   });
 
   return [collectRewardBydepositIDMessage, collectDepositGnsMessage];
+}
+
+export function makeCollectProtocolFeeMessage({ caller }: { caller: string }): TransactionMessage[] {
+  const collectProtocolFeeMessage = makeTransactionMessage({
+    packagePath: PACKAGE_LAUNCHPAD_PATH,
+    send: "",
+    func: TransactionMessageFunctionType.CollectProtocolFee,
+    args: [],
+    caller,
+  });
+
+  return [collectProtocolFeeMessage];
 }


### PR DESCRIPTION
## Summary
- Add launchpad protocol fee fields to the governance delegation model.
- Append launchpad CollectProtocolFee to Governance Claim All when launchpad protocol fees are available.
- Include launchpad protocol fees in the reward card total so launchpad-only rewards can still be claimed.

## Changes
- Added launchpadProtocolFees and launchpadProtocolFeeUsd to My Delegation response types and mocks.
- Added a launchpad CollectProtocolFee transaction message builder with coverage.
- Updated governance Claim All to send CollectReward first and conditionally append CollectProtocolFee.

## Validation
- yarn workspace @gnoswap-labs/web jest --runTestsByPath src/repositories/governance/governance.message.spec.ts src/repositories/launchpad/launchpad.message.spec.ts --runInBand
- yarn workspace @gnoswap-labs/web next lint --file changed frontend files
- yarn workspace @gnoswap-labs/web build
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claim both governance rewards and launchpad protocol fees in a single action.
  * Rewards UI shows combined total (governance + launchpad) and updates the claim button accordingly.

* **Tests**
  * Added tests covering protocol fee collection and combined-claim behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->