### PR TITLE
fix: keep pool add ticks and start price in the sorted token order

### DIFF
--- a/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
@@ -30,6 +30,7 @@ import { CreatePoolFailedResponse, CreatePoolSuccessResponse } from "@repositori
 import { CommonState } from "@states/index";
 import { subscriptFormat } from "@utils/number-utils";
 import { makeDisplayPrice } from "@utils/pool-utils";
+import { sortTokenPaths } from "@utils/sort-utils";
 import { formatTokenExchangeRate } from "@utils/stake-position-utils";
 import { priceToNearTick } from "@utils/swap-utils";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
@@ -40,7 +41,7 @@ import { useAddress } from "@hooks/common/use-address";
 import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
 import { useTransactionEventStore } from "@hooks/common/use-transaction-event-store";
 import PoolAddConfirmModal from "@layouts/pool/pool-add/components/pool-add-confirm-modal/PoolAddConfirmModal";
-import { delay } from "@utils/common";
+import { checkGnotPath, delay } from "@utils/common";
 
 export interface EarnAddLiquidityConfirmModalProps {
   tokenA: TokenModel | null;
@@ -326,6 +327,17 @@ export const usePoolAddLiquidityConfirmModal = ({
       }
     }
 
+    /**
+     * The selected price range is quoted in the compare token, but a pool always stores
+     * ticks based on the sorted token0. When the compare token is token1 (e.g. after flipping
+     * the token pair), the prices are inverted, so the ticks have to be inverted back.
+     */
+    const [firstSortedPath] = [checkGnotPath(tokenA.path), checkGnotPath(tokenB.path)].sort(sortTokenPaths);
+    const basePath = checkGnotPath(selectPool.compareToken?.path ?? tokenA.path);
+    if (basePath !== firstSortedPath) {
+      [minTick, maxTick] = [-maxTick, -minTick];
+    }
+
     broadcastLoading(
       getMessage(DexEvent.ADD, "pending", {
         tokenASymbol: tokenA?.displaySymbol,
@@ -454,6 +466,7 @@ export const usePoolAddLiquidityConfirmModal = ({
     selectPool.isCreate,
     selectPool.selectedFullRange,
     selectPool.startPrice,
+    selectPool.compareToken?.path,
     addLiquidity,
     tokenAAmount,
     tokenBAmount,

--- a/packages/web/src/layouts/pool/pool-add/containers/earn-add-liquidity-container/EarnAddLiquidityContainer.utils.ts
+++ b/packages/web/src/layouts/pool/pool-add/containers/earn-add-liquidity-container/EarnAddLiquidityContainer.utils.ts
@@ -1,50 +1,5 @@
-import BigNumber from "bignumber.js";
-
-import type { TokenModel } from "@models/token/token-model";
-import { checkGnotPath } from "@utils/common";
-import { makeRawPrice } from "@utils/pool-utils";
-import { sortTokenPaths } from "@utils/sort-utils";
-import { priceToNearTick, tickToPrice } from "@utils/swap-utils";
-
-export const snapPoolAddRawStartingPrice = (rawPrice: number, tickSpacing: number): number | null => {
-  if (BigNumber(rawPrice).isNaN() || !Number.isFinite(rawPrice) || rawPrice <= 0) {
-    return null;
-  }
-
-  const tick = priceToNearTick(rawPrice, tickSpacing);
-  return tickToPrice(tick);
-};
-
-const getPoolOrderPath = (token: TokenModel): string => {
-  return token.wrappedPath || checkGnotPath(token.path) || token.path;
-};
-
-export const makePoolAddSortedRawPrice = (
-  displayPrice: number,
-  baseToken: TokenModel,
-  quoteToken: TokenModel,
-): number => {
-  const rawPriceInInputOrder = makeRawPrice(displayPrice, baseToken, quoteToken);
-  const [firstPath] = [getPoolOrderPath(baseToken), getPoolOrderPath(quoteToken)].sort(sortTokenPaths);
-
-  if (firstPath === getPoolOrderPath(baseToken)) {
-    return rawPriceInInputOrder;
-  }
-
-  return BigNumber(1).div(rawPriceInInputOrder).toNumber();
-};
-
-export const resolvePoolAddStartingPrice = (
-  displayPrice: string,
-  tokenA: TokenModel,
-  tokenB: TokenModel,
-  tickSpacing: number,
-): number | null => {
-  const priceNum = BigNumber(displayPrice).toNumber();
-  if (BigNumber(priceNum).isNaN() || !Number.isFinite(priceNum) || priceNum <= 0) {
-    return null;
-  }
-
-  const rawPrice = makePoolAddSortedRawPrice(priceNum, tokenA, tokenB);
-  return snapPoolAddRawStartingPrice(rawPrice, tickSpacing);
-};
+export {
+  makePoolAddSortedRawPrice,
+  resolvePoolAddStartingPrice,
+  snapPoolAddRawStartingPrice,
+} from "../pool-add-starting-price.utils";

--- a/packages/web/src/layouts/pool/pool-add/containers/pool-add-liquidity-container/PoolAddLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-add/containers/pool-add-liquidity-container/PoolAddLiquidityContainer.tsx
@@ -25,13 +25,12 @@ import { isNativeToken, TokenModel } from "@models/token/token-model";
 import { SwapState } from "@states/index";
 import { formatRate } from "@utils/new-number-utils";
 import { makeRouteUrl, replaceRouteUrlWithoutNavigation } from "@utils/page.utils";
-import { invertSqrtPriceX96, makeDisplayPrice, makeRawPrice } from "@utils/pool-utils";
+import { invertSqrtPriceX96, makeDisplayPrice } from "@utils/pool-utils";
 import { sortTokenPaths } from "@utils/sort-utils";
 import {
   getDepositAmountsByAmountA,
   getDepositAmountsByAmountB,
   makeSwapFeeTier,
-  priceToNearTick,
   priceToSqrtX96,
   priceToTick,
   tickToPrice,
@@ -41,6 +40,7 @@ import { makeDisplayTokenAmount, makeRawTokenAmount } from "@utils/token-utils";
 import { usePool } from "@hooks/pool/data/use-pool";
 import { usePoolAddLiquidityConfirmModal } from "@hooks/pool/ui/use-pool-add-liquidity-confirm-modal";
 import PoolAddLiquidity, { PriceRangeSummary } from "../../components/pool-add-liquidity/PoolAddLiquidity";
+import { resolvePoolAddStartingPrice } from "../pool-add-starting-price.utils";
 
 export const SWAP_FEE_TIERS: SwapFeeTierType[] = ["FEE_100", "FEE_500", "FEE_3000", "FEE_10000"];
 
@@ -522,8 +522,8 @@ const PoolAddLiquidityContainer: React.FC = () => {
         }));
         return;
       }
-      const priceBN = BigNumber(price);
-      if (!priceBN.isFinite() || !priceBN.gt(0)) {
+      const startPrice = resolvePoolAddStartingPrice(price, tokenA, tokenB, selectPool.tickSpacing);
+      if (startPrice === null) {
         setCreateOption(prev => ({
           ...prev,
           startPrice: null,
@@ -531,12 +531,9 @@ const PoolAddLiquidityContainer: React.FC = () => {
         }));
         return;
       }
-      const rawPrice = makeRawPrice(priceBN.toNumber(), tokenA, tokenB);
-      const tick = priceToNearTick(rawPrice, selectPool.tickSpacing);
-      const nearStartPrice = tickToPrice(tick);
       setCreateOption({
         isCreate: true,
-        startPrice: nearStartPrice,
+        startPrice,
       });
     },
     [selectPool.tickSpacing, tokenA, tokenB],

--- a/packages/web/src/layouts/pool/pool-add/containers/pool-add-starting-price.utils.ts
+++ b/packages/web/src/layouts/pool/pool-add/containers/pool-add-starting-price.utils.ts
@@ -1,0 +1,54 @@
+import BigNumber from "bignumber.js";
+
+import type { TokenModel } from "@models/token/token-model";
+import { checkGnotPath } from "@utils/common";
+import { makeRawPrice } from "@utils/pool-utils";
+import { sortTokenPaths } from "@utils/sort-utils";
+import { priceToNearTick, tickToPrice } from "@utils/swap-utils";
+
+export const snapPoolAddRawStartingPrice = (rawPrice: number, tickSpacing: number): number | null => {
+  if (BigNumber(rawPrice).isNaN() || !Number.isFinite(rawPrice) || rawPrice <= 0) {
+    return null;
+  }
+
+  const tick = priceToNearTick(rawPrice, tickSpacing);
+  return tickToPrice(tick);
+};
+
+const getPoolOrderPath = (token: TokenModel): string => {
+  return token.wrappedPath || checkGnotPath(token.path) || token.path;
+};
+
+/**
+ * The starting price is entered in the order shown on the screen, but a pool always
+ * stores the price based on the sorted token0. Invert it when the base token is token1.
+ */
+export const makePoolAddSortedRawPrice = (
+  displayPrice: number,
+  baseToken: TokenModel,
+  quoteToken: TokenModel,
+): number => {
+  const rawPriceInInputOrder = makeRawPrice(displayPrice, baseToken, quoteToken);
+  const [firstPath] = [getPoolOrderPath(baseToken), getPoolOrderPath(quoteToken)].sort(sortTokenPaths);
+
+  if (firstPath === getPoolOrderPath(baseToken)) {
+    return rawPriceInInputOrder;
+  }
+
+  return BigNumber(1).div(rawPriceInInputOrder).toNumber();
+};
+
+export const resolvePoolAddStartingPrice = (
+  displayPrice: string,
+  tokenA: TokenModel,
+  tokenB: TokenModel,
+  tickSpacing: number,
+): number | null => {
+  const priceNum = BigNumber(displayPrice).toNumber();
+  if (BigNumber(priceNum).isNaN() || !Number.isFinite(priceNum) || priceNum <= 0) {
+    return null;
+  }
+
+  const rawPrice = makePoolAddSortedRawPrice(priceNum, tokenA, tokenB);
+  return snapPoolAddRawStartingPrice(rawPrice, tickSpacing);
+};

--- a/packages/web/src/repositories/pool/pool.message.spec.ts
+++ b/packages/web/src/repositories/pool/pool.message.spec.ts
@@ -14,6 +14,7 @@ jest.mock("@constants/environment.constant", () => ({
 
 import {
   makeCreateExternalIncentiveMessageWithApproves,
+  makeCreatePoolMessageWithApproves,
   makePositionMintMessageWithApproves,
 } from "@repositories/pool/pool.message";
 
@@ -77,6 +78,32 @@ describe("pool.message.ts", () => {
       "1250000",
       "3000000",
     ]);
+  });
+
+  it("uses the given start price as is, whichever order the token pair is passed in", async () => {
+    const caller = "caller";
+    const fetchAllowance = jest.fn(async () => 0);
+    const request = {
+      feeTier: "FEE_3000" as const,
+      startPrice: "50",
+      createPoolFee: 0,
+      caller,
+    };
+
+    const orderedMessages = await makeCreatePoolMessageWithApproves(
+      { ...request, tokenA: createTokenModel("tokenA_path"), tokenB: createTokenModel("tokenB_path") },
+      fetchAllowance,
+    );
+    const reversedMessages = await makeCreatePoolMessageWithApproves(
+      { ...request, tokenA: createTokenModel("tokenB_path"), tokenB: createTokenModel("tokenA_path") },
+      fetchAllowance,
+    );
+
+    const orderedArgs = orderedMessages.find(message => message.func === "CreatePool")?.args;
+    const reversedArgs = reversedMessages.find(message => message.func === "CreatePool")?.args;
+
+    expect(orderedArgs?.slice(0, 3)).toEqual(["tokenA_path", "tokenB_path", "3000"]);
+    expect(reversedArgs).toEqual(orderedArgs);
   });
 
   it("reorders mint token paths and amounts by the sorted token pair", async () => {

--- a/packages/web/src/repositories/pool/pool.message.spec.ts
+++ b/packages/web/src/repositories/pool/pool.message.spec.ts
@@ -79,6 +79,41 @@ describe("pool.message.ts", () => {
     ]);
   });
 
+  it("reorders mint token paths and amounts by the sorted token pair", async () => {
+    const caller = "caller";
+    const fetchAllowance = jest.fn(async () => 0);
+
+    const messages = await makePositionMintMessageWithApproves(
+      {
+        tokenA: createTokenModel("tokenB_path"),
+        tokenB: createTokenModel("tokenA_path"),
+        feeTier: "FEE_3000",
+        tokenAAmount: "3",
+        tokenBAmount: "1.25",
+        minTick: -10,
+        maxTick: 20,
+        slippage: 1,
+        caller,
+        referrerAddress: null,
+      },
+      fetchAllowance,
+    );
+
+    const mintMessage = messages.find(message => message.func === "Mint");
+
+    expect(mintMessage?.args?.slice(0, 9)).toEqual([
+      "tokenA_path",
+      "tokenB_path",
+      "3000",
+      "-10",
+      "20",
+      "1250000",
+      "3000000",
+      "1237500",
+      "2970000",
+    ]);
+  });
+
   it("sums GNS incentive reward and creation deposit approvals for the same spender", async () => {
     const caller = "caller";
     const fetchAllowance = jest.fn(async () => 0);

--- a/packages/web/src/repositories/pool/pool.message.ts
+++ b/packages/web/src/repositories/pool/pool.message.ts
@@ -69,13 +69,10 @@ export function makeCreatePoolMessageWithApproves(
   }
 
   /**
-   * If the token path pairs are out of order, adjust the price and token order.
+   * The given start price is already based on the sorted token0, so only the token order is adjusted.
    */
-  const isOrdered = isOrderedTokenPaths(tokenAPath, tokenBPath);
-
   const [orderedPoolAPath, orderedPoolBPath] = [tokenAPath, tokenBPath].sort(sortTokenPaths);
-  const orderedStartPriceNum = isOrdered || startPriceNum === 0 ? startPriceNum : 1 / startPriceNum;
-  const startPriceSqrt = tickToSqrtPriceX96(priceToTick(orderedStartPriceNum));
+  const startPriceSqrt = tickToSqrtPriceX96(priceToTick(startPriceNum));
 
   const createPoolMessage = makeTransactionMessage({
     caller,

--- a/packages/web/src/repositories/pool/pool.message.ts
+++ b/packages/web/src/repositories/pool/pool.message.ts
@@ -156,14 +156,26 @@ export function makePositionMintMessageWithApproves(
     }
   }
 
+  /**
+   * Mint always expects the sorted token pair (token0, token1) with the matching amounts.
+   * The given ticks are already based on token0, so only the paths and the amounts are reordered.
+   */
+  const isOrdered = isOrderedTokenPaths(tokenAWrappedPath, tokenBWrappedPath);
+  const [token0Path, token1Path] = isOrdered
+    ? [tokenAWrappedPath, tokenBWrappedPath]
+    : [tokenBWrappedPath, tokenAWrappedPath];
+  const [amount0Raw, amount1Raw] = isOrdered
+    ? [tokenAAmountRaw, tokenBAmountRaw]
+    : [tokenBAmountRaw, tokenAAmountRaw];
+
   const mintMessage = makePositionMintMessage(
-    tokenAWrappedPath,
-    tokenBWrappedPath,
+    token0Path,
+    token1Path,
     feeTier,
     minTick,
     maxTick,
-    tokenAAmountRaw,
-    tokenBAmountRaw,
+    amount0Raw,
+    amount1Raw,
     slippage,
     caller,
     referrerAddress,


### PR DESCRIPTION
## Summary

Adding a position after flipping the token pair failed with a slippage error. There were two independent causes, both coming from values being built in the **compare token** order while the pool always works in the **sorted token pair** (`token0 < token1`) order.

```
ERROR: [GNOSWAP-POSITION-002] slippage failed || Price Slippage Check(amount0(68014865) >= amount0Min(67674791), amount1(0) >= amount1Min(3383000000))
```

## Problem

### 1. Mint ticks were sent with the wrong sign

`confirm()` computes ticks from `selectPool.minPrice / maxPrice`, which are quoted in the compare token. Flipping the pair makes the compare token `token1`, which inverts the prices and therefore the sign of the ticks (e.g. `[32160, 46080]` was sent as `[-46080, -32160]`). The range then falls outside the current price, only one side of the pair is consumed, and the other amount comes back as `0`.

`makePositionMintMessageWithApproves` also passed `tokenA` / `tokenB` through unsorted, so the paths, desired amounts and slippage minimums could be misaligned with the pool ordering.

### 2. The pool start price was inverted twice

Both pool add containers resolve the entered starting price into the sorted `token0` order (`resolvePoolAddStartingPrice`), but `makeCreatePoolMessageWithApproves` inverted it *again* whenever the request token pair was out of order. Flipping the pair made the two inversions cancel into a reciprocal price, so the pool was created at the wrong price and the mint in the same transaction fell outside the range.

Comparing the two transactions makes it visible — same range, reciprocal start price:

| | `CreatePool` sqrtPriceX96 | implied price |
| --- | --- | --- |
| before flip (succeeds) | `560166482337120227348373754579` | `49.989` |
| after flip (fails) | `11205778877017825642056062361` | `0.020004` |

`PoolAddLiquidityContainer` additionally kept the starting price in the UI's `tokenA` order rather than the sorted order, which is the ordering `useSelectPool` assumes when it derives the current price.

## Changes

- `use-pool-add-liquidity-confirm-modal.tsx`: invert the ticks to `[-maxTick, -minTick]` when the compare token is not the sorted `token0`, so the ticks are always token0-based. Full range is unaffected since `MIN_TICK` / `MAX_TICK` are symmetric.
- `pool.message.ts`:
  - reorder the `Mint` token paths, desired amounts and slippage minimums by the sorted token pair (no-op when the input is already ordered);
  - drop the extra start price inversion from `CreatePool`, since the caller now always supplies a token0-based price.
- `pool-add-starting-price.utils.ts` (new): the starting price resolver moved out of `EarnAddLiquidityContainer.utils.ts`, which now re-exports it, and `PoolAddLiquidityContainer` uses it as well so both pool add flows share one convention.

## Test plan

- [x] `pool.message.spec.ts` — added cases for a reversed token pair (paths, desired amounts and slippage minimums emitted in sorted order) and for `CreatePool` producing the same start price regardless of the input token order.
- [x] `EarnAddLiquidityContainer.utils.spec.ts` still passing (7 tests total across both suites).
- [x] `tsc --noEmit` and `eslint` report no new errors on the touched files.
- [ ] Manual check: create a pool and add a position both before and after flipping the token pair, and confirm both transactions succeed with the same start price and tick range.
