### PR TITLE
fix: lowercase wugnot fallback symbol

### DIFF
--- a/packages/web/src/common/values/token-constant.ts
+++ b/packages/web/src/common/values/token-constant.ts
@@ -75,10 +75,10 @@ export const WUGNOT_TOKEN: TokenModel = {
   chainId: "portal-loop",
   name: "wrapped GNOT",
   path: "gno.land/r/gnoland/wugnot",
-  tokenId: "gno.land/r/gnoland/wugnot.WUGNOT",
+  tokenId: "gno.land/r/gnoland/wugnot.wugnot",
   decimals: 6,
-  symbol: "WUGNOT",
-  displaySymbol: "WUGNOT",
+  symbol: "wugnot",
+  displaySymbol: "wugnot",
   logoURI: "https://raw.githubusercontent.com/onbloc/gno-token-resource/main/grc20/images/gno_land_r_demo_wugnot.svg",
   priceID: "gno.land/r/gnoland/wugnot",
   description:


### PR DESCRIPTION
## Summary
- Lowercase the hardcoded `WUGNOT_TOKEN` fallback `symbol` and `displaySymbol` to `wugnot`
- Align the fallback `tokenId` suffix with the lowercase wugnot symbol returned by the token metadata API

## Why
The portfolio asset list can render `WUGNOT_TOKEN` before token metadata replaces the fallback. The fallback used uppercase `WUGNOT`, while the DB and `/v1/token-metas` return lowercase `wugnot`.

## Validation
- `yarn workspace @gnoswap-labs/web lint --file src/common/values/token-constant.ts`
- `yarn prettier --check packages/web/src/common/values/token-constant.ts`
- `git diff --check`
- Direct constant check confirmed `symbol: "wugnot"` and `displaySymbol: "wugnot"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated token metadata formatting for consistency, changing the WUGNOT token identifier and symbols to lowercase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->