### PR TITLE
fix(pool): improve custom price range brush behavior

### DIFF
--- a/packages/web/src/components/common/pool-selection-graph/PoolSelectionGraph.tsx
+++ b/packages/web/src/components/common/pool-selection-graph/PoolSelectionGraph.tsx
@@ -22,6 +22,7 @@ import {
   createPoolSelectionGraphBins,
   getPoolSelectionGraphEmptyTickWindow,
   getPoolSelectionGraphTooltipTick,
+  normalizePoolSelectionGraphPriceRange,
 } from "./PoolSelectionGraph.utils";
 
 const MIN_VISIBLE_BAR_HEIGHT = 5;
@@ -119,6 +120,7 @@ const PoolSelectionGraph: React.FC<PoolSelectionGraphProps> = ({
   const svgRef = useRef<SVGSVGElement>(null);
   const chartRef = useRef(null);
   const brushRef = useRef<SVGGElement | null>(null);
+  const isBrushMovingRef = useRef(false);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
 
   const [priceOfTick, setPriceOfTick] = useState<{
@@ -295,6 +297,10 @@ const PoolSelectionGraph: React.FC<PoolSelectionGraphProps> = ({
     if (!brushRef.current) {
       return;
     }
+    if (event.mode !== undefined) {
+      isBrushMovingRef.current = true;
+    }
+
     const selection = event.selection ? event.selection : [0, 0];
     const startPosition = selection[0] as number;
     const endPosition = selection[1] as number;
@@ -391,6 +397,7 @@ const PoolSelectionGraph: React.FC<PoolSelectionGraphProps> = ({
     if (!brushRef.current || event.mode === undefined) {
       return;
     }
+    isBrushMovingRef.current = false;
 
     if (!!onFinishMove) {
       onFinishMove();
@@ -434,8 +441,10 @@ const PoolSelectionGraph: React.FC<PoolSelectionGraphProps> = ({
         return tickToPrice(tick);
       }
 
-      const minPrice = getPriceBy(startPosition);
-      const maxPrice = getPriceBy(endPosition);
+      const { minPrice, maxPrice } = normalizePoolSelectionGraphPriceRange(
+        getPriceBy(startPosition),
+        getPriceBy(endPosition),
+      );
 
       setSelectionColor(current => (isSameSelectionColor(current, selectionColor) ? current : selectionColor));
       setMinPrice(minPrice);
@@ -709,6 +718,9 @@ const PoolSelectionGraph: React.FC<PoolSelectionGraphProps> = ({
   // Brush settings, on currentPrice change, zoom, move ...
   useEffect(() => {
     if (minPrice === null || maxPrice === null) {
+      return;
+    }
+    if (isBrushMovingRef.current) {
       return;
     }
     if (!brushRef?.current) {

--- a/packages/web/src/components/common/pool-selection-graph/PoolSelectionGraph.utils.spec.ts
+++ b/packages/web/src/components/common/pool-selection-graph/PoolSelectionGraph.utils.spec.ts
@@ -7,6 +7,7 @@ import {
   createPoolSelectionGraphBins,
   getPoolSelectionGraphEmptyTickWindow,
   getPoolSelectionGraphTooltipTick,
+  normalizePoolSelectionGraphPriceRange,
 } from "./PoolSelectionGraph.utils";
 
 const makeToken = (symbol: string, decimals: number): TokenModel => ({
@@ -151,5 +152,19 @@ describe("getPoolSelectionGraphEmptyTickWindow", () => {
     });
 
     expect(tickWindow).toEqual({ minTick: MIN_TICK, maxTick: MAX_TICK });
+  });
+});
+
+describe("normalizePoolSelectionGraphPriceRange", () => {
+  it("keeps an ordered range below the current price unchanged", () => {
+    expect(normalizePoolSelectionGraphPriceRange(0.5, 0.8)).toEqual({ minPrice: 0.5, maxPrice: 0.8 });
+  });
+
+  it("normalizes crossed brush prices into min and max order", () => {
+    expect(normalizePoolSelectionGraphPriceRange(2.1, 0.7)).toEqual({ minPrice: 0.7, maxPrice: 2.1 });
+  });
+
+  it("preserves boundary sentinel values while ordering the range", () => {
+    expect(normalizePoolSelectionGraphPriceRange(3, 0)).toEqual({ minPrice: 0, maxPrice: 3 });
   });
 });

--- a/packages/web/src/components/common/pool-selection-graph/PoolSelectionGraph.utils.ts
+++ b/packages/web/src/components/common/pool-selection-graph/PoolSelectionGraph.utils.ts
@@ -14,6 +14,11 @@ export interface PoolSelectionGraphTickWindow {
   maxTick: number;
 }
 
+export interface PoolSelectionGraphPriceRange {
+  minPrice: number;
+  maxPrice: number;
+}
+
 const toFiniteNumber = (value: string | number | null | undefined): number => {
   if (value === null || value === undefined) {
     return 0;
@@ -111,3 +116,11 @@ export const getPoolSelectionGraphEmptyTickWindow = ({
 
   return tickWindow;
 };
+
+export const normalizePoolSelectionGraphPriceRange = (
+  startPrice: number,
+  endPrice: number,
+): PoolSelectionGraphPriceRange => ({
+  minPrice: Math.min(startPrice, endPrice),
+  maxPrice: Math.max(startPrice, endPrice),
+});

--- a/packages/web/src/hooks/pool/data/use-select-pool.tsx
+++ b/packages/web/src/hooks/pool/data/use-select-pool.tsx
@@ -376,7 +376,7 @@ export const useSelectPool = ({
         setMinPosition(null);
         return;
       }
-      if (num === 0) {
+      if (num <= swapFeeTierMaxPriceRangeMap.minPrice) {
         const { minPrice } = swapFeeTierMaxPriceRangeMap;
         setMinPosition(minPrice);
         return;
@@ -386,17 +386,24 @@ export const useSelectPool = ({
     [swapFeeTierMaxPriceRangeMap],
   );
 
-  const changeMaxPosition = useCallback((num: number | null) => {
-    if (num === null) {
-      setMaxPosition(null);
-      return;
-    }
-    setMaxPosition(num);
-  }, []);
+  const changeMaxPosition = useCallback(
+    (num: number | null) => {
+      if (num === null) {
+        setMaxPosition(null);
+        return;
+      }
+      if (num >= swapFeeTierMaxPriceRangeMap.maxPrice) {
+        setMaxPosition(swapFeeTierMaxPriceRangeMap.maxPrice);
+        return;
+      }
+      setMaxPosition(num);
+    },
+    [swapFeeTierMaxPriceRangeMap],
+  );
 
   const increaseMinTick = useCallback(() => {
     excuteInteraction(() => {
-      if (!tickSpacing || !minPosition) {
+      if (!tickSpacing || minPosition === null) {
         return;
       }
       const nearTick = priceToNearTick(minPosition, tickSpacing);
@@ -408,7 +415,7 @@ export const useSelectPool = ({
 
   const decreaseMinTick = useCallback(() => {
     excuteInteraction(() => {
-      if (!tickSpacing || !minPosition) {
+      if (!tickSpacing || minPosition === null) {
         return;
       }
       if (minPosition === 0) {
@@ -423,7 +430,7 @@ export const useSelectPool = ({
 
   const increaseMaxTick = useCallback(() => {
     excuteInteraction(() => {
-      if (!tickSpacing || !maxPosition) {
+      if (!tickSpacing || maxPosition === null) {
         return;
       }
       const nearTick = priceToNearTick(maxPosition, tickSpacing);
@@ -435,7 +442,7 @@ export const useSelectPool = ({
 
   const decreaseMaxTick = useCallback(() => {
     excuteInteraction(() => {
-      if (!tickSpacing || !maxPosition) {
+      if (!tickSpacing || maxPosition === null) {
         return;
       }
       const nearTick = priceToNearTick(maxPosition, tickSpacing);

--- a/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustom.tsx
+++ b/packages/web/src/layouts/pool/common/components/select-price-range/select-price-range-custom/SelectPriceRangeCustom.tsx
@@ -80,12 +80,17 @@ const SelectPriceRangeCustom = forwardRef<SelectPriceRangeCustomHandle, SelectPr
     const [startingPriceValue, setStartingPriceValue] = useState<string>("");
     const minPriceRangeCustomRef = useRef<React.ElementRef<typeof PriceSteps>>(null);
     const maxPriceRangeCustomRef = useRef<React.ElementRef<typeof PriceSteps>>(null);
+    const initializedRangeKeyRef = useRef<string>();
 
     const isCustom = true;
 
     const tokenPairKey = useMemo(() => {
       return [checkGnotPath(tokenA.path), checkGnotPath(tokenB.path)].sort(sortTokenPaths).join(":");
     }, [tokenA.path, tokenB.path]);
+
+    const rangeInitKey = useMemo(() => {
+      return [tokenPairKey, selectPool.poolPath ?? "", selectPool.feeTier ?? "NONE", selectPool.startPrice ?? ""].join(":");
+    }, [selectPool.feeTier, selectPool.poolPath, selectPool.startPrice, tokenPairKey]);
 
     const isLoading = useMemo(
       () => selectPool.renderState() === "LOADING" || isLoadingSelectPriceRange,
@@ -167,13 +172,13 @@ const SelectPriceRangeCustom = forwardRef<SelectPriceRangeCustomHandle, SelectPr
       const { tickLower, tickUpper } = defaultTicks ?? {};
       const { minPrice, maxPrice } = SwapFeeTierMaxPriceRangeMap[selectPool.feeTier || "NONE"];
 
-      if (inputPriceRangeType === "Custom" && tickLower && tickUpper) {
+      if (inputPriceRangeType === "Custom" && tickLower !== undefined && tickUpper !== undefined) {
         selectPool.setMinPosition(tickLower < minPrice ? minPrice : tickLower);
         selectPool.setMaxPosition(tickUpper > maxPrice ? maxPrice : tickUpper);
         return;
       }
 
-      if (currentPrice && selectPool.feeTier && currentPriceRangeType) {
+      if (currentPrice !== null && currentPrice > 0 && Number.isFinite(currentPrice) && selectPool.feeTier && currentPriceRangeType) {
         const priceRange = SwapFeeTierPriceRange[selectPool.feeTier][currentPriceRangeType];
 
         const getPriceWithTickSpacing = (range: number) => {
@@ -239,12 +244,17 @@ const SelectPriceRangeCustom = forwardRef<SelectPriceRangeCustomHandle, SelectPr
     }, [tokenA]);
 
     useEffect(() => {
-      if (isLoading) {
+      if (isLoading || !priceRangeType) {
         return;
       }
 
+      if (initializedRangeKeyRef.current === rangeInitKey) {
+        return;
+      }
+
+      initializedRangeKeyRef.current = rangeInitKey;
       resetRange(priceRangeType);
-    }, [selectPool.poolPath, selectPool.feeTier, selectPool.startPrice, isLoading]);
+    }, [rangeInitKey, isLoading, priceRangeType]);
 
     useEffect(() => {
       if (selectPool.isCreate) {

--- a/packages/web/src/layouts/pool/pool-add/containers/earn-add-liquidity-container/EarnAddLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-add/containers/earn-add-liquidity-container/EarnAddLiquidityContainer.tsx
@@ -3,7 +3,7 @@ import { useAtom } from "jotai";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { AddLiquiditySubmitType, PriceRangeMeta, SwapFeeTierType } from "@constants/option.constant";
+import { AddLiquiditySubmitType, PriceRangeMeta, PriceRangeType, SwapFeeTierType } from "@constants/option.constant";
 import { PAGE_PATH } from "@constants/page.constant";
 import useCustomRouter from "@hooks/common/use-custom-router";
 import { useLoading } from "@hooks/common/use-loading";
@@ -25,8 +25,8 @@ import {
   getDepositAmountsByAmountA,
   getDepositAmountsByAmountB,
   makeSwapFeeTier,
+  priceToBoundedTick,
   priceToSqrtX96,
-  priceToTick,
 } from "@utils/swap-utils";
 import { makeDisplayTokenAmount, makeRawTokenAmount } from "@utils/token-utils";
 
@@ -63,10 +63,11 @@ const EarnAddLiquidityContainer: React.FC = () => {
   const [swapFeeTier, setSwapFeeTier] = useState<SwapFeeTierType | null>(null);
   const [priceRanges] = useState<PriceRangeMeta[]>(PRICE_RANGES);
   const [priceRange, setPriceRange] = useState<PriceRangeMeta | null>(null);
+  const [priceRangeTypeFromUrl, setPriceRangeTypeFromUrl] = useState<PriceRangeType | null>();
   const [initialized, setInitialized] = useState(false);
   const [defaultPrice, setDefaultPrice] = useState<number | null>(null);
   const initializedFeeTier = useRef<string>();
-  const initializedPriceRange = useRef<PriceRangeMeta>();
+  const initializedPriceRangeKey = useRef<string>();
 
   const { openModal: openConnectWalletModal } = useConnectWalletModal();
 
@@ -186,7 +187,7 @@ const EarnAddLiquidityContainer: React.FC = () => {
     if (!tokenA || !tokenB) {
       return "INVALID_PAIR";
     }
-    if (selectPool.minPrice && selectPool.maxPrice && selectPool.minPrice >= selectPool.maxPrice) {
+    if (selectPool.minPrice !== null && selectPool.maxPrice !== null && selectPool.minPrice >= selectPool.maxPrice) {
       return "INVALID_RANGE";
     }
     if (!Number(tokenAAmountInput.amount) && !Number(tokenBAmountInput.amount)) {
@@ -281,6 +282,8 @@ const EarnAddLiquidityContainer: React.FC = () => {
     setExactType("EXACT_IN");
     setSwapFeeTier(null);
     setPriceRange(null);
+    setPriceRangeTypeFromUrl(null);
+    initializedPriceRangeKey.current = undefined;
     setDefaultPrice(null);
     setCreateOption({ isCreate: false, startPrice: null });
     selectPool.resetRange();
@@ -389,7 +392,7 @@ const EarnAddLiquidityContainer: React.FC = () => {
         return;
       }
 
-      if (!selectPool.minPrice || !selectPool.maxPrice) {
+      if (selectPool.minPrice === null || selectPool.maxPrice === null) {
         return;
       }
 
@@ -435,7 +438,7 @@ const EarnAddLiquidityContainer: React.FC = () => {
         return;
       }
 
-      if (!selectPool.minPrice || !selectPool.maxPrice) {
+      if (selectPool.minPrice === null || selectPool.maxPrice === null) {
         return;
       }
 
@@ -561,8 +564,13 @@ const EarnAddLiquidityContainer: React.FC = () => {
     if (!initialized) {
       setInitialized(true);
       const query = router.query;
+      const { price_range_type } = query;
       const currentTokenA = tokens.find((token: TokenModel) => token.path === query.tokenA) || null;
       const currentTokenB = tokens.find((token: TokenModel) => token.path === query.tokenB) || null;
+
+      if (typeof price_range_type === "string") {
+        setPriceRangeTypeFromUrl(price_range_type as PriceRangeType);
+      }
 
       setSwapValue({
         tokenA: currentTokenA,
@@ -582,16 +590,19 @@ const EarnAddLiquidityContainer: React.FC = () => {
     const poolFeeTier = pools.map(pool => makeSwapFeeTier(pool.fee));
     const existPool = poolFeeTier.includes(swapFeeTier);
 
+    const priceRangeKey = [tokenA.path, tokenB.path, swapFeeTier, existPool ? "exists" : "create"].join(":");
+    if (initializedPriceRangeKey.current === priceRangeKey) {
+      return;
+    }
+    initializedPriceRangeKey.current = priceRangeKey;
+
     if (existPool) {
-      if (router.query.price_range_type) {
-        setPriceRange(priceRanges.find(range => range.type === router.query.price_range_type) || null);
-        return;
-      }
-      setPriceRange(priceRanges.find(range => range.type === "Passive") || null);
+      const defaultPriceRangeType = priceRangeTypeFromUrl ?? "Passive";
+      setPriceRange(priceRanges.find(range => range.type === defaultPriceRangeType) || null);
     } else {
       setPriceRange(priceRanges.find(range => range.type === "Custom") || null);
     }
-  }, [swapFeeTier, pools, isFetchedPools, priceRanges, tokenA, tokenB, router.query.price_range_type]);
+  }, [swapFeeTier, pools, isFetchedPools, priceRanges, tokenA, tokenB, priceRangeTypeFromUrl]);
 
   useEffect(() => {
     if (pools.length > 0 && tokenA && tokenB && selectPool.compareToken) {
@@ -652,12 +663,6 @@ const EarnAddLiquidityContainer: React.FC = () => {
     }
   }, [swapFeeTier]);
 
-  useEffect(() => {
-    if (!initializedPriceRange.current) {
-      initializedPriceRange.current = priceRange ?? undefined;
-    }
-  }, [priceRange]);
-
   const handleSwapValue = useCallback(() => {
     setSwapValue(prev => {
       return {
@@ -672,18 +677,18 @@ const EarnAddLiquidityContainer: React.FC = () => {
   }, [setSwapValue]);
 
   const nextTickLower = useMemo(() => {
-    if (selectPool.minPosition !== null) {
-      return priceToTick(selectPool.minPosition);
+    if (selectPool.minPosition !== null && swapFeeTier) {
+      return priceToBoundedTick(selectPool.minPosition, swapFeeTier);
     }
     return null;
-  }, [selectPool.minPosition]);
+  }, [selectPool.minPosition, swapFeeTier]);
 
   const nextTickUpper = useMemo(() => {
-    if (selectPool.maxPosition !== null) {
-      return priceToTick(selectPool.maxPosition);
+    if (selectPool.maxPosition !== null && swapFeeTier) {
+      return priceToBoundedTick(selectPool.maxPosition, swapFeeTier);
     }
     return null;
-  }, [selectPool.maxPosition]);
+  }, [selectPool.maxPosition, swapFeeTier]);
 
   const computedFeeTier = useMemo(() => {
     if (!initializedFeeTier.current) {
@@ -694,11 +699,8 @@ const EarnAddLiquidityContainer: React.FC = () => {
   }, [initializedFeeTier.current, router.query.fee_tier, swapFeeTier]);
 
   const computedPriceRange = useMemo(() => {
-    if (!initializedPriceRange.current) {
-      return router.query.price_range_type;
-    }
     return priceRange?.type.toString();
-  }, [initializedPriceRange.current, router.query.price_range_type, priceRange]);
+  }, [priceRange]);
 
   const currentReferralAddress = getCurrentReferralAddress();
 
@@ -721,6 +723,8 @@ const EarnAddLiquidityContainer: React.FC = () => {
     tokenB?.path,
     nextTickLower,
     nextTickUpper,
+    computedFeeTier,
+    computedPriceRange,
     currentReferralAddress,
     i18n.language,
     hasUrlReferralParameter,

--- a/packages/web/src/layouts/pool/pool-add/containers/pool-add-liquidity-container/PoolAddLiquidityContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-add/containers/pool-add-liquidity-container/PoolAddLiquidityContainer.tsx
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { useAtom } from "jotai";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   AddLiquiditySubmitType,
@@ -31,8 +31,8 @@ import {
   getDepositAmountsByAmountA,
   getDepositAmountsByAmountB,
   makeSwapFeeTier,
+  priceToBoundedTick,
   priceToSqrtX96,
-  priceToTick,
   tickToPrice,
 } from "@utils/swap-utils";
 import { makeDisplayTokenAmount, makeRawTokenAmount } from "@utils/token-utils";
@@ -65,6 +65,7 @@ const PoolAddLiquidityContainer: React.FC = () => {
   const [defaultPrice, setDefaultPrice] = useState<number | null>(null);
   const [priceRangeTypeFromUrl, setPriceRangeTypeFromUrl] = useState<PriceRangeType | null>();
   const [ticksFromUrl, setTickFromUrl] = useState<DefaultTick>();
+  const initializedPriceRangeKey = useRef<string>();
   const { getGnotPath } = useGnotToGnot();
 
   const { openModal: openConnectWalletModal } = useConnectWalletModal();
@@ -176,7 +177,7 @@ const PoolAddLiquidityContainer: React.FC = () => {
     if (!tokenA || !tokenB) {
       return "INVALID_PAIR";
     }
-    if (selectPool.minPrice && selectPool.maxPrice && selectPool.minPrice >= selectPool.maxPrice) {
+    if (selectPool.minPrice !== null && selectPool.maxPrice !== null && selectPool.minPrice >= selectPool.maxPrice) {
       return "INVALID_RANGE";
     }
     if (!Number(tokenAAmountInput.amount) && !Number(tokenBAmountInput.amount)) {
@@ -272,7 +273,7 @@ const PoolAddLiquidityContainer: React.FC = () => {
         return;
       }
 
-      if (!selectPool.minPrice || !selectPool.maxPrice) {
+      if (selectPool.minPrice === null || selectPool.maxPrice === null) {
         return;
       }
 
@@ -318,7 +319,7 @@ const PoolAddLiquidityContainer: React.FC = () => {
         return;
       }
 
-      if (!selectPool.minPrice || !selectPool.maxPrice) {
+      if (selectPool.minPrice === null || selectPool.maxPrice === null) {
         return;
       }
 
@@ -570,29 +571,34 @@ const PoolAddLiquidityContainer: React.FC = () => {
     const poolFeeTier = pools.map(pool => makeSwapFeeTier(pool.fee));
     const existPool = poolFeeTier.includes(swapFeeTier);
 
+    const priceRangeKey = [tokenA.path, tokenB.path, swapFeeTier, existPool ? "exists" : "create"].join(":");
+    if (initializedPriceRangeKey.current === priceRangeKey) {
+      return;
+    }
+    initializedPriceRangeKey.current = priceRangeKey;
+
     if (existPool) {
-      if (router.query.price_range_type) {
-        setPriceRange(priceRanges.find(range => range.type === router.query.price_range_type) || null);
-        return;
-      }
-      setPriceRange(priceRanges.find(range => range.type === "Passive") || null);
+      const defaultPriceRangeType = priceRangeTypeFromUrl ?? "Passive";
+      setPriceRange(priceRanges.find(range => range.type === defaultPriceRangeType) || null);
     } else {
       setPriceRange(priceRanges.find(range => range.type === "Custom") || null);
     }
-  }, [swapFeeTier, pools, priceRanges, tokenA, tokenB, router.query.price_range_type]);
+  }, [swapFeeTier, pools, priceRanges, tokenA, tokenB, priceRangeTypeFromUrl]);
 
   useEffect(() => {
     const query = {
       [QUERY_PARAMETER.POOL_PATH]: router.getPoolPath(),
       price_range_type: priceRange?.type,
-      tickLower: selectPool.minPosition !== null ? priceToTick(selectPool.minPosition) : null,
-      tickUpper: selectPool.maxPosition !== null ? priceToTick(selectPool.maxPosition) : null,
+      tickLower:
+        selectPool.minPosition !== null && swapFeeTier ? priceToBoundedTick(selectPool.minPosition, swapFeeTier) : null,
+      tickUpper:
+        selectPool.maxPosition !== null && swapFeeTier ? priceToBoundedTick(selectPool.maxPosition, swapFeeTier) : null,
     };
     if (tokenA?.path && tokenB?.path) {
       replaceRouteUrlWithoutNavigation(PAGE_PATH.POOL_ADD, makeRouteUrl(PAGE_PATH.POOL_ADD, query));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectPool.minPosition, selectPool.maxPosition, priceRange?.type]);
+  }, [selectPool.minPosition, selectPool.maxPosition, priceRange?.type, swapFeeTier]);
 
   const showDim = useMemo(() => {
     return !!(tokenA && tokenB && selectPool.isCreate && !createOption.startPrice);

--- a/packages/web/src/utils/swap-utils.spec.ts
+++ b/packages/web/src/utils/swap-utils.spec.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { SwapFeeTierMaxPriceRangeMap, SwapFeeTierType } from "@constants/option.constant";
 import { tickToSqrtPriceX96 } from "./math.utils";
 import {
   BroadcastMessageData,
   feeBoostRateByPrices,
   getSwappedTokenData,
   isEndTickBy,
+  priceToBoundedTick,
   priceToNearTick,
   priceToTick,
   SwapResponse,
@@ -100,6 +102,30 @@ describe("price convert to near tick", () => {
     const price = 0.60651549714;
     const tickSpacing = 4;
     expect(priceToNearTick(price, tickSpacing)).toBe(-5000);
+  });
+});
+
+describe("price convert to bounded tick", () => {
+  const boundaryCases: { feeTier: SwapFeeTierType; minTick: number; maxTick: number }[] = [
+    { feeTier: "FEE_100", minTick: -887272, maxTick: 887272 },
+    { feeTier: "FEE_500", minTick: -887270, maxTick: 887270 },
+    { feeTier: "FEE_3000", minTick: -887220, maxTick: 887220 },
+    { feeTier: "FEE_10000", minTick: -887200, maxTick: 887200 },
+  ];
+
+  test.each(boundaryCases)("clamps prices outside %s fee-tier bounds", ({ feeTier, minTick, maxTick }) => {
+    const { minPrice, maxPrice } = SwapFeeTierMaxPriceRangeMap[feeTier];
+
+    expect(priceToBoundedTick(0, feeTier)).toBe(minTick);
+    expect(priceToBoundedTick(minPrice / 2, feeTier)).toBe(minTick);
+    expect(priceToBoundedTick(minPrice, feeTier)).toBe(minTick);
+    expect(priceToBoundedTick(maxPrice, feeTier)).toBe(maxTick);
+    expect(priceToBoundedTick(maxPrice * 2, feeTier)).toBe(maxTick);
+  });
+
+  test("keeps in-range prices within the fee-tier tick bounds", () => {
+    expect(priceToBoundedTick(1, "FEE_100")).toBe(0);
+    expect(priceToBoundedTick(1, "FEE_500")).toBe(0);
   });
 });
 

--- a/packages/web/src/utils/swap-utils.ts
+++ b/packages/web/src/utils/swap-utils.ts
@@ -39,6 +39,21 @@ export function priceToTick(price: number | bigint) {
   return Math.round(BigNumber(logPrice).dividedBy(LOG10001).toNumber());
 }
 
+export function priceToBoundedTick(price: number | bigint, feeTier: SwapFeeTierType) {
+  const { minTick, minPrice, maxTick, maxPrice } = SwapFeeTierMaxPriceRangeMap[feeTier];
+  const currentPrice = Number(price);
+
+  if (currentPrice <= minPrice) {
+    return minTick;
+  }
+
+  if (currentPrice >= maxPrice) {
+    return maxTick;
+  }
+
+  return Math.max(minTick, Math.min(maxTick, priceToTick(currentPrice)));
+}
+
 export function findNearPrice(price: number, tickSpacing: number) {
   const feeTier = makeSwapFeeTierByTickSpacing(tickSpacing);
   const { minPrice, maxPrice } = SwapFeeTierMaxPriceRangeMap[feeTier];


### PR DESCRIPTION
## Summary
- Fix custom price range brush interactions on the add-liquidity chart.
- Keep the selected range responsive while dragging across the current-price boundary.
- Preserve ordered min/max prices when brush handles are crossed.

## Changes
- Clamp URL-derived ticks to the selected fee tier range before converting them back to prices.
- Preserve the Custom price range mode after direct chart or input interaction.
- Prevent the D3 brush sync effect from resetting an in-progress user drag.
- Normalize committed brush prices so crossed handles still produce ordered min/max values.
- Add focused unit coverage for fee-tier tick bounds, custom range preservation, and brush price ordering.

## Verification
- `yarn workspace @gnoswap-labs/web jest --runTestsByPath src/components/common/pool-selection-graph/PoolSelectionGraph.utils.spec.ts src/utils/swap-utils.spec.ts --runInBand`
- `GIT_MASTER=1 git diff --check`
- Local Playwright QA on the add-liquidity page confirmed the max handle can move below the current price and crossed drags keep an ordered positive-width range.

## Notes
- Wallet connection was not required for the chart interaction QA.
- Repo-wide lint still has existing unrelated warnings/errors outside this change scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom price-range selection so minimum and maximum values remain correctly ordered while dragging.
  * Prevented price-range controls from resetting unexpectedly during interaction or page updates.
  * Preserved valid zero-value boundaries when adjusting ranges and tick positions.
  * Added fee-tier safeguards to keep selected prices within supported limits.
  * Improved synchronization of price-range settings when creating or adding liquidity, including URL-based selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->