### PR TITLE
fix(pool): use allowed incentive tokens

### DIFF
--- a/packages/web/src/containers/select-token-incentivize-container/SelectTokenContainer.tsx
+++ b/packages/web/src/containers/select-token-incentivize-container/SelectTokenContainer.tsx
@@ -6,32 +6,19 @@ import { TokenModel } from "@models/token/token-model";
 import { useAtomValue } from "jotai";
 import { ThemeState } from "@states/index";
 import useEscCloseModal from "@hooks/common/use-esc-close-modal";
-import { ORDER } from "@containers/select-token-container/SelectTokenContainer";
-import { useAtom } from "jotai";
-import { EarnState } from "@states/index";
+import { useGetAllowedExternalRewardTokenPaths } from "@query/pools";
+import { filterAllowedIncentiveTokens } from "./incentive-token-filter";
 
 interface SelectTokenIncentivizeContainerProps {
   changeToken?: (token: TokenModel) => void;
   callback?: (value: boolean) => void;
 }
-const customSort = (a: TokenModel, b: TokenModel) => {
-  const symbolA = a.symbol.toUpperCase();
-  const symbolB = b.symbol.toUpperCase();
-
-  const indexA = ORDER.slice(0, 2).indexOf(symbolA);
-  const indexB = ORDER.slice(0, 2).indexOf(symbolB);
-
-  if (indexA === -1) return 1;
-  if (indexB === -1) return -1;
-
-  return indexA - indexB;
-};
 const SelectTokenIncentivizeContainer: React.FC<SelectTokenIncentivizeContainerProps> = ({ changeToken, callback }) => {
   const { tokens, balances, updateTokens, updateBalances } = useTokenData();
+  const { data: allowedTokenPaths = [] } = useGetAllowedExternalRewardTokenPaths();
   const [keyword, setKeyword] = useState("");
   const clearModal = useClearModal();
   const themeKey = useAtomValue(ThemeState.themeKey);
-  const [currentPool] = useAtom(EarnState.pool);
 
   useEffect(() => {
     updateTokens();
@@ -42,19 +29,12 @@ const SelectTokenIncentivizeContainer: React.FC<SelectTokenIncentivizeContainerP
   }, [tokens]);
 
   const defaultTokens = useMemo(() => {
-    return tokens.filter((_, index) => index < 5);
-  }, [tokens]);
+    return filterAllowedIncentiveTokens(tokens, allowedTokenPaths).filter((_, index) => index < 5);
+  }, [allowedTokenPaths, tokens]);
 
   const filteredTokens = useMemo(() => {
-    const temp = tokens.sort(customSort);
-    const token1 = tokens.filter(
-      item => item.path === currentPool?.tokenA.path && !item.symbol.includes("GNOT") && item.symbol !== "GNS",
-    );
-    const token2 = tokens.filter(
-      item => item.path === currentPool?.tokenB.path && !item.symbol.includes("GNOT") && item.symbol !== "GNS",
-    );
-    return [...temp.slice(0, 2), ...token1, ...token2];
-  }, [tokens, currentPool]);
+    return filterAllowedIncentiveTokens(tokens, allowedTokenPaths);
+  }, [allowedTokenPaths, tokens]);
 
   const selectToken = useCallback(
     (token: TokenModel) => {

--- a/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.spec.ts
+++ b/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.spec.ts
@@ -1,0 +1,45 @@
+import { TokenModel } from "@models/token/token-model";
+import { filterAllowedIncentiveTokens } from "./incentive-token-filter";
+
+function makeToken(symbol: string, path: string, wrappedPath?: string): TokenModel {
+  return {
+    path,
+    wrappedPath,
+    tokenId: path,
+    type: path === "ugnot" ? "Native" : "GRC20",
+    chainId: "dev.gnoswap",
+    name: symbol,
+    symbol,
+    displaySymbol: symbol,
+    decimals: 6,
+    logoURI: "",
+    createdAt: "",
+    priceID: path,
+  };
+}
+
+describe("filterAllowedIncentiveTokens", () => {
+  it("returns only staker allowed external reward tokens", () => {
+    const tokens = [
+      makeToken("ATONE", "gno.land/r/demo/atone"),
+      makeToken("USDC", "gno.land/r/demo/usdc"),
+      makeToken("GNS", "gno.land/r/gnoswap/gns"),
+      makeToken("GNOT", "ugnot", "gno.land/r/gnoland/wugnot"),
+    ];
+
+    const result = filterAllowedIncentiveTokens(tokens, ["gno.land/r/gnoland/wugnot", "gno.land/r/gnoswap/gns"]);
+
+    expect(result.map(token => token.symbol)).toEqual(["GNOT", "GNS"]);
+  });
+
+  it("deduplicates native GNOT and wrapped GNOT by reward token path", () => {
+    const tokens = [
+      makeToken("WUGNOT", "gno.land/r/gnoland/wugnot"),
+      makeToken("GNOT", "ugnot", "gno.land/r/gnoland/wugnot"),
+    ];
+
+    const result = filterAllowedIncentiveTokens(tokens, ["gno.land/r/gnoland/wugnot"]);
+
+    expect(result.map(token => token.symbol)).toEqual(["GNOT"]);
+  });
+});

--- a/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.spec.ts
+++ b/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.spec.ts
@@ -30,7 +30,7 @@ describe("filterAllowedIncentiveTokens", () => {
 
     const result = filterAllowedIncentiveTokens(tokens, ["gno.land/r/gnoland/wugnot", "gno.land/r/gnoswap/gns"]);
 
-    expect(result.map(token => token.symbol)).toEqual(["WUGNOT", "GNS"]);
+    expect(result.map(token => token.symbol)).toEqual(["GNOT", "GNS"]);
   });
 
   it("sorts by allowed token path order instead of symbol order", () => {
@@ -53,5 +53,16 @@ describe("filterAllowedIncentiveTokens", () => {
     const result = filterAllowedIncentiveTokens(tokens, ["gno.land/r/gnoland/wugnot"]);
 
     expect(result.map(token => token.symbol)).toEqual(["WGNOT"]);
+  });
+
+  it("deduplicates wrapped GNOT and native GNOT by incentive path while preferring native GNOT", () => {
+    const tokens = [
+      makeToken("WUGNOT", "gno.land/r/gnoland/wugnot"),
+      makeToken("GNOT", "ugnot", "gno.land/r/gnoland/wugnot"),
+    ];
+
+    const result = filterAllowedIncentiveTokens(tokens, ["gno.land/r/gnoland/wugnot"]);
+
+    expect(result.map(token => token.symbol)).toEqual(["GNOT"]);
   });
 });

--- a/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.spec.ts
+++ b/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.spec.ts
@@ -23,23 +23,35 @@ describe("filterAllowedIncentiveTokens", () => {
     const tokens = [
       makeToken("ATONE", "gno.land/r/demo/atone"),
       makeToken("USDC", "gno.land/r/demo/usdc"),
+      makeToken("WUGNOT", "gno.land/r/gnoland/wugnot"),
       makeToken("GNS", "gno.land/r/gnoswap/gns"),
       makeToken("GNOT", "ugnot", "gno.land/r/gnoland/wugnot"),
     ];
 
     const result = filterAllowedIncentiveTokens(tokens, ["gno.land/r/gnoland/wugnot", "gno.land/r/gnoswap/gns"]);
 
-    expect(result.map(token => token.symbol)).toEqual(["GNOT", "GNS"]);
+    expect(result.map(token => token.symbol)).toEqual(["WUGNOT", "GNS"]);
   });
 
-  it("deduplicates native GNOT and wrapped GNOT by reward token path", () => {
+  it("sorts by allowed token path order instead of symbol order", () => {
+    const tokens = [
+      makeToken("AAA", "gno.land/r/gnoland/wugnot"),
+      makeToken("ZZZ", "gno.land/r/gnoswap/gns"),
+    ];
+
+    const result = filterAllowedIncentiveTokens(tokens, ["gno.land/r/gnoswap/gns", "gno.land/r/gnoland/wugnot"]);
+
+    expect(result.map(token => token.symbol)).toEqual(["ZZZ", "AAA"]);
+  });
+
+  it("deduplicates tokens by path", () => {
     const tokens = [
       makeToken("WUGNOT", "gno.land/r/gnoland/wugnot"),
-      makeToken("GNOT", "ugnot", "gno.land/r/gnoland/wugnot"),
+      makeToken("WGNOT", "gno.land/r/gnoland/wugnot"),
     ];
 
     const result = filterAllowedIncentiveTokens(tokens, ["gno.land/r/gnoland/wugnot"]);
 
-    expect(result.map(token => token.symbol)).toEqual(["GNOT"]);
+    expect(result.map(token => token.symbol)).toEqual(["WGNOT"]);
   });
 });

--- a/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.ts
+++ b/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.ts
@@ -1,0 +1,40 @@
+import { TokenModel } from "@models/token/token-model";
+import { checkGnotPath } from "@utils/common";
+
+const INCENTIVE_TOKEN_ORDER = ["GNOT", "GNS"] as const;
+
+function tokenPriority(token: TokenModel): number {
+  const normalizedSymbol = token.symbol.toUpperCase();
+  const index = INCENTIVE_TOKEN_ORDER.findIndex(symbol => symbol === normalizedSymbol);
+  return index === -1 ? INCENTIVE_TOKEN_ORDER.length : index;
+}
+
+function canonicalRewardPath(token: TokenModel): string {
+  return token.wrappedPath || checkGnotPath(token.path);
+}
+
+export function filterAllowedIncentiveTokens(
+  tokens: readonly TokenModel[],
+  allowedTokenPaths: readonly string[],
+): TokenModel[] {
+  const allowedPathSet = new Set(allowedTokenPaths);
+  const selectedPathSet = new Set<string>();
+
+  return tokens
+    .filter(token => allowedPathSet.has(canonicalRewardPath(token)))
+    .sort((a, b) => {
+      const priorityDiff = tokenPriority(a) - tokenPriority(b);
+      if (priorityDiff !== 0) {
+        return priorityDiff;
+      }
+      return a.symbol.localeCompare(b.symbol);
+    })
+    .filter(token => {
+      const rewardPath = canonicalRewardPath(token);
+      if (selectedPathSet.has(rewardPath)) {
+        return false;
+      }
+      selectedPathSet.add(rewardPath);
+      return true;
+    });
+}

--- a/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.ts
+++ b/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.ts
@@ -1,16 +1,8 @@
 import { TokenModel } from "@models/token/token-model";
-import { checkGnotPath } from "@utils/common";
 
-const INCENTIVE_TOKEN_ORDER = ["GNOT", "GNS"] as const;
-
-function tokenPriority(token: TokenModel): number {
-  const normalizedSymbol = token.symbol.toUpperCase();
-  const index = INCENTIVE_TOKEN_ORDER.findIndex(symbol => symbol === normalizedSymbol);
-  return index === -1 ? INCENTIVE_TOKEN_ORDER.length : index;
-}
-
-function canonicalRewardPath(token: TokenModel): string {
-  return token.wrappedPath || checkGnotPath(token.path);
+function tokenPriority(token: TokenModel, allowedTokenPaths: readonly string[]): number {
+  const index = allowedTokenPaths.findIndex(path => path === token.path);
+  return index === -1 ? allowedTokenPaths.length : index;
 }
 
 export function filterAllowedIncentiveTokens(
@@ -21,20 +13,19 @@ export function filterAllowedIncentiveTokens(
   const selectedPathSet = new Set<string>();
 
   return tokens
-    .filter(token => allowedPathSet.has(canonicalRewardPath(token)))
+    .filter(token => allowedPathSet.has(token.path))
     .sort((a, b) => {
-      const priorityDiff = tokenPriority(a) - tokenPriority(b);
+      const priorityDiff = tokenPriority(a, allowedTokenPaths) - tokenPriority(b, allowedTokenPaths);
       if (priorityDiff !== 0) {
         return priorityDiff;
       }
       return a.symbol.localeCompare(b.symbol);
     })
     .filter(token => {
-      const rewardPath = canonicalRewardPath(token);
-      if (selectedPathSet.has(rewardPath)) {
+      if (selectedPathSet.has(token.path)) {
         return false;
       }
-      selectedPathSet.add(rewardPath);
+      selectedPathSet.add(token.path);
       return true;
     });
 }

--- a/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.ts
+++ b/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.ts
@@ -1,8 +1,20 @@
 import { TokenModel } from "@models/token/token-model";
+import { checkGnotPath, isNativeToken } from "@utils/common";
 
 function tokenPriority(token: TokenModel, allowedTokenPaths: readonly string[]): number {
-  const index = allowedTokenPaths.findIndex(path => path === token.path);
+  const index = allowedTokenPaths.findIndex(path => path === incentiveTokenPath(token));
   return index === -1 ? allowedTokenPaths.length : index;
+}
+
+function incentiveTokenPath(token: TokenModel): string {
+  if (isNativeToken(token.path)) {
+    return token.wrappedPath || checkGnotPath(token.path);
+  }
+  return checkGnotPath(token.path);
+}
+
+function nativeTokenPriority(token: TokenModel): number {
+  return isNativeToken(token.path) ? 0 : 1;
 }
 
 export function filterAllowedIncentiveTokens(
@@ -13,19 +25,24 @@ export function filterAllowedIncentiveTokens(
   const selectedPathSet = new Set<string>();
 
   return tokens
-    .filter(token => allowedPathSet.has(token.path))
+    .filter(token => allowedPathSet.has(incentiveTokenPath(token)))
     .sort((a, b) => {
       const priorityDiff = tokenPriority(a, allowedTokenPaths) - tokenPriority(b, allowedTokenPaths);
       if (priorityDiff !== 0) {
         return priorityDiff;
       }
+      const nativePriorityDiff = nativeTokenPriority(a) - nativeTokenPriority(b);
+      if (nativePriorityDiff !== 0) {
+        return nativePriorityDiff;
+      }
       return a.symbol.localeCompare(b.symbol);
     })
     .filter(token => {
-      if (selectedPathSet.has(token.path)) {
+      const rewardPath = incentiveTokenPath(token);
+      if (selectedPathSet.has(rewardPath)) {
         return false;
       }
-      selectedPathSet.add(token.path);
+      selectedPathSet.add(rewardPath);
       return true;
     });
 }

--- a/packages/web/src/react-query/pools/index.ts
+++ b/packages/web/src/react-query/pools/index.ts
@@ -1,5 +1,6 @@
 export * from "./use-get-liquidity-ticks-by-path";
 export * from "./use-get-incentivize-pool-list";
+export * from "./use-get-allowed-external-reward-token-paths";
 export * from "./use-get-incentive-creation-deposit";
 export * from "./use-get-lasted-block-height";
 export * from "./use-get-pool-creation-fee";

--- a/packages/web/src/react-query/pools/use-get-allowed-external-reward-token-paths.ts
+++ b/packages/web/src/react-query/pools/use-get-allowed-external-reward-token-paths.ts
@@ -1,0 +1,18 @@
+import { UseQueryOptions, useQuery } from "@tanstack/react-query";
+
+import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
+
+import { QUERY_KEY } from "../query-keys";
+
+export const useGetAllowedExternalRewardTokenPaths = (options?: UseQueryOptions<string[], Error>) => {
+  const { poolRepository } = useGnoswapContext();
+
+  return useQuery<string[], Error>({
+    queryKey: [QUERY_KEY.allowedExternalRewardTokenPaths],
+    queryFn: async () => {
+      return poolRepository.getAllowedExternalRewardTokenPaths();
+    },
+    staleTime: 30_000,
+    ...options,
+  });
+};

--- a/packages/web/src/react-query/pools/use-get-allowed-external-reward-token-paths.ts
+++ b/packages/web/src/react-query/pools/use-get-allowed-external-reward-token-paths.ts
@@ -1,14 +1,16 @@
 import { UseQueryOptions, useQuery } from "@tanstack/react-query";
 
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
+import { useWallet } from "@hooks/wallet/data/use-wallet";
 
 import { QUERY_KEY } from "../query-keys";
 
 export const useGetAllowedExternalRewardTokenPaths = (options?: UseQueryOptions<string[], Error>) => {
   const { poolRepository } = useGnoswapContext();
+  const { currentChainId } = useWallet();
 
   return useQuery<string[], Error>({
-    queryKey: [QUERY_KEY.allowedExternalRewardTokenPaths],
+    queryKey: [QUERY_KEY.allowedExternalRewardTokenPaths, currentChainId],
     queryFn: async () => {
       return poolRepository.getAllowedExternalRewardTokenPaths();
     },

--- a/packages/web/src/react-query/query-keys.ts
+++ b/packages/web/src/react-query/query-keys.ts
@@ -40,6 +40,7 @@ export enum QUERY_KEY {
   poolDetail = "pool_details",
   prices = "prices",
   incentivizePools = "incentivizePools",
+  allowedExternalRewardTokenPaths = "allowed_external_reward_token_paths",
   poolWithdrawalFee = "pool_withdrawal_fee",
   unstakingFee = "unstaking_fee",
   poolStakingList = "pool_staking_list",

--- a/packages/web/src/repositories/pool/pool-repository-impl.ts
+++ b/packages/web/src/repositories/pool/pool-repository-impl.ts
@@ -1,7 +1,11 @@
 import { getGRC20Allowance } from "@common/clients/gno-provider";
 import { NetworkClient } from "@common/clients/network-client";
 import { WalletClient } from "@common/clients/wallet-client";
-import { SendTransactionResponse, SendTransactionSuccessResponse, WalletResponse } from "@common/clients/wallet-client/protocols";
+import {
+  SendTransactionResponse,
+  SendTransactionSuccessResponse,
+  WalletResponse,
+} from "@common/clients/wallet-client/protocols";
 import { CommonError } from "@common/errors";
 import { PoolError } from "@common/errors/pool";
 import { DEFAULT_GAS_FEE, DEFAULT_GAS_WANTED, DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } from "@common/values";
@@ -22,7 +26,13 @@ import {
   makeABCIParams,
 } from "@utils/rpc-utils";
 import { generateSendTransactionParams, withTransactionGuard } from "@utils/transaction-utils";
-import { PoolListResponse, PoolPricesResponse, PoolRepository, PoolResponse } from ".";
+import {
+  AllowedExternalRewardTokensResponse,
+  PoolListResponse,
+  PoolPricesResponse,
+  PoolRepository,
+  PoolResponse,
+} from ".";
 import {
   makeCollectExternalIncentivePenaltyMessageWithApproves,
   makeCreateExternalIncentiveMessageWithApproves,
@@ -99,6 +109,23 @@ export class PoolRepositoryImpl implements PoolRepository {
     } catch (error) {
       console.error(error);
       return DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT;
+    }
+  };
+
+  getAllowedExternalRewardTokenPaths = async (): Promise<string[]> => {
+    if (!this.networkClient) {
+      return [];
+    }
+
+    try {
+      const response = await this.networkClient.get<AllowedExternalRewardTokensResponse>({
+        url: "/incentivize/allowed-tokens",
+      });
+
+      return response?.data?.data?.tokens?.map(token => token.tokenPath) || [];
+    } catch (error) {
+      console.error(error);
+      return [];
     }
   };
 

--- a/packages/web/src/repositories/pool/pool-repository-mock.ts
+++ b/packages/web/src/repositories/pool/pool-repository-mock.ts
@@ -54,6 +54,10 @@ export class PoolRepositoryMock implements PoolRepository {
     return DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT;
   };
 
+  getAllowedExternalRewardTokenPaths = async (): Promise<string[]> => {
+    return ["gno.land/r/gnoland/wugnot", "gno.land/r/gnoswap/gns"];
+  };
+
   getPoolDetailByPoolPath = async (): Promise<PoolDetailModel> => {
     return PoolDetailData.pool as never;
   };

--- a/packages/web/src/repositories/pool/pool-repository.spec.ts
+++ b/packages/web/src/repositories/pool/pool-repository.spec.ts
@@ -119,6 +119,29 @@ describe("getIncentivizePools", () => {
   });
 });
 
+describe("getAllowedExternalRewardTokenPaths", () => {
+  it("requests allowed external reward tokens from API", async () => {
+    const networkClient = new MockNetworkClient({
+      data: {
+        tokens: [
+          { tokenPath: "gno.land/r/gnoswap/gns", minRewardAmount: "0" },
+          { tokenPath: "gno.land/r/gnoland/wugnot", minRewardAmount: "100" },
+        ],
+      },
+    });
+    const repository = new PoolRepositoryImpl(networkClient, null, null);
+
+    const tokenPaths = await repository.getAllowedExternalRewardTokenPaths();
+
+    expect(networkClient.getCalls).toEqual([
+      {
+        url: "/incentivize/allowed-tokens",
+      },
+    ]);
+    expect(tokenPaths).toEqual(["gno.land/r/gnoswap/gns", "gno.land/r/gnoland/wugnot"]);
+  });
+});
+
 describe("getLiquidityTicksOfPoolByPath", () => {
   it("requests pool liquidity ticks and preserves liquidityNet strings", async () => {
     const liquidityNet = "340282366920938463463374607431768211456";

--- a/packages/web/src/repositories/pool/pool-repository.ts
+++ b/packages/web/src/repositories/pool/pool-repository.ts
@@ -20,6 +20,8 @@ export interface PoolRepository {
 
   getIncentiveCreationDeposit: () => Promise<string>;
 
+  getAllowedExternalRewardTokenPaths: () => Promise<string[]>;
+
   getWithdrawalFee: () => Promise<number>;
 
   getUnstakingFee: () => Promise<number>;

--- a/packages/web/src/repositories/pool/response/allowed-external-reward-token-response.ts
+++ b/packages/web/src/repositories/pool/response/allowed-external-reward-token-response.ts
@@ -1,0 +1,10 @@
+export interface AllowedExternalRewardTokenResponse {
+  tokenPath: string;
+  minRewardAmount: string;
+}
+
+export interface AllowedExternalRewardTokensResponse {
+  data: {
+    tokens: AllowedExternalRewardTokenResponse[];
+  };
+}

--- a/packages/web/src/repositories/pool/response/index.ts
+++ b/packages/web/src/repositories/pool/response/index.ts
@@ -2,3 +2,4 @@ export * from "./pool-list-response";
 export * from "./pool-detail-response";
 export * from "./pool-prices-response";
 export * from "./pool-liquidity-ticks-response";
+export * from "./allowed-external-reward-token-response";


### PR DESCRIPTION
## Summary
- Fetch allowed external reward token paths from the pool API for the incentivize token selector.
- Filter the Add Incentive token list by the allowed token paths returned by the API.
- Add repository and filter tests for the allowed reward token flow.

## Tests
- yarn workspace @gnoswap-labs/web jest packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.spec.ts packages/web/src/repositories/pool/pool-repository.spec.ts --runInBand

## Notes
- yarn workspace @gnoswap-labs/web tsc --noEmit still fails on existing unrelated type errors in the workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Token selection for incentivizing rewards now filters based on allowed external reward token paths
  - Default token options limited to the first 5 allowed tokens
  - Enhanced token ordering consistency across reward token selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->