### PR TITLE
fix: keep unwrap swap navigation in current tab

### DIFF
--- a/packages/web/src/providers/snackbar-provider/snackbar/contents/ReceiveWugnotContent.spec.tsx
+++ b/packages/web/src/providers/snackbar-provider/snackbar/contents/ReceiveWugnotContent.spec.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+
+import { ReceiveWugnotContent } from "./ReceiveWugnotContent";
+
+jest.mock("@constants/environment.constant", () => ({
+  WRAPPED_GNOT_PATH: "gno.land/r/gnoland/wugnot",
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("@components/common/icons/IconArrowRight", () => {
+  const IconArrowRight = () => <span data-testid="arrow-right" />;
+  return IconArrowRight;
+});
+
+jest.mock("@components/common/icons/IconWrap", () => {
+  const IconWrap = ({ className }: { className?: string }) => <span className={className} data-testid="wrap-icon" />;
+  return IconWrap;
+});
+
+describe("ReceiveWugnotContent", () => {
+  it("opens the unwrap swap route in the current tab", () => {
+    render(<ReceiveWugnotContent onClick={jest.fn()} close={jest.fn()} />);
+
+    const link = screen.getByRole("link", { name: /Modal:toast.receive-wugnot.link/i });
+
+    expect(link).toHaveAttribute("href", "/swap?from=gno.land/r/gnoland/wugnot&to=ugnot");
+    expect(link).not.toHaveAttribute("target");
+    expect(link).not.toHaveAttribute("rel");
+  });
+});

--- a/packages/web/src/providers/snackbar-provider/snackbar/contents/ReceiveWugnotContent.tsx
+++ b/packages/web/src/providers/snackbar-provider/snackbar/contents/ReceiveWugnotContent.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import Link from "next/link";
 
 import { GNOT_UNIT_DENOM } from "@common/values/token-constant";
 import IconArrowRight from "@components/common/icons/IconArrowRight";
@@ -39,9 +40,9 @@ const ReceiveWugnotContent: React.FC<{ content?: SnackbarContent; onClick: () =>
             __html: sanitizeHtml(content?.description || t("Modal:toast.receive-wugnot.desc")),
           }}
         />
-        <a className="link" href={getUnwrapUrl()} target="_blank" rel="noopener noreferrer" onClick={onClickLink}>
+        <Link className="link" href={getUnwrapUrl()} onClick={onClickLink}>
           {t("Modal:toast.receive-wugnot.link")} <IconArrowRight />
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Keep the wrapped GNOT toast's unwrap swap link in the current tab.
- Add a regression test that ensures the link does not render `target` or `rel` attributes.

## Context
- The toast link previously opened `/swap?from=...&to=...` in a new `noopener` tab.
- Wallet restoration in the app depends on `sessionStorage`, so the new tab could start without the existing wallet session and show `Wallet Login`.

## Changes
- Replaced the internal unwrap swap `<a target="_blank" rel="noopener noreferrer">` with Next `Link`.
- Covered the current-tab behavior in `ReceiveWugnotContent.spec.tsx`.

## Verification
- `corepack yarn workspace @gnoswap-labs/web jest src/providers/snackbar-provider/snackbar/contents/ReceiveWugnotContent.spec.tsx --runInBand`
- `corepack yarn workspace @gnoswap-labs/web next lint --file src/providers/snackbar-provider/snackbar/contents/ReceiveWugnotContent.tsx --file src/providers/snackbar-provider/snackbar/contents/ReceiveWugnotContent.spec.tsx`
- `corepack yarn workspace @gnoswap-labs/web prettier --check src/providers/snackbar-provider/snackbar/contents/ReceiveWugnotContent.tsx src/providers/snackbar-provider/snackbar/contents/ReceiveWugnotContent.spec.tsx`
- `corepack yarn workspace @gnoswap-labs/web build`

## Notes
- `next lint` for the full workspace still fails on pre-existing errors outside this change, including `src/common/errors/response.ts`, `src/hooks/common/use-click-outside.tsx`, and `src/hooks/common/use-delay-loading.tsx`.
- `tsc --noEmit` also fails on pre-existing spec fixture type errors outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the receive wugnot notification content.

* **Bug Fixes**
  * Updated the receive wugnot link to use client-side navigation instead of opening in a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->