### PR TITLE
fix: show claimed reward token symbols

### DIFF
--- a/packages/web/src/models/position/mapper/position-mapper.spec.ts
+++ b/packages/web/src/models/position/mapper/position-mapper.spec.ts
@@ -25,4 +25,32 @@ describe("PositionMapper", () => {
   it("defaults missing totalDailyRewardsUsd", () => {
     expect(PositionMapper.from(position).totalDailyRewardsUsd).toBe("$0");
   });
+
+  it("fills claimed reward token display symbol from token symbol", () => {
+    const mappedPosition = PositionMapper.from({
+      ...position,
+      claimedRewards: [
+        {
+          rewardType: "INTERNAL_REWARD",
+          claimedAmount: "100",
+          rewardToken: {
+            path: "gno.land/r/gns",
+            tokenId: "gns",
+            type: "GRC20",
+            chainId: "dev.gnoswap",
+            name: "Gnoswap",
+            symbol: "GNS",
+            displaySymbol: "",
+            decimals: 6,
+            logoURI: "",
+            createdAt: "2024-01-24T15:12:21Z",
+            priceID: "GNS",
+            rewardType: "INTERNAL_REWARD",
+          },
+        },
+      ],
+    });
+
+    expect(mappedPosition.claimedRewards[0]?.rewardToken.displaySymbol).toBe("GNS");
+  });
 });

--- a/packages/web/src/models/position/mapper/position-mapper.ts
+++ b/packages/web/src/models/position/mapper/position-mapper.ts
@@ -4,7 +4,7 @@ import { PositionResponse } from "@repositories/position/response";
 import { RewardResponse } from "@repositories/position/response/reward-response";
 import { PoolPositionModel } from "../pool-position-model";
 import { PositionModel } from "../position-model";
-import { RewardModel } from "../reward-model";
+import { ClaimedRewardModel, RewardModel, RewardTokenModel } from "../reward-model";
 import { toUnitFormat } from "@utils/number-utils";
 import { formatDisplayTokenSymbol } from "@utils/token-utils";
 import { SwapFeeTierInfoMap } from "@constants/option.constant";
@@ -47,7 +47,7 @@ export class PositionMapper {
       stakedAt: position.stakedAt || "",
       stakedUsdValue: position.stakedUsd || "",
       rewards: position.rewards?.map(PositionMapper.rewardFromResponse) || [],
-      claimedRewards: position.claimedRewards || [],
+      claimedRewards: position.claimedRewards?.map(PositionMapper.claimedRewardFromResponse) || [],
       closed: position.closed,
       totalDailyRewardsUsd: toUnitFormat(position.totalDailyRewardsUsd ?? "", true, true),
       totalClaimedUsd: position.totalClaimedUsd,
@@ -62,15 +62,28 @@ export class PositionMapper {
 
   public static rewardFromResponse(reward: RewardResponse): RewardModel {
     return {
-      rewardToken: {
-        ...reward.rewardToken,
-        displaySymbol: formatDisplayTokenSymbol(reward.rewardToken.symbol),
-      },
+      rewardToken: PositionMapper.rewardTokenFromResponse(reward.rewardToken),
       apr: reward.apr !== "" ? Number(reward.apr) : null,
       totalAmount: reward.totalAmount,
       claimableAmount: reward.claimableAmount,
       claimableUsd: reward.claimableUsd,
       // rewardType: reward.rewardType.toUpperCase() as RewardType,
+    };
+  }
+
+  private static claimedRewardFromResponse(reward: ClaimedRewardModel): ClaimedRewardModel {
+    return {
+      ...reward,
+      rewardToken: PositionMapper.rewardTokenFromResponse(reward.rewardToken),
+    };
+  }
+
+  private static rewardTokenFromResponse(rewardToken: RewardTokenModel): RewardTokenModel {
+    return {
+      ...rewardToken,
+      displaySymbol: formatDisplayTokenSymbol(
+        rewardToken.symbol || rewardToken.displaySymbol || rewardToken.name || rewardToken.path,
+      ),
     };
   }
 


### PR DESCRIPTION
## Summary
- Normalize claimed reward token display symbols in the position mapper.
- Reuse the same reward token display fallback used by regular rewards so tooltip rows do not render logo-only tokens.

## Changes
- Map `claimedRewards` through `PositionMapper` instead of passing API response tokens through unchanged.
- Add a regression test for claimed reward tokens with an empty `displaySymbol`.

## Verification
- `yarn workspace @gnoswap-labs/web test:ci --runTestsByPath src/models/position/mapper/position-mapper.spec.ts --runInBand`
- `yarn build`
- `yarn exec eslint packages/web/src/models/position/mapper/position-mapper.ts packages/web/src/models/position/mapper/position-mapper.spec.ts`