### PR TITLE
fix: coerce leaderboard rank before offset

### DIFF
--- a/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx
+++ b/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx
@@ -40,6 +40,10 @@ const createLeaderboardUser = (rank: number): LeaderboardUser => ({
   totalPoint: "0",
 });
 
+const createApiLeaderboardUser = (rank: string): LeaderboardUser => {
+  return JSON.parse(JSON.stringify({ ...createLeaderboardUser(0), rank }));
+};
+
 describe("LeaderboardTableRow", () => {
   it("displays the global rank when a page rank offset is provided", () => {
     render(
@@ -72,5 +76,22 @@ describe("LeaderboardTableRow", () => {
 
     expect(screen.getByText("#101")).toBeInTheDocument();
     expect(screen.queryByText("#201")).not.toBeInTheDocument();
+  });
+
+  it("coerces a serialized API rank before applying the page offset", () => {
+    render(
+      <GnoswapThemeProvider>
+        <LeaderboardTableRow
+          myAddress={undefined}
+          data={createApiLeaderboardUser("1")}
+          tdWidths={[100, 100, 100, 100, 100, 100]}
+          isMobile={false}
+          rankOffset={100}
+        />
+      </GnoswapThemeProvider>,
+    );
+
+    expect(screen.getByText("#101")).toBeInTheDocument();
+    expect(screen.queryByText("#1100")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.tsx
+++ b/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.tsx
@@ -51,9 +51,10 @@ const LeaderboardTableRow = ({
   }, [data.swapFeeUsd, data.providedLiquidityFeeUsd, data.stakingRewardsUsd, data.governanceRewardsUsd]);
 
   const displayRankNumber = React.useMemo(() => {
-    if (!data.rank) return "-";
-    if (!rankOffset || data.rank > rankOffset) return data.rank;
-    return data.rank + rankOffset;
+    const rank = Number(data.rank);
+    if (!Number.isFinite(rank) || rank <= 0) return "-";
+    if (!rankOffset || rank > rankOffset) return rank;
+    return rank + rankOffset;
   }, [data.rank, rankOffset]);
 
   const displayRank = React.useMemo(() => {


### PR DESCRIPTION
## Summary
- Coerce leaderboard rank values to numbers before applying page rank offsets.
- Add regression coverage for serialized API rank values such as `"1"`.

## Context
- Follow-up to #924.
- Runtime leaderboard API data can provide rank as a serialized value, so `data.rank + rankOffset` could concatenate into values such as `#1100` instead of `#101`.

## Changes
- Normalize `data.rank` with `Number(...)` before rank display math.
- Treat non-finite or non-positive rank values as missing rank.
- Add a test covering the string-rank regression.

## Verification
- `yarn workspace @gnoswap-labs/web jest --runInBand src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx`
- `yarn workspace @gnoswap-labs/web next lint --file src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.tsx --file src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx`
- `yarn prettier --check packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.tsx packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx`
- `git diff --check`

## Notes
- The spec file is ignored by the repo-level Next lint pattern, consistent with existing project config.
- No visual screenshot attached because this is a text-rank arithmetic fix covered by component tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed leaderboard ranking display to properly convert and validate rank data before applying offset adjustments, ensuring accurate ranking positions are shown.

* **Tests**
  * Added test coverage for rank coercion and offset calculation behavior in leaderboard rankings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->