### PR TITLE
fix: correct leaderboard paginated ranks

### DIFF
--- a/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx
+++ b/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
+import { LeaderboardVisibilityStatus, LeaderboardUser } from "@repositories/leaderboard/response/common/types";
+import LeaderboardTableRow from "./LeaderboardTableRow";
+
+jest.mock("@components/common/tooltip/Tooltip", () => {
+  return function MockTooltip({ children }: { readonly children: React.ReactNode }) {
+    return <>{children}</>;
+  };
+});
+
+jest.mock("@hooks/common/use-custom-router", () => ({
+  __esModule: true,
+  default: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const createLeaderboardUser = (rank: number): LeaderboardUser => ({
+  accountAddress: "g1testaddress000000000000000000000000000000000",
+  accountName: "",
+  governanceRewardsPoint: "0",
+  governanceRewardsUsd: "0",
+  hiddenYn: LeaderboardVisibilityStatus.VISIBLE,
+  paidSwapFeePoint: "0",
+  providedLiquidityFeePoint: "0",
+  providedLiquidityFeeUsd: "0",
+  rank,
+  referralPoint: "0",
+  referrerAddress: "",
+  stakingRewardsPoint: "0",
+  stakingRewardsUsd: "0",
+  swapFeeUsd: "0",
+  totalPoint: "0",
+});
+
+describe("LeaderboardTableRow", () => {
+  it("displays the global rank when a page rank offset is provided", () => {
+    render(
+      <GnoswapThemeProvider>
+        <LeaderboardTableRow
+          myAddress={undefined}
+          data={createLeaderboardUser(1)}
+          tdWidths={[100, 100, 100, 100, 100, 100]}
+          isMobile={false}
+          rankOffset={100}
+        />
+      </GnoswapThemeProvider>,
+    );
+
+    expect(screen.getByText("#101")).toBeInTheDocument();
+  });
+
+  it("keeps the API rank when it is already greater than the page offset", () => {
+    render(
+      <GnoswapThemeProvider>
+        <LeaderboardTableRow
+          myAddress={undefined}
+          data={createLeaderboardUser(101)}
+          tdWidths={[100, 100, 100, 100, 100, 100]}
+          isMobile={false}
+          rankOffset={100}
+        />
+      </GnoswapThemeProvider>,
+    );
+
+    expect(screen.getByText("#101")).toBeInTheDocument();
+    expect(screen.queryByText("#201")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.tsx
+++ b/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.tsx
@@ -25,12 +25,14 @@ const LeaderboardTableRow = ({
   tdWidths,
   isMobile,
   isMe = false,
+  rankOffset = 0,
 }: {
   myAddress: string | undefined;
   data: LeaderboardUser;
   tdWidths: number[];
   isMobile: boolean;
   isMe?: boolean;
+  rankOffset?: number;
 }) => {
   const Hover = isMe ? HoverSection : HoverOnBgSection;
   const TableWrapper = isMe ? WrapperHoverBackground : Wrapper;
@@ -48,10 +50,21 @@ const LeaderboardTableRow = ({
     };
   }, [data.swapFeeUsd, data.providedLiquidityFeeUsd, data.stakingRewardsUsd, data.governanceRewardsUsd]);
 
-  const displayRank = React.useMemo(() => {
+  const displayRankNumber = React.useMemo(() => {
     if (!data.rank) return "-";
-    return `#${data.rank}`;
-  }, [data.rank]);
+    if (!rankOffset || data.rank > rankOffset) return data.rank;
+    return data.rank + rankOffset;
+  }, [data.rank, rankOffset]);
+
+  const displayRank = React.useMemo(() => {
+    if (displayRankNumber === "-") return displayRankNumber;
+    return `#${displayRankNumber}`;
+  }, [displayRankNumber]);
+
+  const displayUser = React.useMemo(() => {
+    if (displayRankNumber === "-" || displayRankNumber === data.rank) return data;
+    return { ...data, rank: displayRankNumber };
+  }, [data, displayRankNumber]);
 
   return (
     <TableWrapper>
@@ -59,7 +72,7 @@ const LeaderboardTableRow = ({
       <Hover style={isLeaderboardHidden(data.hiddenYn) ? { cursor: "auto" } : {}}>
         <UserColumn
           myAddress={myAddress}
-          user={data}
+          user={displayUser}
           isMe={isMe}
           tdWidth={tdWidths.at(1)}
           style={{ justifyContent: "flex-start" }}

--- a/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table/LeaderboardTable.tsx
+++ b/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table/LeaderboardTable.tsx
@@ -13,10 +13,12 @@ export default function LeaderboardTable({
   myAddress,
   currentUserData,
   leaderboardEntries,
+  rankOffset = 0,
 }: {
   myAddress: string | undefined;
   currentUserData?: LeaderboardUser;
   leaderboardEntries: LeaderboardUser[];
+  rankOffset?: number;
 }) {
   const { connected } = useConnection();
   const { isTablet, isMobile } = useWindowSize();
@@ -45,6 +47,7 @@ export default function LeaderboardTable({
           data={leader}
           tdWidths={widths}
           isMobile={isMobile}
+          rankOffset={rankOffset}
         />
       ))}
     </>

--- a/packages/web/src/layouts/leaderboard-layout/containers/leaderboard-table-container/LeaderboardTableContainer.tsx
+++ b/packages/web/src/layouts/leaderboard-layout/containers/leaderboard-table-container/LeaderboardTableContainer.tsx
@@ -17,13 +17,16 @@ interface LeaderboardTableContainerProps {
   readonly movePage: (page: number) => void;
 }
 
+const LEADERBOARD_PAGE_SIZE = 100;
+
 export default function LeaderboardTableContainer({ keyword, page, movePage }: LeaderboardTableContainerProps) {
   const theme = useTheme();
   const { isMobile } = useWindowSize();
   const { address: myAddress } = useAddress();
 
-  const { data: leaderboardInfos } = useGetLeaderboard({ limit: 100, page });
+  const { data: leaderboardInfos } = useGetLeaderboard({ limit: LEADERBOARD_PAGE_SIZE, page });
   const { data: leaderboardMyInfo } = useGetLeaderboardByAddress(myAddress || "");
+  const rankOffset = Math.max(page - 1, 0) * LEADERBOARD_PAGE_SIZE;
 
   const filteredData = React.useMemo(() => {
     if (!leaderboardInfos?.users) return [];
@@ -58,6 +61,7 @@ export default function LeaderboardTableContainer({ keyword, page, movePage }: L
             myAddress={myAddress}
             currentUserData={leaderboardMyInfo}
             leaderboardEntries={filteredData}
+            rankOffset={rankOffset}
           />
         )}
       </LeaderboardTableWrapper>


### PR DESCRIPTION
## Summary
- Correct leaderboard row ranks when paginated API results start again from rank 1.
- Add regression coverage for page-offset rank display.

## Context
- The leaderboard fetches 100 users per page. On page 2, a local rank of 1 should render as #101.

## Changes
- Reuse the leaderboard page size constant for the API limit and display rank offset.
- Apply the offset only to paginated list rows, not the fixed current-user row.
- Avoid double offsetting when the API already returns a global rank.

## Verification
- `yarn workspace @gnoswap-labs/web jest --runInBand src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx`
- `yarn workspace @gnoswap-labs/web next lint --file src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.tsx --file src/layouts/leaderboard-layout/components/leaderboard-table/LeaderboardTable.tsx --file src/layouts/leaderboard-layout/containers/leaderboard-table-container/LeaderboardTableContainer.tsx --file src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx`
- `yarn prettier --check packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.tsx packages/web/src/layouts/leaderboard-layout/components/leaderboard-table/LeaderboardTable.tsx packages/web/src/layouts/leaderboard-layout/containers/leaderboard-table-container/LeaderboardTableContainer.tsx packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx`
- `git diff --check`

## Notes
- Full `yarn workspace @gnoswap-labs/web lint` currently fails on pre-existing unrelated files, including `src/common/errors/response.ts`, `src/hooks/common/use-click-outside.tsx`, and `src/hooks/common/use-delay-loading.tsx`.
- Full `yarn workspace @gnoswap-labs/web tsc --noEmit` currently fails on pre-existing unrelated spec type errors.
- Screenshots not attached because this is a text-only rank display fix covered by component tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Leaderboard rank display now correctly reflects global positions across paginated results. Ranks are properly adjusted based on page position to ensure users see their true ranking position, not just their position within the current page.

* **Tests**
  * Added test coverage for leaderboard row rendering, including verification of rank computation across different page offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->