### PR TITLE
refactor: token approvals through common realm

### DIFF
--- a/packages/web/src/common/clients/wallet-client/transaction-messages/common.spec.ts
+++ b/packages/web/src/common/clients/wallet-client/transaction-messages/common.spec.ts
@@ -1,3 +1,5 @@
+import { PACKAGE_COMMON_PATH } from "@constants/environment.constant";
+
 import {
   makeTransactionMessage,
   makeTransactionMessagesWithApproves,
@@ -36,18 +38,18 @@ describe("makeTransactionMessagesWithApproves", () => {
       {
         caller,
         send: "",
-        pkg_path: tokenPath,
+        pkg_path: PACKAGE_COMMON_PATH,
         func: "Approve",
-        args: [targetAddress, "100"],
+        args: [tokenPath, targetAddress, "100"],
         gasFee: undefined,
       },
       transactionMessage,
       {
         caller,
         send: "",
-        pkg_path: tokenPath,
+        pkg_path: PACKAGE_COMMON_PATH,
         func: "Approve",
-        args: [targetAddress, "0"],
+        args: [tokenPath, targetAddress, "0"],
         gasFee: undefined,
       },
     ]);
@@ -63,9 +65,9 @@ describe("makeTransactionMessagesWithApproves", () => {
       {
         caller,
         send: "",
-        pkg_path: tokenPath,
+        pkg_path: PACKAGE_COMMON_PATH,
         func: "Approve",
-        args: [targetAddress, "0"],
+        args: [tokenPath, targetAddress, "0"],
         gasFee: undefined,
       },
     ]);
@@ -98,26 +100,26 @@ describe("makeTransactionMessagesWithApproves", () => {
       {
         caller,
         send: "",
-        pkg_path: tokenPath,
+        pkg_path: PACKAGE_COMMON_PATH,
         func: "Approve",
-        args: [targetAddress, "100"],
+        args: [tokenPath, targetAddress, "100"],
         gasFee: undefined,
       },
       transactionMessage,
       {
         caller,
         send: "",
-        pkg_path: tokenPath,
+        pkg_path: PACKAGE_COMMON_PATH,
         func: "Approve",
-        args: [targetAddress, "0"],
+        args: [tokenPath, targetAddress, "0"],
         gasFee: undefined,
       },
       {
         caller,
         send: "",
-        pkg_path: tokenPath,
+        pkg_path: PACKAGE_COMMON_PATH,
         func: "Approve",
-        args: [skippedTargetAddress, "0"],
+        args: [tokenPath, skippedTargetAddress, "0"],
         gasFee: undefined,
       },
     ]);
@@ -138,12 +140,50 @@ describe("makeTransactionMessagesWithApproves", () => {
       {
         caller,
         send: "",
-        pkg_path: tokenPath,
+        pkg_path: PACKAGE_COMMON_PATH,
         func: "Approve",
-        args: [targetAddress, "100"],
+        args: [tokenPath, targetAddress, "100"],
         gasFee: undefined,
       },
       transactionMessage,
+    ]);
+  });
+
+  it("uses common realm Approve for IBC token approve and reset messages", async () => {
+    const ibcTokenPath = "gno.land/r/aib/ibc/apps/transfer.9C935EC805585DF5162725E2C857BF2F5E390F2418B3DB7595448A5485BC6F8A";
+    const fetchAllowance = jest.fn(async () => 0);
+
+    const messages = await makeTransactionMessagesWithApproves(
+      [transactionMessage],
+      [
+        {
+          tokenPath: ibcTokenPath,
+          targetAddress,
+          amount: "100",
+          caller,
+        },
+      ],
+      fetchAllowance,
+    );
+
+    expect(messages).toEqual([
+      {
+        caller,
+        send: "",
+        pkg_path: PACKAGE_COMMON_PATH,
+        func: "Approve",
+        args: [ibcTokenPath, targetAddress, "100"],
+        gasFee: undefined,
+      },
+      transactionMessage,
+      {
+        caller,
+        send: "",
+        pkg_path: PACKAGE_COMMON_PATH,
+        func: "Approve",
+        args: [ibcTokenPath, targetAddress, "0"],
+        gasFee: undefined,
+      },
     ]);
   });
 });

--- a/packages/web/src/common/clients/wallet-client/transaction-messages/common.ts
+++ b/packages/web/src/common/clients/wallet-client/transaction-messages/common.ts
@@ -4,7 +4,7 @@ import { getGRC20Allowance } from "@common/clients/gno-provider";
 import { GnoProvider } from "@common/clients/gno-provider/gno-provider";
 import { TransactionMessageError } from "@common/errors";
 import { DEFAULT_ALLOWANCE_LIMIT } from "@common/values";
-import { PACKAGE_NFT_PATH, WRAPPED_GNOT_PATH } from "@constants/environment.constant";
+import { PACKAGE_COMMON_PATH, PACKAGE_NFT_PATH, WRAPPED_GNOT_PATH } from "@constants/environment.constant";
 import { MAX_INT64_STR } from "@utils/math.utils";
 
 export interface TransactionBankMessage {
@@ -81,9 +81,9 @@ export function makeTokenApproveMessage(
   return makeTransactionMessage({
     caller,
     send: "",
-    packagePath: tokenPath,
+    packagePath: PACKAGE_COMMON_PATH,
     func: "Approve",
-    args: [targetAddress, amount.toString()],
+    args: [tokenPath, targetAddress, amount.toString()],
   });
 }
 

--- a/packages/web/src/constants/environment.constant.ts
+++ b/packages/web/src/constants/environment.constant.ts
@@ -33,6 +33,8 @@ export const PACKAGE_REFERRAL_ADDRESS = getAddressByPackagePath(PACKAGE_REFERRAL
 
 export const PACKAGE_NFT_PATH = process.env.NEXT_PUBLIC_PACKAGE_NFT_PATH || "";
 
+export const PACKAGE_COMMON_PATH = process.env.NEXT_PUBLIC_PACKAGE_COMMON_PATH || "gno.land/r/gnoswap/common";
+
 export const PACKAGE_GOVERNANCE_PATH = process.env.NEXT_PUBLIC_PACKAGE_GOVERNANCE_PATH || "";
 
 export const PACKAGE_GOVERNANCE_STAKER_PATH = process.env.NEXT_PUBLIC_PACKAGE_GOVERNANCE_STAKER_PATH || "";

--- a/packages/web/src/repositories/governance/governance.message.spec.ts
+++ b/packages/web/src/repositories/governance/governance.message.spec.ts
@@ -1,4 +1,5 @@
 jest.mock("@constants/environment.constant", () => ({
+  PACKAGE_COMMON_PATH: "common_path",
   GNS_TOKEN_PATH: "gns_token_path",
   PACKAGE_GOVERNANCE_PATH: "governance_path",
   PACKAGE_GOVERNANCE_STAKER_ADDRESS: "governance_staker_address",
@@ -19,9 +20,9 @@ describe("governance.message.ts", () => {
 
     expect(messages[0]).toMatchObject({
       caller,
-      pkg_path: "gns_token_path",
+      pkg_path: "common_path",
       func: "Approve",
-      args: ["governance_staker_address", "123000000"],
+      args: ["gns_token_path", "governance_staker_address", "123000000"],
     });
     expect(messages[1]).toMatchObject({
       caller,

--- a/packages/web/src/repositories/launchpad/launchpad.message.spec.ts
+++ b/packages/web/src/repositories/launchpad/launchpad.message.spec.ts
@@ -1,4 +1,5 @@
 jest.mock("@constants/environment.constant", () => ({
+  PACKAGE_COMMON_PATH: "common_path",
   GNS_TOKEN_PATH: "gns_token_path",
   PACKAGE_LAUNCHPAD_ADDRESS: "launchpad_address",
   PACKAGE_LAUNCHPAD_PATH: "launchpad_path",
@@ -21,9 +22,9 @@ describe("launchpad.message.ts", () => {
 
     expect(messages[0]).toMatchObject({
       caller,
-      pkg_path: "gns_token_path",
+      pkg_path: "common_path",
       func: "Approve",
-      args: ["launchpad_address", "456000000"],
+      args: ["gns_token_path", "launchpad_address", "456000000"],
     });
     expect(messages[1]).toMatchObject({
       caller,

--- a/packages/web/src/repositories/pool/pool.message.spec.ts
+++ b/packages/web/src/repositories/pool/pool.message.spec.ts
@@ -1,6 +1,7 @@
 import type { TokenModel } from "@models/token/token-model";
 
 jest.mock("@constants/environment.constant", () => ({
+  PACKAGE_COMMON_PATH: "common_path",
   GNS_TOKEN_PATH: "gns_token_path",
   PACKAGE_POOL_ADDRESS: "pool_address",
   PACKAGE_POOL_PATH: "pool_path",
@@ -52,15 +53,15 @@ describe("pool.message.ts", () => {
 
     expect(messages[0]).toMatchObject({
       caller,
-      pkg_path: "tokenA_path",
+      pkg_path: "common_path",
       func: "Approve",
-      args: ["pool_address", "1250000"],
+      args: ["tokenA_path", "pool_address", "1250000"],
     });
     expect(messages[1]).toMatchObject({
       caller,
-      pkg_path: "tokenB_path",
+      pkg_path: "common_path",
       func: "Approve",
-      args: ["pool_address", "3000000"],
+      args: ["tokenB_path", "pool_address", "3000000"],
     });
     expect(messages[2]).toMatchObject({
       caller,
@@ -97,9 +98,9 @@ describe("pool.message.ts", () => {
 
     expect(messages[0]).toMatchObject({
       caller,
-      pkg_path: "gns_token_path",
+      pkg_path: "common_path",
       func: "Approve",
-      args: ["staker_address", "1750000000"],
+      args: ["gns_token_path", "staker_address", "1750000000"],
     });
     expect(messages[1]).toMatchObject({
       caller,

--- a/packages/web/src/repositories/position/position.message.spec.ts
+++ b/packages/web/src/repositories/position/position.message.spec.ts
@@ -7,6 +7,7 @@ import type { TransactionMessage } from "@common/clients/wallet-client/transacti
 import BigNumber from "bignumber.js";
 
 jest.mock("@constants/environment.constant", () => ({
+  PACKAGE_COMMON_PATH: "common_path",
   // GNOT wrapper
   WRAPPED_GNOT_PATH: "wugnot",
 
@@ -126,15 +127,16 @@ const splitMessagesByApproveReset = (
 };
 
 const toResetApproveMessage = (message: TransactionMessage): TransactionMessage => {
-  const targetAddress = message.args?.[0];
+  const tokenPath = message.args?.[0];
+  const targetAddress = message.args?.[1];
 
-  if (message.func !== "Approve" || !targetAddress) {
-    throw new Error("Approve message must include a target address");
+  if (message.func !== "Approve" || !tokenPath || !targetAddress) {
+    throw new Error("Approve message must include token and target addresses");
   }
 
   return {
     ...message,
-    args: [targetAddress, "0"],
+    args: [tokenPath, targetAddress, "0"],
   };
 };
 
@@ -416,17 +418,17 @@ describe("position.message.ts", () => {
           {
             caller,
             send: "",
-            pkg_path: "wugnot",
+            pkg_path: "common_path",
             func: "Approve",
-            args: ["pool_address", "2500"],
+            args: ["wugnot", "pool_address", "2500"],
             gasFee: undefined,
           },
           {
             caller,
             send: "",
-            pkg_path: "tokenB_path",
+            pkg_path: "common_path",
             func: "Approve",
-            args: ["pool_address", "3000000"],
+            args: ["tokenB_path", "pool_address", "3000000"],
             gasFee: undefined,
           },
         ]),
@@ -532,17 +534,17 @@ describe("position.message.ts", () => {
           {
             caller,
             send: "",
-            pkg_path: "wugnot",
+            pkg_path: "common_path",
             func: "Approve",
-            args: ["pool_address", "2500"],
+            args: ["wugnot", "pool_address", "2500"],
             gasFee: undefined,
           },
           {
             caller,
             send: "",
-            pkg_path: "tokenB_path",
+            pkg_path: "common_path",
             func: "Approve",
-            args: ["pool_address", "3000000"],
+            args: ["tokenB_path", "pool_address", "3000000"],
             gasFee: undefined,
           },
         ]),

--- a/packages/web/src/repositories/swap-router/swap-router.message.spec.ts
+++ b/packages/web/src/repositories/swap-router/swap-router.message.spec.ts
@@ -3,6 +3,7 @@ import type { EstimatedRoute } from "@models/swap/swap-route-info";
 import type { TokenModel } from "@models/token/token-model";
 
 jest.mock("@constants/environment.constant", () => ({
+  PACKAGE_COMMON_PATH: "common_path",
   PACKAGE_ROUTER_ADDRESS: "router_address",
   PACKAGE_ROUTER_PATH: "router_path",
   WRAPPED_GNOT_PATH: "wugnot",
@@ -78,9 +79,9 @@ describe("swap-router.message.ts", () => {
       {
         caller,
         send: "",
-        pkg_path: "token_in",
+        pkg_path: "common_path",
         func: "Approve",
-        args: ["router_address", "1250000"],
+        args: ["token_in", "router_address", "1250000"],
         gasFee: undefined,
       },
     ]);
@@ -91,10 +92,10 @@ describe("swap-router.message.ts", () => {
       args: ["token_in", "token_out", "1250000", "token_in:token_out:3000", "1", "2000000", "123", ""],
     });
     expect(resetMessages).toEqual(
-      approveMessages.map(message => ({ ...message, args: [message.args?.[0] || "", "0"] })),
+      approveMessages.map(message => ({ ...message, args: [message.args?.[0] || "", message.args?.[1] || "", "0"] })),
     );
-    expect(messages.some(message => message.args?.[0] === "pool_address" && message.func === "Approve")).toBe(false);
-    expect(messages.some(message => message.pkg_path === "token_out" && message.func === "Approve")).toBe(false);
+    expect(messages.some(message => message.args?.[1] === "pool_address" && message.func === "Approve")).toBe(false);
+    expect(messages.some(message => message.args?.[0] === "token_out" && message.func === "Approve")).toBe(false);
   });
 
   it("approves only input token for exact-out swaps using max sent amount", async () => {
@@ -123,9 +124,9 @@ describe("swap-router.message.ts", () => {
       {
         caller,
         send: "",
-        pkg_path: "token_in",
+        pkg_path: "common_path",
         func: "Approve",
-        args: ["router_address", "1250000"],
+        args: ["token_in", "router_address", "1250000"],
         gasFee: undefined,
       },
     ]);
@@ -136,9 +137,9 @@ describe("swap-router.message.ts", () => {
       args: ["token_in", "token_out", "2000000", "token_in:token_out:3000", "1", "1250000", "123", ""],
     });
     expect(resetMessages).toEqual(
-      approveMessages.map(message => ({ ...message, args: [message.args?.[0] || "", "0"] })),
+      approveMessages.map(message => ({ ...message, args: [message.args?.[0] || "", message.args?.[1] || "", "0"] })),
     );
-    expect(messages.some(message => message.args?.[0] === "pool_address" && message.func === "Approve")).toBe(false);
-    expect(messages.some(message => message.pkg_path === "token_out" && message.func === "Approve")).toBe(false);
+    expect(messages.some(message => message.args?.[1] === "pool_address" && message.func === "Approve")).toBe(false);
+    expect(messages.some(message => message.args?.[0] === "token_out" && message.func === "Approve")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Route token approval messages through the GnoSwap common realm `Approve` helper.
- Use `PACKAGE_COMMON_PATH` with a `gno.land/r/gnoswap/common` fallback for approval messages.
- Update approval message tests across pool, swap, governance, launchpad, and position flows.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized token approval and reset transactions to use the shared approval implementation.
  * Corrected approval argument formatting by consistently including the token path.
  * Improved approval handling across governance, launchpad, pool, liquidity, and swap transactions.
  * Added configurable support for the shared package path, with a default value when not provided.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->