### PR TITLE
fix: format tiny leaderboard usd values

### DIFF
--- a/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx
+++ b/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx
@@ -119,15 +119,17 @@ describe("LeaderboardTableRow", () => {
     expect(screen.queryByText("$")).not.toBeInTheDocument();
   });
 
-  it("does not expose point precision below 0.01", () => {
+  it("does not expose USD precision below 0.01", () => {
     render(
       <GnoswapThemeProvider>
         <LeaderboardTableRow
           myAddress={undefined}
           data={{
             ...createLeaderboardUser(647),
-            paidSwapFeePoint: "0.009",
-            totalPoint: "0.009",
+            swapFeeUsd: "0.009",
+            providedLiquidityFeeUsd: "0.009",
+            stakingRewardsUsd: "0.009",
+            governanceRewardsUsd: "0.009",
           }}
           tdWidths={[100, 100, 100, 100, 100, 100]}
           isMobile={false}
@@ -135,8 +137,8 @@ describe("LeaderboardTableRow", () => {
       </GnoswapThemeProvider>,
     );
 
-    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getAllByText("<$0.01")).toHaveLength(2);
     expect(screen.queryByText("0.009")).not.toBeInTheDocument();
-    expect(screen.queryByText("0.01")).not.toBeInTheDocument();
+    expect(screen.queryByText("$0.009")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx
+++ b/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx
@@ -94,4 +94,49 @@ describe("LeaderboardTableRow", () => {
     expect(screen.getByText("#101")).toBeInTheDocument();
     expect(screen.queryByText("#1100")).not.toBeInTheDocument();
   });
+
+  it("displays tiny positive USD values with the minimum USD label", () => {
+    render(
+      <GnoswapThemeProvider>
+        <LeaderboardTableRow
+          myAddress={undefined}
+          data={{
+            ...createLeaderboardUser(647),
+            governanceRewardsUsd: "0.0000003",
+            swapFeeUsd: "0.000000996805274021",
+            providedLiquidityFeeUsd: "0.000000969767947872",
+            stakingRewardsUsd: "0.0000006",
+            paidSwapFeePoint: "0.000000996805274021",
+            totalPoint: "0.000000996805274021",
+          }}
+          tdWidths={[100, 100, 100, 100, 100, 100]}
+          isMobile={false}
+        />
+      </GnoswapThemeProvider>,
+    );
+
+    expect(screen.getAllByText("<$0.01")).toHaveLength(3);
+    expect(screen.queryByText("$")).not.toBeInTheDocument();
+  });
+
+  it("does not expose point precision below 0.01", () => {
+    render(
+      <GnoswapThemeProvider>
+        <LeaderboardTableRow
+          myAddress={undefined}
+          data={{
+            ...createLeaderboardUser(647),
+            paidSwapFeePoint: "0.009",
+            totalPoint: "0.009",
+          }}
+          tdWidths={[100, 100, 100, 100, 100, 100]}
+          isMobile={false}
+        />
+      </GnoswapThemeProvider>,
+    );
+
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.queryByText("0.009")).not.toBeInTheDocument();
+    expect(screen.queryByText("0.01")).not.toBeInTheDocument();
+  });
 });

--- a/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.tsx
+++ b/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.tsx
@@ -12,7 +12,7 @@ import { LeaderboardUser } from "@repositories/leaderboard/response/common/types
 import { isLeaderboardHidden } from "@utils/leaderboard-utils";
 import { formatOtherPrice } from "@utils/new-number-utils";
 
-const formatUsdValue = (value: string | number | null | undefined) => {
+const formatUsdValue = (value: string | number | null) => {
   if (value == null || value === "") return "-";
   return formatOtherPrice(value, { isKMB: false });
 };

--- a/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.tsx
+++ b/packages/web/src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.tsx
@@ -10,13 +10,11 @@ import PointComposition from "../point-composition/PointComposition";
 import UserColumn from "../user-column/UserColumn";
 import { LeaderboardUser } from "@repositories/leaderboard/response/common/types";
 import { isLeaderboardHidden } from "@utils/leaderboard-utils";
-import { numberToFormat } from "@utils/string-utils";
-import { removeTrailingZeros } from "@utils/number-utils";
+import { formatOtherPrice } from "@utils/new-number-utils";
 
-const formatUsdValue = (value: string | number) => {
+const formatUsdValue = (value: string | number | null | undefined) => {
   if (value == null || value === "") return "-";
-  const formattedValue = `$${numberToFormat(value, { decimals: 2, forceDecimals: true, truncateDecimals: true })}`;
-  return removeTrailingZeros(formattedValue);
+  return formatOtherPrice(value, { isKMB: false });
 };
 
 const LeaderboardTableRow = ({


### PR DESCRIPTION
## Summary
- Fix leaderboard USD columns rendering as a bare `$` when values are below `$0.01`.
- Reuse the shared price formatter so tiny positive Swap, Position, and Staking values display as `<$0.01`.
- Add regression coverage for tiny USD values and point precision below `0.01`.

## Context
- The leaderboard API returns small positive values such as `0.000000996805274021` on page 7.
- The previous row formatter truncated these values to `$0.00` and then stripped trailing zeros, leaving only `$` in the table.

## Changes
- Updated `LeaderboardTableRow` USD formatting to use `formatOtherPrice(value, { isKMB: false })`.
- Covered Swap, Position, and Staking USD cells below `$0.01` in the row test.
- Covered the existing Points behavior so values below `0.01` do not expose extra precision.

## Verification
- `yarn workspace @gnoswap-labs/web exec jest src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx --runInBand`
- `yarn workspace @gnoswap-labs/web lint --file src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.tsx --file src/layouts/leaderboard-layout/components/leaderboard-table-row/LeaderboardTableRow.spec.tsx`
- LSP diagnostics on changed files: no errors
- Browser QA with `NEXT_PUBLIC_DEFAULT_CHAIN_API_URL=https://beta.gnoswap.io/api/v1`: opened `/leaderboard`, clicked page `7`, confirmed `leaderboard?limit=100&page=7` returned 200, bare `$` count was 0, and `<$0.01` rendered in the table.

## Notes
- Full `tsc --noEmit` currently fails on pre-existing unrelated spec fixture type errors and missing SVG type declarations outside this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new test cases to verify leaderboard currency rendering for extremely small USD amounts, including correct handling of values below one cent.

* **Bug Fixes**
  * Improved USD formatting to consistently show “<$0.01” for amounts under one cent and prevent stray/unchanged tiny currency values from appearing.
  * Updated leaderboard row price/value formatting to use the shared formatting behavior for more consistent rounding and display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->