### PR TITLE
refactor: reduce earn token data polling

### DIFF
--- a/packages/web/src/components/common/pool-graph/PoolGraph.tsx
+++ b/packages/web/src/components/common/pool-graph/PoolGraph.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import * as uuid from "uuid";
 
 import { FloatingPosition } from "@hooks/common/use-floating-tooltip";
-import { useTokenData } from "@hooks/token/data/use-token-data";
+import { useGetAllTokenPrices } from "@query/token";
 import { PoolLiquiditySegmentModel } from "@models/pool/pool-liquidity-model";
 import { TokenModel } from "@models/token/token-model";
 import { formatTokenExchangeRate } from "@utils/stake-position-utils";
@@ -84,7 +84,7 @@ const PoolGraph: React.FC<PoolGraphProps> = ({
   const svgRef = useRef<SVGSVGElement | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const lastHoverBinIndexRef = useRef<number | undefined>();
-  const { tokenPrices } = useTokenData();
+  const { data: tokenPrices = {} } = useGetAllTokenPrices();
 
   const boundsWidth = width - margin.right - margin.left;
   const boundsHeight = height - margin.top - margin.bottom;

--- a/packages/web/src/layouts/earn/components/pool-list/pool-list-table/pool-info/PoolInfo.tsx
+++ b/packages/web/src/layouts/earn/components/pool-list/pool-list-table/pool-info/PoolInfo.tsx
@@ -20,7 +20,7 @@ import { cx } from "@emotion/css";
 import PriceWarning from "@components/common/price-warning/PriceWarning";
 import { TokenModel } from "@models/token/token-model";
 import { checkGnotPath } from "@utils/common";
-import { useTokenData } from "@hooks/token/data/use-token-data";
+import { useGetAllTokenPrices } from "@query/token";
 import { isArray } from "@common/utils/data-check-util";
 import { usePrefetchNavigation } from "@hooks/common/use-prefetch-navigation";
 import { QUERY_PARAMETER } from "@constants/page.constant";
@@ -33,7 +33,7 @@ interface PoolInfoProps {
 }
 
 const PoolInfo: React.FC<PoolInfoProps> = ({ pool, routeItem, breakpoint }) => {
-  const { tokenPrices } = useTokenData();
+  const { data: tokenPrices = {} } = useGetAllTokenPrices();
 
   const {
     poolId,

--- a/packages/web/src/layouts/earn/containers/earn-my-position-container/EarnMyPositionContainer.tsx
+++ b/packages/web/src/layouts/earn/containers/earn-my-position-container/EarnMyPositionContainer.tsx
@@ -7,7 +7,7 @@ import useCustomRouter from "@hooks/common/use-custom-router";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { usePoolData } from "@hooks/pool/data/use-pool-data";
 import { usePositionData } from "@hooks/pool/data/use-position-data";
-import { useTokenData } from "@hooks/token/data/use-token-data";
+import { useGetAllTokenPrices } from "@query/token";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
 import { useConnectWalletModal } from "@hooks/wallet/ui/use-connect-wallet-modal";
 import { PoolPositionModel } from "@models/position/pool-position-model";
@@ -31,7 +31,7 @@ const EarnMyPositionContainer: React.FC<EarnMyPositionContainerProps> = ({
 }) => {
   const router = useCustomRouter();
   const { connected, connectAdenaClient, isSwitchNetwork, switchNetwork, account } = useWallet();
-  const { tokenPrices = {}, updateTokenPrices } = useTokenData();
+  const { data: tokenPrices = {} } = useGetAllTokenPrices();
   const { isFetchedPools, loading: isLoadingPool, pools } = usePoolData();
   const { width } = useWindowSize();
   const { openModal } = useConnectWalletModal();
@@ -74,7 +74,6 @@ const EarnMyPositionContainer: React.FC<EarnMyPositionContainerProps> = ({
     }
   };
   useEffect(() => {
-    updateTokenPrices();
     if (typeof window !== "undefined") {
       if (window.innerWidth < 920) setMobile(true);
       else setMobile(false);

--- a/packages/web/src/layouts/earn/containers/incentivized-pool-card-list-container/IncentivizedPoolCardListContainer.tsx
+++ b/packages/web/src/layouts/earn/containers/incentivized-pool-card-list-container/IncentivizedPoolCardListContainer.tsx
@@ -6,7 +6,7 @@ import useCustomRouter from "@hooks/common/use-custom-router";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { useIncentivizePool } from "@hooks/pool/data/use-incentivize-pool";
 import { ThemeState } from "@states/index";
-import { useTokenData } from "@hooks/token/data/use-token-data";
+import { useGetAllTokenPrices } from "@query/token";
 import { IncentivizePoolCardInfoWithPriceGrade } from "@models/pool/info/pool-card-info";
 
 import IncentivizedPoolCardList from "../../components/incentivized-pool-card-list/IncentivizedPoolCardList";
@@ -35,7 +35,7 @@ const IncentivizedPoolCardListContainer: React.FC = () => {
     isFetched: isFetchedIncentivizedPools,
     isLoading: isLoadingIncentivizedPool,
   } = useIncentivizePool(address);
-  const { tokenPrices } = useTokenData();
+  const { data: tokenPrices = {} } = useGetAllTokenPrices();
   const themeKey = useAtomValue(ThemeState.themeKey);
   const divRef = useRef<HTMLDivElement | null>(null);
   const { width } = useWindowSize();

--- a/packages/web/src/layouts/earn/containers/pool-list-container/PoolListContainer.tsx
+++ b/packages/web/src/layouts/earn/containers/pool-list-container/PoolListContainer.tsx
@@ -5,7 +5,7 @@ import { EARN_POOL_LIST_SIZE } from "@constants/table.constant";
 import useClickOutside from "@hooks/common/use-click-outside";
 import useCustomRouter from "@hooks/common/use-custom-router";
 import { usePoolData } from "@hooks/pool/data/use-pool-data";
-import { useTokenData } from "@hooks/token/data/use-token-data";
+import { useGetAllTokenPrices } from "@query/token";
 import { PoolListInfo } from "@models/pool/info/pool-list-info";
 import { TokenModel } from "@models/token/token-model";
 import { CommonState, ThemeState } from "@states/index";
@@ -26,9 +26,9 @@ const PoolListContainer: React.FC = () => {
   const [searchIcon, setSearchIcon] = useState(false);
   const [breakpoint] = useAtom(CommonState.breakpoint);
   const router = useCustomRouter();
-  const { poolListInfos, isFetchedPools, updatePools } = usePoolData();
+  const { poolListInfos, isFetchedPools } = usePoolData();
   const [componentRef, isClickOutside, setIsInside] = useClickOutside();
-  const { tokenPrices } = useTokenData();
+  const { data: tokenPrices = {} } = useGetAllTokenPrices();
 
   const themeKey = useAtomValue(ThemeState.themeKey);
 
@@ -40,13 +40,6 @@ const PoolListContainer: React.FC = () => {
       !tokenPrices?.[checkGnotPath(tokenA.priceID)]?.usd || !tokenPrices?.[checkGnotPath(tokenB.priceID)]?.usd,
     [tokenPrices],
   );
-
-  /**
-   * Fetch pool data on component mount
-   */
-  useEffect(() => {
-    updatePools();
-  }, []);
 
   /**
    * Hide search icon when clicking outside and no keyword is entered
@@ -149,7 +142,7 @@ const PoolListContainer: React.FC = () => {
           tokenBPriceGrade,
         };
       });
-  }, [poolListInfos, keyword, poolType, anyEmptyPrice, matchesKeyword, filteredPoolType]);
+  }, [poolListInfos, keyword, poolType, anyEmptyPrice, matchesKeyword, filteredPoolType, tokenPrices]);
 
   /**
    * Sort filtered pools based on current sort option

--- a/packages/web/src/layouts/earn/earn-token-data-optimization.spec.ts
+++ b/packages/web/src/layouts/earn/earn-token-data-optimization.spec.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+const readSource = (relativePath: string) => readFileSync(path.join(__dirname, relativePath), { encoding: "utf8" });
+
+describe("earn token data optimization", () => {
+  const priceOnlyConsumers = [
+    "containers/earn-my-position-container/EarnMyPositionContainer.tsx",
+    "containers/incentivized-pool-card-list-container/IncentivizedPoolCardListContainer.tsx",
+    "containers/pool-list-container/PoolListContainer.tsx",
+    "components/pool-list/pool-list-table/pool-info/PoolInfo.tsx",
+    "../../components/common/pool-graph/PoolGraph.tsx",
+  ];
+
+  it("keeps price-only consumers off the full token data hook", () => {
+    for (const relativePath of priceOnlyConsumers) {
+      const source = readSource(relativePath);
+
+      expect(source).toContain("useGetAllTokenPrices");
+      expect(source).not.toContain("useTokenData");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Replace price-only Earn page consumers of useTokenData with useGetAllTokenPrices.
- Remove redundant mount-time refetches that amplified RPC/fetch activity on /earn.
- Add a regression spec to keep price-only Earn consumers off the full token data hook.


## Test
- yarn jest --testPathPattern="PoolGraph|PoolInfoLazyChart|PoolListContainer|earn-token-data-optimization"
- yarn next lint --file src/components/common/pool-graph/PoolGraph.tsx --file src/layouts/earn/components/pool-list/pool-list-table/pool-info/PoolInfo.tsx --file src/layouts/earn/containers/earn-my-position-container/EarnMyPositionContainer.tsx --file src/layouts/earn/containers/incentivized-pool-card-list-container/IncentivizedPoolCardListContainer.tsx --file src/layouts/earn/containers/pool-list-container/PoolListContainer.tsx --file src/layouts/earn/earn-token-data-optimization.spec.ts
- yarn workspace @gnoswap-labs/web build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Updated earning and pool views to use a focused token-price data source.
  * Token price displays now remain stable while data is loading, with safe empty-state handling.
  * Pool listings and related cards continue updating their price indicators as pricing data changes.

* **Tests**
  * Added coverage to verify earning views use the optimized token-price source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->