### PR TITLE
fix: allow pool's own token pair as external incentivize reward tokens

### DIFF
--- a/packages/web/src/components/common/select-pair-button/SelectPairIncentivizeButton.tsx
+++ b/packages/web/src/components/common/select-pair-button/SelectPairIncentivizeButton.tsx
@@ -14,6 +14,7 @@ interface SelectPairIncentivizeButtonProps {
   callback?: (value: boolean) => void;
   isHiddenArrow?: boolean;
   className?: string;
+  poolTokens?: readonly TokenModel[];
 }
 
 const SelectPairIncentivizeButton: React.FC<SelectPairIncentivizeButtonProps> = ({
@@ -24,12 +25,14 @@ const SelectPairIncentivizeButton: React.FC<SelectPairIncentivizeButtonProps> = 
   callback,
   isHiddenArrow,
   className,
+  poolTokens,
 }) => {
   const { t } = useTranslation();
 
   const { openModal } = useSelectTokenIncentivizeModal({
     changeToken,
     callback,
+    poolTokens,
   });
 
   const onClickButton = useCallback(() => {

--- a/packages/web/src/components/common/token-amount-input/TokenAmountInput.tsx
+++ b/packages/web/src/components/common/token-amount-input/TokenAmountInput.tsx
@@ -18,6 +18,7 @@ export interface TokenAmountInputProps extends TokenAmountInputModel {
   style?: React.CSSProperties;
   isVisibleMaxButton?: boolean;
   integersOnly?: boolean;
+  poolTokens?: readonly TokenModel[];
 }
 
 const TokenAmountInput: React.FC<TokenAmountInputProps> = ({
@@ -32,6 +33,7 @@ const TokenAmountInput: React.FC<TokenAmountInputProps> = ({
   style,
   isVisibleMaxButton = true,
   integersOnly = false,
+  poolTokens,
 }) => {
   const { t } = useTranslation();
 
@@ -128,6 +130,7 @@ const TokenAmountInput: React.FC<TokenAmountInputProps> = ({
             disabled={disabledSelectPair}
             changeToken={changeToken}
             isHiddenArrow={disabledSelectPair}
+            poolTokens={poolTokens}
           />
         </div>
       </div>

--- a/packages/web/src/containers/select-token-incentivize-container/SelectTokenContainer.tsx
+++ b/packages/web/src/containers/select-token-incentivize-container/SelectTokenContainer.tsx
@@ -7,13 +7,18 @@ import { useAtomValue } from "jotai";
 import { ThemeState } from "@states/index";
 import useEscCloseModal from "@hooks/common/use-esc-close-modal";
 import { useGetAllowedExternalRewardTokenPaths } from "@query/pools";
-import { filterAllowedIncentiveTokens } from "./incentive-token-filter";
+import { filterAllowedIncentiveTokens, incentiveTokenPath } from "./incentive-token-filter";
 
 interface SelectTokenIncentivizeContainerProps {
   changeToken?: (token: TokenModel) => void;
   callback?: (value: boolean) => void;
+  poolTokens?: readonly TokenModel[];
 }
-const SelectTokenIncentivizeContainer: React.FC<SelectTokenIncentivizeContainerProps> = ({ changeToken, callback }) => {
+const SelectTokenIncentivizeContainer: React.FC<SelectTokenIncentivizeContainerProps> = ({
+  changeToken,
+  callback,
+  poolTokens,
+}) => {
   const { tokens, balances, updateTokens, updateBalances } = useTokenData();
   const { data: allowedTokenPaths = [] } = useGetAllowedExternalRewardTokenPaths();
   const [keyword, setKeyword] = useState("");
@@ -28,13 +33,18 @@ const SelectTokenIncentivizeContainer: React.FC<SelectTokenIncentivizeContainerP
     if (tokens.length > 0) updateBalances();
   }, [tokens]);
 
+  const combinedAllowedTokenPaths = useMemo(() => {
+    const poolTokenPaths = (poolTokens ?? []).map(incentiveTokenPath);
+    return [...allowedTokenPaths, ...poolTokenPaths];
+  }, [allowedTokenPaths, poolTokens]);
+
   const defaultTokens = useMemo(() => {
-    return filterAllowedIncentiveTokens(tokens, allowedTokenPaths).filter((_, index) => index < 5);
-  }, [allowedTokenPaths, tokens]);
+    return filterAllowedIncentiveTokens(tokens, combinedAllowedTokenPaths).filter((_, index) => index < 5);
+  }, [combinedAllowedTokenPaths, tokens]);
 
   const filteredTokens = useMemo(() => {
-    return filterAllowedIncentiveTokens(tokens, allowedTokenPaths);
-  }, [allowedTokenPaths, tokens]);
+    return filterAllowedIncentiveTokens(tokens, combinedAllowedTokenPaths);
+  }, [combinedAllowedTokenPaths, tokens]);
 
   const selectToken = useCallback(
     (token: TokenModel) => {

--- a/packages/web/src/containers/select-token-incentivize-container/SelectTokenContainer.tsx
+++ b/packages/web/src/containers/select-token-incentivize-container/SelectTokenContainer.tsx
@@ -35,7 +35,7 @@ const SelectTokenIncentivizeContainer: React.FC<SelectTokenIncentivizeContainerP
 
   const combinedAllowedTokenPaths = useMemo(() => {
     const poolTokenPaths = (poolTokens ?? []).map(incentiveTokenPath);
-    return [...allowedTokenPaths, ...poolTokenPaths];
+    return [...poolTokenPaths, ...allowedTokenPaths];
   }, [allowedTokenPaths, poolTokens]);
 
   const defaultTokens = useMemo(() => {

--- a/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.ts
+++ b/packages/web/src/containers/select-token-incentivize-container/incentive-token-filter.ts
@@ -6,7 +6,7 @@ function tokenPriority(token: TokenModel, allowedTokenPaths: readonly string[]):
   return index === -1 ? allowedTokenPaths.length : index;
 }
 
-function incentiveTokenPath(token: TokenModel): string {
+export function incentiveTokenPath(token: TokenModel): string {
   if (isNativeToken(token.path)) {
     return token.wrappedPath || checkGnotPath(token.path);
   }

--- a/packages/web/src/hooks/token/ui/use-select-token-incentivize-modal.tsx
+++ b/packages/web/src/hooks/token/ui/use-select-token-incentivize-modal.tsx
@@ -7,6 +7,7 @@ import { useCallback } from "react";
 export interface SelectTokenModalProps {
   changeToken?: (token: TokenModel) => void;
   callback?: (value: boolean) => void;
+  poolTokens?: readonly TokenModel[];
 }
 export interface SelectTokenModalModel {
   openModal: () => void;
@@ -15,14 +16,15 @@ export interface SelectTokenModalModel {
 export const useSelectTokenIncentivizeModal = ({
   changeToken,
   callback,
+  poolTokens,
 }: SelectTokenModalProps): SelectTokenModalModel => {
   const [, setOpenedModal] = useAtom(CommonState.openedModal);
   const [, setModalContent] = useAtom(CommonState.modalContent);
 
   const openModal = useCallback(() => {
     setOpenedModal(true);
-    setModalContent(<SelectTokenContainer changeToken={changeToken} callback={callback} />);
-  }, [changeToken, setModalContent, setOpenedModal, callback]);
+    setModalContent(<SelectTokenContainer changeToken={changeToken} callback={callback} poolTokens={poolTokens} />);
+  }, [changeToken, setModalContent, setOpenedModal, callback, poolTokens]);
 
   return {
     openModal,

--- a/packages/web/src/layouts/pool/pool-incentivize/components/pool-incentivize/PoolIncentivize.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/pool-incentivize/PoolIncentivize.tsx
@@ -74,6 +74,10 @@ const PoolIncentivize: React.FC<PoolIncentivizeProps> = ({
     return temp;
   }, [selectedPool]);
 
+  const poolTokens = useMemo((): TokenModel[] | undefined => {
+    return selectedItem ? [selectedItem.tokenA, selectedItem.tokenB] : undefined;
+  }, [selectedItem]);
+
   const poolSelectItems = useMemo((): PoolSelectItemInfo[] => {
     return pools
       .map(PoolMapper.toPoolSelectItemInfo)
@@ -123,7 +127,13 @@ const PoolIncentivize: React.FC<PoolIncentivizeProps> = ({
 
       <article className="token-amount-input">
         <h5 className="section-title">{t("IncentivizePool:incentiPool.form.rewaAmt.label")}</h5>
-        <TokenAmountInput changeToken={changeToken} connected={connected} {...tokenAmountInput} changable={true} />
+        <TokenAmountInput
+          changeToken={changeToken}
+          connected={connected}
+          {...tokenAmountInput}
+          changable={true}
+          poolTokens={poolTokens}
+        />
       </article>
       <PoolIncentivizeDetails
         amount={tokenAmountInput.amount}


### PR DESCRIPTION
## Summary
- The External Incentive reward token selector on `/incentivize` only exposed the backend-managed global allowlist, even though the staker contract also accepts a pool's own two underlying tokens as a valid external reward token regardless of that allowlist.
- Reward token options now include the selected pool's token pair in addition to the global allowlist, with the pool's own tokens ranked first.

## Changes
- Export a shared token-path normalization helper from the incentive token filter.
- Thread the selected pool's token pair through `TokenAmountInput` → `SelectPairIncentivizeButton` → the token-select modal → the token-select container.
- Merge the pool's token pair into the allowed-token set (pool tokens first, then the global allowlist) before filtering/sorting the selectable list; duplicates are naturally deduplicated.

## Verification
- `tsc --noEmit` on the affected package: no new type errors (pre-existing unrelated `.spec.tsx` errors only).
- `eslint` on all changed files: no new errors, only pre-existing warnings unrelated to this change.

## Notes
- Both incentivize entry points (pool-specific and pool-picker) share the same `PoolIncentivize` component, so this fix applies to both flows without touching either container directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incentive token selection by prioritizing tokens available in the selected pool.
  * Pool token options are now correctly included when filtering and displaying eligible incentive tokens.
  * Preserved existing external reward token options while adding relevant pool tokens to the selection list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->