### PR TITLE
fix(launchpad): disable withdrawn claims

### DIFF
--- a/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-my-participation/LaunchpadMyParticipation.tsx
+++ b/packages/web/src/layouts/launchpad/launchpad-detail/components/launchpad-my-participation/LaunchpadMyParticipation.tsx
@@ -73,6 +73,7 @@ const LaunchpadMyParticipation = ({
         claimableTime: item.claimableTime,
         claimableRewardAmount: rawToDisplayAmount(item.claimableRewardAmount, rewardInfo.rewardTokenDecimals),
         depositAmount: rawToDisplayAmount(item.depositAmount, GNS_TOKEN.decimals),
+        withdrawn: item.withdrawn,
       });
     });
   }, [data, rewardInfo.rewardTokenDecimals]);

--- a/packages/web/src/models/launchpad/launchpad-participation-model.ts
+++ b/packages/web/src/models/launchpad/launchpad-participation-model.ts
@@ -41,4 +41,6 @@ export interface LaunchpadParticipationModel {
   claimedRewardAmount: number;
 
   depositApr: number | null;
+
+  withdrawn: boolean;
 }

--- a/packages/web/src/repositories/launchpad/mock/launchpad-participation-list.json
+++ b/packages/web/src/repositories/launchpad/mock/launchpad-participation-list.json
@@ -21,7 +21,8 @@
         "claimableBlockHeight": 300,
         "claimableRewardAmount": 1249249,
         "claimedRewardAmount": 200,
-        "depositApr": 5399.7217246
+        "depositApr": 5399.7217246,
+        "withdrawn": false
       },
       {
         "id": 1,
@@ -42,7 +43,8 @@
         "claimableBlockHeight": 300,
         "claimableRewardAmount": 1249249,
         "claimedRewardAmount": 200,
-        "depositApr": 5399.7217246
+        "depositApr": 5399.7217246,
+        "withdrawn": false
       }
     ]
   }

--- a/packages/web/src/utils/launchpad-claimable-participation.spec.ts
+++ b/packages/web/src/utils/launchpad-claimable-participation.spec.ts
@@ -1,0 +1,36 @@
+import { isLaunchpadParticipationClaimable } from "./launchpad-claimable-participation";
+
+describe("isLaunchpadParticipationClaimable", () => {
+  const now = new Date("2026-06-10T00:00:00.000Z").getTime();
+  const claimableTime = "2026-06-09T00:00:00.000Z";
+
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(now);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns false when backend marks participation withdrawn", () => {
+    const participation = {
+      claimableTime,
+      claimableRewardAmount: 100,
+      depositAmount: 100,
+      withdrawn: true,
+    };
+
+    expect(isLaunchpadParticipationClaimable(participation)).toBe(false);
+  });
+
+  it("uses amount and time rules when participation is not withdrawn", () => {
+    expect(
+      isLaunchpadParticipationClaimable({
+        claimableTime,
+        claimableRewardAmount: 100,
+        depositAmount: 100,
+        withdrawn: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/web/src/utils/launchpad-claimable-participation.ts
+++ b/packages/web/src/utils/launchpad-claimable-participation.ts
@@ -6,6 +6,7 @@ interface LaunchpadParticipationClaimState {
   claimableTime: string;
   claimableRewardAmount: number;
   depositAmount: number;
+  withdrawn: boolean;
 }
 
 const CLAIMED_AMOUNT_THRESHOLD = 0.01;
@@ -13,7 +14,7 @@ const CLAIMED_AMOUNT_THRESHOLD = 0.01;
 export const isLaunchpadParticipationClaimed = ({
   claimableRewardAmount,
   depositAmount,
-}: Omit<LaunchpadParticipationClaimState, "claimableTime">) => {
+}: Pick<LaunchpadParticipationClaimState, "claimableRewardAmount" | "depositAmount">) => {
   const isClaimedReward = BigNumber(claimableRewardAmount).isLessThan(CLAIMED_AMOUNT_THRESHOLD);
   const isClaimedDeposit = BigNumber(depositAmount).isLessThan(CLAIMED_AMOUNT_THRESHOLD);
 
@@ -24,7 +25,10 @@ export const isLaunchpadParticipationClaimable = ({
   claimableTime,
   claimableRewardAmount,
   depositAmount,
+  withdrawn,
 }: LaunchpadParticipationClaimState) => {
+  if (withdrawn) return false;
+
   const claimableTimestamp = safeParseTime(claimableTime);
 
   if (claimableTimestamp == null) return false;


### PR DESCRIPTION
## Summary
- Consume the Launchpad participation `withdrawn` field from the API contract.
- Disable individual Claim and Claim All eligibility when a participation is withdrawn.
- Add focused coverage for withdrawn claimability and update launchpad mock participation data.

## Tests
- `yarn workspace @gnoswap-labs/web jest src/utils/launchpad-claimable-participation.spec.ts --runInBand`
- `yarn workspace @gnoswap-labs/web next lint --file src/utils/launchpad-claimable-participation.ts --file src/utils/launchpad-claimable-participation.spec.ts --file src/models/launchpad/launchpad-participation-model.ts --file src/layouts/launchpad/launchpad-detail/components/launchpad-my-participation/LaunchpadMyParticipation.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launchpad participations now track withdrawal status, enabling better state management across the platform.

* **Bug Fixes**
  * Updated claim validation logic to account for withdrawal status during eligibility verification.

* **Tests**
  * Added test coverage for claim eligibility validation scenarios, including withdrawal status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->