### PR TITLE
fix: update earn stake CTA link

### DIFF
--- a/packages/web/src/layouts/earn/components/earn-description/EarnDescription.spec.tsx
+++ b/packages/web/src/layouts/earn/components/earn-description/EarnDescription.spec.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { Provider as JotaiProvider } from "jotai";
+
+import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
+
+import EarnDescription from "./EarnDescription";
+
+jest.mock("react-i18next", () => ({
+  Trans: ({ values }: { values: { apr: string } }) => <span>{values.apr}</span>,
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("@components/common/icons/IconArrowRight", () => {
+  const IconArrowRight = () => <span data-testid="arrow-right" />;
+  return IconArrowRight;
+});
+
+const renderEarnDescription = () =>
+  render(
+    <JotaiProvider>
+      <GnoswapThemeProvider>
+        <EarnDescription
+          highestAprInfo={{
+            apr: 123,
+            path: "gno.land/r/gnoland/wugnot:gno.land/r/gnoswap/gns:3000",
+          }}
+        />
+      </GnoswapThemeProvider>
+    </JotaiProvider>,
+  );
+
+describe("EarnDescription", () => {
+  it("links the Go to Stake action to the stake position page", () => {
+    renderEarnDescription();
+
+    const stakeLink = screen.getByRole("link", { name: "Earn:earnInstruction.stake.goto" });
+
+    expect(stakeLink).toHaveAttribute("href", "/earn/pool/stake");
+  });
+});

--- a/packages/web/src/layouts/earn/components/earn-description/EarnDescription.tsx
+++ b/packages/web/src/layouts/earn/components/earn-description/EarnDescription.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from "react-i18next";
 
 import IconArrowRight from "@components/common/icons/IconArrowRight";
 import { EXT_URL } from "@constants/external-url.contant";
+import { PAGE_PATH } from "@constants/page.constant";
 
 import { EarnDescriptionWrapper } from "./EarnDescription.styles";
 
@@ -44,7 +45,7 @@ const EarnDescription: React.FC<EarnDescriptionProps> = ({ highestAprInfo }) => 
                 apr: `${BigNumber(highestAprInfo.apr).toFormat(0)}%`,
               }}
             />
-            <a className="link-wrapper-no-flex" href={`/earn/pool?poolPath=${highestAprInfo.path}#staking`}>
+            <a className="link-wrapper-no-flex" href={PAGE_PATH.POOL_STAKE}>
               {t("Earn:earnInstruction.stake.goto")}
               <IconArrowRight />
             </a>


### PR DESCRIPTION
## Summary
- Update the Earn page Go to Stake CTA to link directly to `/earn/pool/stake`.
- Add a regression test for the CTA href.

## Changes
- Replace the pool-detail `#staking` anchor link with `PAGE_PATH.POOL_STAKE`.
- Cover the EarnDescription stake CTA with a Jest DOM assertion.

## Verification
- `yarn workspace @gnoswap-labs/web jest --runTestsByPath src/layouts/earn/components/earn-description/EarnDescription.spec.tsx --runInBand`
- `git diff --check`
- `yarn workspace @gnoswap-labs/web lint --file src/layouts/earn/components/earn-description/EarnDescription.tsx --file src/layouts/earn/components/earn-description/EarnDescription.spec.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Go to Stake” link in the Earn section to always point to the correct staking page.
  * The APR display and translated content remain unchanged.

* **Tests**
  * Added coverage to verify the Earn description renders the stake link correctly and points to the expected destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->