### PR TITLE
fix(portfolio): respect toggle state for My Position count

### DIFF
--- a/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.spec.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.spec.tsx
@@ -1,0 +1,60 @@
+import { render } from "@testing-library/react";
+
+import { usePositionData } from "@hooks/pool/data/use-position-data";
+
+import WalletMyPositionsHeader from "./WalletMyPositionsHeader";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("@hooks/wallet/data/use-wallet", () => ({
+  useWallet: () => ({ isSwitchNetwork: false }),
+}));
+
+jest.mock("@hooks/pool/data/use-position-data", () => ({
+  usePositionData: jest.fn(),
+}));
+
+jest.mock("@components/common/switch/Switch", () => ({
+  __esModule: true,
+  default: () => <input type="checkbox" readOnly />,
+}));
+
+jest.mock("./WalletMyPositionsHeader.styles", () => ({
+  wrapper: {},
+}));
+
+const mockUsePositionData = usePositionData as jest.Mock;
+
+describe("WalletMyPositionsHeader", () => {
+  beforeEach(() => {
+    mockUsePositionData.mockReturnValue({
+      positions: [],
+      isFetchedPosition: true,
+      totalPositionCount: 1,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requests only open positions when closed positions are hidden", () => {
+    render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={false} />);
+
+    expect(mockUsePositionData).toHaveBeenCalledWith({
+      withClosed: false,
+      scopeId: "WalletMyPositionsHeader",
+    });
+  });
+
+  it("requests open and closed positions when closed positions are shown", () => {
+    render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={true} />);
+
+    expect(mockUsePositionData).toHaveBeenCalledWith({
+      withClosed: true,
+      scopeId: "WalletMyPositionsHeader",
+    });
+  });
+});

--- a/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.tsx
@@ -19,7 +19,7 @@ const WalletMyPositionsHeader: React.FC<{ toggleClosed: () => void; isClosed: bo
     isFetchedPosition: isFetchedPosition,
     totalPositionCount,
   } = usePositionData({
-    isClosed: false,
+    withClosed: isClosed,
     scopeId: "WalletMyPositionsHeader",
   });
 

--- a/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.spec.tsx
+++ b/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.spec.tsx
@@ -1,0 +1,107 @@
+import { render } from "@testing-library/react";
+
+import { usePositionData } from "@hooks/pool/data/use-position-data";
+
+import WalletPositionCardListContainer from "./WalletPositionCardListContainer";
+
+jest.mock("jotai", () => ({
+  ...jest.requireActual("jotai"),
+  useAtomValue: () => "light",
+}));
+
+jest.mock("@components/common/my-position-card-list/MyPositionCardList", () => ({
+  __esModule: true,
+  default: () => <div data-testid="my-position-card-list" />,
+}));
+
+jest.mock("@hooks/common/use-custom-router", () => ({
+  __esModule: true,
+  default: () => ({
+    getPoolPath: jest.fn(),
+    movePageWithPoolPath: jest.fn(),
+  }),
+}));
+
+jest.mock("@hooks/common/use-window-size", () => {
+  const size = { width: 1200 };
+  return {
+    useWindowSize: () => size,
+  };
+});
+
+jest.mock("@hooks/pool/data/use-pool-data", () => {
+  const pools: unknown[] = [];
+  return {
+    usePoolData: () => ({ pools, loading: false }),
+  };
+});
+
+jest.mock("@hooks/pool/data/use-position-data", () => ({
+  usePositionData: jest.fn(),
+}));
+
+jest.mock("@hooks/token/data/use-gnot-wugnot", () => {
+  const getGnotPath = (token: unknown) => token;
+  return {
+    useGnotToGnot: () => ({ getGnotPath }),
+  };
+});
+
+jest.mock("@hooks/token/data/use-token-data", () => {
+  const tokenPrices = {};
+  return {
+    useTokenData: () => ({ tokenPrices }),
+  };
+});
+
+jest.mock("@hooks/wallet/data/use-wallet", () => {
+  const wallet = { connected: true };
+  return {
+    useWallet: () => wallet,
+  };
+});
+
+jest.mock("@services/converters/position", () => ({
+  PositionConverter: {
+    convertPositions: jest.fn(positions => positions),
+  },
+}));
+
+const mockUsePositionData = usePositionData as jest.Mock;
+
+describe("WalletPositionCardListContainer", () => {
+  beforeEach(() => {
+    mockUsePositionData.mockReturnValue({
+      isFetchedPosition: true,
+      loading: false,
+      positions: [],
+      totalPositionCount: 0,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requests only open positions when closed positions are hidden", () => {
+    render(<WalletPositionCardListContainer isClosed={false} />);
+
+    expect(mockUsePositionData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        withClosed: false,
+        page: 1,
+      }),
+    );
+  });
+
+  it("requests open and closed positions when closed positions are shown", () => {
+    render(<WalletPositionCardListContainer isClosed={true} />);
+
+    expect(mockUsePositionData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        withClosed: true,
+        page: 1,
+      }),
+    );
+  });
+});

--- a/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.tsx
+++ b/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.tsx
@@ -29,9 +29,9 @@ const WalletPositionCardListContainer: React.FC<{ isClosed: boolean }> = ({ isCl
     const { DESKTOP, TABLET } = POSITION_CARD_DISPLAY_COUNT;
 
     if (width < DESKTOP_MIN && width >= TABLET_MIN) {
-      return TABLET * 7; // 3 * 7 = 21
+      return TABLET * 7;
     }
-    return DESKTOP * 5; // 4 * 5 = 20
+    return DESKTOP * 5;
   }, [width]);
 
   const {
@@ -40,7 +40,7 @@ const WalletPositionCardListContainer: React.FC<{ isClosed: boolean }> = ({ isCl
     positions: positionsData = [],
     totalPositionCount,
   } = usePositionData({
-    isClosed: false,
+    withClosed: isClosed,
     page,
     limit,
   });


### PR DESCRIPTION
## Description

Replace hardcoded `isClosed: false` with dynamic `withClosed: isClosed` to ensure position count only includes closed positions when the `"show closed positions" toggle is ON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closed-position views now load the correct set of portfolio data based on the selected tab, improving consistency across wallet position screens.
  * Position lists and headers now respect whether closed positions should be included, so the displayed results match the current view.

* **Tests**
  * Added coverage for wallet position header and list behavior to verify the correct position data is requested in both open and closed views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->