### PR TITLE
fix(portfolio): apply reward token decimals

### DIFF
--- a/packages/web/src/layouts/portfolio/components/wallet-balance/wallet-balance-detail/WalletBalanceDetail.spec.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-balance/wallet-balance-detail/WalletBalanceDetail.spec.tsx
@@ -1,10 +1,13 @@
-import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
 import { Provider as JotaiProvider } from "jotai";
 
+import type { TokenModel } from "@models/token/token-model";
 import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
+import type { PositionRewardsResponse } from "@repositories/position/response";
 import { DEVICE_TYPE } from "@styles/media";
 
-import WalletBalanceDetail, { WalletBalanceDetailProps } from "./WalletBalanceDetail";
+import WalletBalanceDetail, { type WalletBalanceDetailProps } from "./WalletBalanceDetail";
 
 // Mock @adena-wallet/sdk
 jest.mock("@adena-wallet/sdk", () => ({
@@ -13,37 +16,144 @@ jest.mock("@adena-wallet/sdk", () => ({
   TransactionBuilder: jest.fn(),
 }));
 
-describe("WalletBalanceDetail Component", () => {
-  it("WalletBalanceDetail render", () => {
-    const mockProps: WalletBalanceDetailProps = {
-      balanceDetailInfo: {
-        availableBalance: "324,324.34",
-        stakedLP: "$2,453,251.20",
-        unstakedLP: "$132,423.34",
-        claimableRewards: "$1213.23",
-        loadingBalance: false,
-        loadingPositions: false,
-        totalClaimedRewards: "$1213.23",
-      },
-      connected: true,
-      claimAll: () => {
-        return;
-      },
-      breakpoint: DEVICE_TYPE.WEB,
-      isSwitchNetwork: false,
-      loadngTransactionClaim: false,
-      positions: [],
-      positionRewards: null,
-      tokens: [],
-      tokenPrices: {},
-    };
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
 
-    render(
+jest.mock("@components/common/tooltip/Tooltip", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    FloatingContent,
+    forcedClose,
+  }: {
+    children: ReactNode;
+    FloatingContent?: ReactNode;
+    forcedClose?: boolean;
+  }) => (
+    <>
+      {children}
+      {!forcedClose && FloatingContent}
+    </>
+  ),
+}));
+
+jest.mock("@hooks/token/data/use-gnot-wugnot", () => ({
+  useGnotToGnot: () => ({
+    getGnotPath: (token: TokenModel) => token,
+  }),
+}));
+
+describe("WalletBalanceDetail Component", () => {
+  const usdcToken: TokenModel = {
+    path: "gno.land/r/demo/usdc",
+    tokenId: "gno.land/r/demo/usdc.USDC",
+    type: "GRC20",
+    address: "",
+    chainId: "test-chain",
+    name: "USDC",
+    symbol: "USDC",
+    displaySymbol: "USDC",
+    decimals: 6,
+    logoURI: "",
+    createdAt: "",
+    priceID: "USDC",
+  };
+
+  const atomToken: TokenModel = {
+    path: "gno.land/r/demo/atom",
+    tokenId: "gno.land/r/demo/atom.ATOM",
+    type: "GRC20",
+    address: "",
+    chainId: "test-chain",
+    name: "ATOM",
+    symbol: "ATOM",
+    displaySymbol: "ATOM",
+    decimals: 18,
+    logoURI: "",
+    createdAt: "",
+    priceID: "ATOM",
+  };
+
+  const baseProps: WalletBalanceDetailProps = {
+    balanceDetailInfo: {
+      availableBalance: "324,324.34",
+      stakedLP: "$2,453,251.20",
+      unstakedLP: "$132,423.34",
+      claimableRewards: "$1213.23",
+      loadingBalance: false,
+      loadingPositions: false,
+      totalClaimedRewards: "$1213.23",
+    },
+    connected: true,
+    claimAll: () => {
+      return;
+    },
+    breakpoint: DEVICE_TYPE.WEB,
+    isSwitchNetwork: false,
+    loadngTransactionClaim: false,
+    positions: [],
+    positionRewards: null,
+    tokens: [],
+    tokenPrices: {},
+  };
+
+  const renderWalletBalanceDetail = (props: Partial<WalletBalanceDetailProps> = {}) => {
+    return render(
       <JotaiProvider>
         <GnoswapThemeProvider>
-          <WalletBalanceDetail {...mockProps} />
+          <WalletBalanceDetail {...baseProps} {...props} />
         </GnoswapThemeProvider>
       </JotaiProvider>,
     );
+  };
+
+  it("WalletBalanceDetail render", () => {
+    renderWalletBalanceDetail();
+  });
+
+  it("applies token decimals to claimed and claimable reward popup amounts", () => {
+    const positionRewards: PositionRewardsResponse = {
+      claimed: {
+        swapFee: [
+          { tokenPath: usdcToken.path, amount: "123456789", usdValue: "10" },
+          { tokenPath: atomToken.path, amount: "1230000000000000000", usdValue: "2" },
+        ],
+        internalReward: [],
+        externalReward: [],
+      },
+      claimable: {
+        swapFee: [],
+        internalReward: [{ tokenPath: usdcToken.path, amount: "7654321", usdValue: "3" }],
+        externalReward: [],
+      },
+      totalUsd: {
+        claimed: {
+          swapFee: "12",
+          internalReward: "0",
+          externalReward: "0",
+          total: "12",
+        },
+        claimable: {
+          swapFee: "0",
+          internalReward: "3",
+          externalReward: "0",
+          total: "3",
+        },
+      },
+      positionsWithSwapFee: [],
+      positionsWithStakingReward: [],
+    };
+
+    renderWalletBalanceDetail({
+      positionRewards,
+      tokens: [usdcToken, atomToken],
+    });
+
+    expect(screen.getByText("123.456789")).toBeInTheDocument();
+    expect(screen.getByText("1.23")).toBeInTheDocument();
+    expect(screen.getByText("7.654321")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/layouts/portfolio/components/wallet-balance/wallet-balance-detail/WalletBalanceDetail.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-balance/wallet-balance-detail/WalletBalanceDetail.tsx
@@ -15,6 +15,7 @@ import {
   PositionRewardsGroupResponse,
   PositionRewardsResponse,
 } from "@repositories/position/response";
+import { AmountConverter } from "@services/converters/common/amount";
 import { DEVICE_TYPE } from "@styles/media";
 
 import StakedPostionsTooltipContent from "./sateked-positions-tooltip/StakedPositinosTooltipContent";
@@ -110,7 +111,7 @@ const WalletBalanceDetail: React.FC<WalletBalanceDetailProps> = ({
         tooltipItems.push({
           rewardType: displayType,
           token,
-          amount: Number(item.amount),
+          amount: Number(AmountConverter.convertSingle(token, item.amount)),
           usd: Number(item.usdValue),
           accumulatedRewardOf1d: null,
           accumulatedRewardOf1dUsd: null,


### PR DESCRIPTION
## Summary
- Apply each reward token's own decimals before rendering Portfolio Total Claimed Rewards and Claimable Rewards popup amounts.
- Add regression coverage with 6-decimal and 18-decimal reward tokens in the popup data.

## Verification
- yarn workspace @gnoswap-labs/web jest src/layouts/portfolio/components/wallet-balance/wallet-balance-detail/WalletBalanceDetail.spec.tsx --runInBand
- yarn workspace @gnoswap-labs/web lint --file src/layouts/portfolio/components/wallet-balance/wallet-balance-detail/WalletBalanceDetail.tsx --file src/layouts/portfolio/components/wallet-balance/wallet-balance-detail/WalletBalanceDetail.spec.tsx
- git diff --check

## Notes
- Repo-wide yarn workspace @gnoswap-labs/web lint is currently blocked by unrelated existing errors such as src/common/errors/response.ts no-explicit-any and duplicated imports in src/containers/select-token-incentivize-container/SelectTokenContainer.tsx.
- Repo-wide yarn workspace @gnoswap-labs/web exec tsc --noEmit --pretty false is currently blocked by unrelated existing spec/type drift across multiple files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reward amount display in tooltips to properly apply token decimal conversions for claimed and claimable rewards.

* **Tests**
  * Enhanced test coverage with improved test fixtures and helper functions.
  * Added test case verifying correct formatting of reward amounts with token decimals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->