### PR TITLE
refactor: remove token data side effects from price-only views

### DIFF
--- a/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/launchpad-claim-amount-field/LaunchpadClaimAmountField.tsx
+++ b/packages/web/src/components/common/launchpad-modal/launchpad-claim-all-modal/launchpad-claim-amount-field/LaunchpadClaimAmountField.tsx
@@ -3,8 +3,8 @@ import Image from "next/image";
 import BigNumber from "bignumber.js";
 
 import { GNS_TOKEN } from "@common/values/token-constant";
-import { useTokenData } from "@hooks/token/data/use-token-data";
 import { ProjectRewardInfoModel } from "@layouts/launchpad/launchpad-detail/LaunchpadDetail";
+import { useGetAllTokenPrices } from "@query/token";
 
 import { ClaimAllFieldWrapper } from "./LaunchpadClaimAmountField.styled";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
@@ -20,7 +20,7 @@ interface LaunchpadClaimAmountFieldProps {
 const DEFAULT_DEPOSIT_TOKEN = GNS_TOKEN;
 
 const LaunchpadClaimAmountField = ({ amount, rewardInfo, type }: LaunchpadClaimAmountFieldProps) => {
-  const { tokenPrices } = useTokenData();
+  const { data: tokenPrices = {} } = useGetAllTokenPrices();
 
   const estimatePrice = React.useMemo(() => {
     const calculatePrice = (tokenPath: string | undefined, amountValue: number) => {

--- a/packages/web/src/containers/trending-card-list-container/TrendingCardListContainer.tsx
+++ b/packages/web/src/containers/trending-card-list-container/TrendingCardListContainer.tsx
@@ -3,7 +3,6 @@ import useCustomRouter from "@hooks/common/use-custom-router";
 import { useLoading } from "@hooks/common/use-loading";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
-import { useTokenData } from "@hooks/token/data/use-token-data";
 import { UpDownType } from "@models/common/card-list-item-info";
 import { TokenModel } from "@models/token/token-model";
 import { useGetChainInfo, useGetTokens } from "@query/token";
@@ -37,7 +36,6 @@ const TrendingCardListContainer: React.FC = () => {
   const { data: { trending = [] } = {} } = useGetChainInfo();
   const { gnot, wugnotPath } = useGnotToGnot();
   const { isLoadingTrendingTokens } = useLoading();
-  useTokenData();
 
   const moveTokenDetails = useCallback(
     (path: string) => {

--- a/packages/web/src/hooks/common/use-loading.tsx
+++ b/packages/web/src/hooks/common/use-loading.tsx
@@ -1,15 +1,15 @@
 import { useMemo } from "react";
-import { useTokenData } from "@hooks/token/data/use-token-data";
 import { useInitLoading } from "@query/common";
 import { useGetDashboardVolume } from "@query/dashboard";
 import { useGetPoolList } from "@query/pools";
-import { useGetChainInfo } from "@query/token";
+import { useGetChainInfo, useGetTokens, useGetAllTokenPrices } from "@query/token";
 import { useGetLaunchpadActiveProjects } from "@query/launchpad/use-get-launchpad-active-projects";
 
 export const useLoading = () => {
   const { data: initialized } = useInitLoading();
   const { isFetched: isFetchedChainData } = useGetChainInfo();
-  const { isFetched: isFetchedTokenData, isFetchedTokenPrices } = useTokenData();
+  const { isFetched: isFetchedTokenData } = useGetTokens();
+  const { isFetched: isFetchedTokenPrices } = useGetAllTokenPrices();
   const { isFetched: isFetchedChainList } = useGetChainInfo({ enabled: false });
   const { isFetched: isFetchedPoolData } = useGetPoolList({ enabled: false });
   const { isFetched: isFetchedDashboardVolume } = useGetDashboardVolume({

--- a/packages/web/src/hooks/common/use-loading.tsx
+++ b/packages/web/src/hooks/common/use-loading.tsx
@@ -59,7 +59,7 @@ export const useLoading = () => {
     }
 
     return !isFetchedChainData;
-  }, [initialized]);
+  }, [initialized, isFetchedChainData]);
 
   const isLoadingDashboardStats = useMemo(() => {
     if (!initialized) {

--- a/packages/web/src/hooks/token/data/use-token-price-helper.tsx
+++ b/packages/web/src/hooks/token/data/use-token-price-helper.tsx
@@ -1,0 +1,28 @@
+import BigNumber from "bignumber.js";
+import { useCallback } from "react";
+
+import { useGetAllTokenPrices, useGetTokens } from "@query/token";
+
+/**
+ * Lightweight helper that provides token metadata and USD pricing without
+ * balance side-effects (no useGetGrc20Balances, no updateBalances, no RPC calls).
+ *
+ * Use when a consumer needs tokens + tokenPrices + getTokenUSDPrice only.
+ */
+export const useTokenPriceHelper = () => {
+  const { data: { tokens = [] } = {} } = useGetTokens();
+  const { data: tokenPrices = {} } = useGetAllTokenPrices();
+
+  const getTokenUSDPrice = useCallback(
+    (tokenAId: string, amount: bigint | string | number) => {
+      const tokenUSDPrice = tokenPrices[tokenAId]?.usd || "0";
+      if (!tokenUSDPrice || Number.isNaN(amount)) {
+        return null;
+      }
+      return BigNumber(amount.toString()).multipliedBy(tokenUSDPrice).toNumber();
+    },
+    [tokenPrices],
+  );
+
+  return { tokens, tokenPrices, getTokenUSDPrice };
+};

--- a/packages/web/src/hooks/token/data/use-token-pricing.tsx
+++ b/packages/web/src/hooks/token/data/use-token-pricing.tsx
@@ -10,19 +10,23 @@ import { useGetAllTokenPrices, useGetTokens } from "@query/token";
  * Use when a consumer needs tokens + tokenPrices + getTokenUSDPrice only.
  */
 export const useTokenPricing = () => {
-  const { data: { tokens = [] } = {} } = useGetTokens();
+  const { data: { tokens = [] } = {}, isFetched: isFetchedTokens } = useGetTokens();
   const { data: tokenPrices = {} } = useGetAllTokenPrices();
 
   const getTokenUSDPrice = useCallback(
     (tokenAId: string, amount: bigint | string | number) => {
       const tokenUSDPrice = tokenPrices[tokenAId]?.usd || "0";
-      if (!tokenUSDPrice || Number.isNaN(amount)) {
+      const amountValue = BigNumber(amount.toString());
+      const priceValue = BigNumber(tokenUSDPrice);
+      const usdValue = amountValue.multipliedBy(priceValue);
+
+      if (!amountValue.isFinite() || !priceValue.isFinite() || !usdValue.isFinite()) {
         return null;
       }
-      return BigNumber(amount.toString()).multipliedBy(tokenUSDPrice).toNumber();
+      return usdValue.toNumber();
     },
     [tokenPrices],
   );
 
-  return { tokens, tokenPrices, getTokenUSDPrice };
+  return { tokens, tokenPrices, getTokenUSDPrice, isFetchedTokens };
 };

--- a/packages/web/src/hooks/token/data/use-token-pricing.tsx
+++ b/packages/web/src/hooks/token/data/use-token-pricing.tsx
@@ -7,7 +7,7 @@ import { useGetAllTokenPrices, useGetTokens } from "@query/token";
  * Lightweight pricing hook that provides token metadata and USD pricing without
  * balance side-effects (no useGetGrc20Balances, no updateBalances, no RPC calls).
  *
- * Use when a consumer needs tokens + tokenPrices + getTokenUSDPrice only.
+ * Use when a consumer needs tokens + getTokenUSDPrice only.
  */
 export const useTokenPricing = () => {
   const { data: { tokens = [] } = {}, isFetched: isFetchedTokens } = useGetTokens();
@@ -28,5 +28,5 @@ export const useTokenPricing = () => {
     [tokenPrices],
   );
 
-  return { tokens, tokenPrices, getTokenUSDPrice, isFetchedTokens };
+  return { tokens, getTokenUSDPrice, isFetchedTokens };
 };

--- a/packages/web/src/hooks/token/data/use-token-pricing.tsx
+++ b/packages/web/src/hooks/token/data/use-token-pricing.tsx
@@ -4,12 +4,12 @@ import { useCallback } from "react";
 import { useGetAllTokenPrices, useGetTokens } from "@query/token";
 
 /**
- * Lightweight helper that provides token metadata and USD pricing without
+ * Lightweight pricing hook that provides token metadata and USD pricing without
  * balance side-effects (no useGetGrc20Balances, no updateBalances, no RPC calls).
  *
  * Use when a consumer needs tokens + tokenPrices + getTokenUSDPrice only.
  */
-export const useTokenPriceHelper = () => {
+export const useTokenPricing = () => {
   const { data: { tokens = [] } = {} } = useGetTokens();
   const { data: tokenPrices = {} } = useGetAllTokenPrices();
 

--- a/packages/web/src/layouts/earn/earn-token-data-optimization.spec.ts
+++ b/packages/web/src/layouts/earn/earn-token-data-optimization.spec.ts
@@ -73,17 +73,17 @@ describe("earn token data optimization", () => {
     });
   });
 
-  describe("governance helper consumers", () => {
+  describe("governance pricing consumers", () => {
     const governanceConsumers = [
       "../../layouts/governance/components/governance-summary/GovernanceSummary.tsx",
       "../../layouts/governance/components/my-delegation/MyDelegation.tsx",
     ];
 
-    it("uses useTokenPriceHelper instead of useTokenData", () => {
+    it("uses useTokenPricing instead of useTokenData", () => {
       for (const relativePath of governanceConsumers) {
         const source = readSource(relativePath);
 
-        expect(source).toContain("useTokenPriceHelper");
+        expect(source).toContain("useTokenPricing");
         expect(source).not.toContain("useTokenData");
       }
     });

--- a/packages/web/src/layouts/earn/earn-token-data-optimization.spec.ts
+++ b/packages/web/src/layouts/earn/earn-token-data-optimization.spec.ts
@@ -20,4 +20,88 @@ describe("earn token data optimization", () => {
       expect(source).not.toContain("useTokenData");
     }
   });
+
+  describe("bare useTokenData removal", () => {
+    const bareRemoved = [
+      "../../containers/trending-card-list-container/TrendingCardListContainer.tsx",
+    ];
+
+    it("removes bare useTokenData calls from consumers that did not destructure it", () => {
+      for (const relativePath of bareRemoved) {
+        const source = readSource(relativePath);
+
+        expect(source).not.toContain("useTokenData");
+      }
+    });
+  });
+
+  describe("tokens-only consumers", () => {
+    const tokensOnlyConsumers = [
+      "../../layouts/swap/containers/swap-container/SwapContainer.tsx",
+      "../../layouts/pool/pool-add/containers/additional-info-container/AdditionalInfoContainer.tsx",
+      "../../layouts/pool/pool-add/components/additional-info/quick-pool-info/QuickPoolInfo.tsx",
+      "../../layouts/pool/pool-incentivize/PoolIncentivize.tsx",
+      "../../layouts/pool/pool-incentivize/components/pool-incentivize/incentive-creation-deposit/IncentiveCreationDeposit.tsx",
+    ];
+
+    it("uses useGetTokens instead of useTokenData", () => {
+      for (const relativePath of tokensOnlyConsumers) {
+        const source = readSource(relativePath);
+
+        expect(source).toContain("useGetTokens");
+        expect(source).not.toContain("useTokenData");
+      }
+    });
+  });
+
+  describe("token-prices-only consumers", () => {
+    const pricesOnlyConsumers = [
+      "../../layouts/pool/pool-detail/containers/pool-pair-information-container/PoolPairInformationContainer.tsx",
+      "../../layouts/pool/pool-detail/components/staking/staking-content/staking-content-card/StakingContentCard.tsx",
+      "../../layouts/pool/pool-stake/components/stake-position/select-stake-result/SelectStakeResult.tsx",
+      "../../layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.tsx",
+      "../../components/common/launchpad-modal/launchpad-claim-all-modal/launchpad-claim-amount-field/LaunchpadClaimAmountField.tsx",
+    ];
+
+    it("uses useGetAllTokenPrices instead of useTokenData", () => {
+      for (const relativePath of pricesOnlyConsumers) {
+        const source = readSource(relativePath);
+
+        expect(source).toContain("useGetAllTokenPrices");
+        expect(source).not.toContain("useTokenData");
+      }
+    });
+  });
+
+  describe("governance helper consumers", () => {
+    const governanceConsumers = [
+      "../../layouts/governance/components/governance-summary/GovernanceSummary.tsx",
+      "../../layouts/governance/components/my-delegation/MyDelegation.tsx",
+    ];
+
+    it("uses useTokenPriceHelper instead of useTokenData", () => {
+      for (const relativePath of governanceConsumers) {
+        const source = readSource(relativePath);
+
+        expect(source).toContain("useTokenPriceHelper");
+        expect(source).not.toContain("useTokenData");
+      }
+    });
+  });
+
+  describe("useLoading", () => {
+    const loadingPaths = [
+      "../../hooks/common/use-loading.tsx",
+    ];
+
+    it("uses useGetTokens and useGetAllTokenPrices directly instead of useTokenData", () => {
+      for (const relativePath of loadingPaths) {
+        const source = readSource(relativePath);
+
+        expect(source).toContain("useGetTokens");
+        expect(source).toContain("useGetAllTokenPrices");
+        expect(source).not.toContain("useTokenData");
+      }
+    });
+  });
 });

--- a/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.spec.tsx
+++ b/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.spec.tsx
@@ -20,8 +20,8 @@ jest.mock("@hooks/common/use-window-size", () => ({
   }),
 }));
 
-jest.mock("@hooks/token/data/use-token-price-helper", () => ({
-  useTokenPriceHelper: () => ({
+jest.mock("@hooks/token/data/use-token-pricing", () => ({
+  useTokenPricing: () => ({
     getTokenUSDPrice: () => 0,
     tokens: [],
   }),

--- a/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.spec.tsx
+++ b/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.spec.tsx
@@ -20,8 +20,8 @@ jest.mock("@hooks/common/use-window-size", () => ({
   }),
 }));
 
-jest.mock("@hooks/token/data/use-token-data", () => ({
-  useTokenData: () => ({
+jest.mock("@hooks/token/data/use-token-price-helper", () => ({
+  useTokenPriceHelper: () => ({
     getTokenUSDPrice: () => 0,
     tokens: [],
   }),

--- a/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.tsx
+++ b/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.tsx
@@ -16,7 +16,7 @@ import { Divider } from "@components/common/divider/divider";
 import { rawToDisplayAmount, toNumberFormat } from "@utils/number-utils";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
-import { useTokenPriceHelper } from "@hooks/token/data/use-token-price-helper";
+import { useTokenPricing } from "@hooks/token/data/use-token-pricing";
 import { TokenModel } from "@models/token/token-model";
 import VideoGuideTrigger from "@components/common/video-guide-trigger/VideoGuideTrigger";
 
@@ -43,7 +43,7 @@ const GovernanceSummary: React.FC<GovernanceSummaryProps> = ({
   const { isMobile } = useWindowSize();
 
   const { getGnotPath } = useGnotToGnot();
-  const { getTokenUSDPrice, tokens } = useTokenPriceHelper();
+  const { getTokenUSDPrice, tokens } = useTokenPricing();
 
   const displayGovernanceSummary: GovernanceSummaryInfo = React.useMemo(() => {
     const { delegationInfo } = governanceSummary;

--- a/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.tsx
+++ b/packages/web/src/layouts/governance/components/governance-summary/GovernanceSummary.tsx
@@ -15,8 +15,8 @@ import { GovernanceSummaryWrapper, GovernanceSummaryTooltipContent } from "./Gov
 import { Divider } from "@components/common/divider/divider";
 import { rawToDisplayAmount, toNumberFormat } from "@utils/number-utils";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
-import { useTokenData } from "@hooks/token/data/use-token-data";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
+import { useTokenPriceHelper } from "@hooks/token/data/use-token-price-helper";
 import { TokenModel } from "@models/token/token-model";
 import VideoGuideTrigger from "@components/common/video-guide-trigger/VideoGuideTrigger";
 
@@ -43,7 +43,7 @@ const GovernanceSummary: React.FC<GovernanceSummaryProps> = ({
   const { isMobile } = useWindowSize();
 
   const { getGnotPath } = useGnotToGnot();
-  const { getTokenUSDPrice, tokens } = useTokenData();
+  const { getTokenUSDPrice, tokens } = useTokenPriceHelper();
 
   const displayGovernanceSummary: GovernanceSummaryInfo = React.useMemo(() => {
     const { delegationInfo } = governanceSummary;

--- a/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
+++ b/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
@@ -8,7 +8,7 @@ import Button, { ButtonHierarchy } from "@components/common/button/Button";
 import IconSwap from "@components/common/icons/IconSwap";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import Tooltip from "@components/common/tooltip/Tooltip";
-import { useTokenPriceHelper } from "@hooks/token/data/use-token-price-helper";
+import { useTokenPricing } from "@hooks/token/data/use-token-pricing";
 import {
   DelegationItemInfo,
   MyDelegatesInfo,
@@ -72,7 +72,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
   const { t } = useTranslation();
   const { getGnotPath } = useGnotToGnot();
   const [isOpenUndelegateModal, setIsOpenUndelegateModal] = useState(false);
-  const { getTokenUSDPrice, tokens } = useTokenPriceHelper();
+  const { getTokenUSDPrice, tokens } = useTokenPricing();
   const [showUndel, setShowUndel] = useState(false);
 
   const sortByAmountAndDate = useCallback((a: DelegationItemInfo, b: DelegationItemInfo) => {

--- a/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
+++ b/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
@@ -72,7 +72,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
   const { t } = useTranslation();
   const { getGnotPath } = useGnotToGnot();
   const [isOpenUndelegateModal, setIsOpenUndelegateModal] = useState(false);
-  const { getTokenUSDPrice, tokens } = useTokenPricing();
+  const { getTokenUSDPrice, isFetchedTokens, tokens } = useTokenPricing();
   const [showUndel, setShowUndel] = useState(false);
 
   const sortByAmountAndDate = useCallback((a: DelegationItemInfo, b: DelegationItemInfo) => {
@@ -198,8 +198,10 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
    * A delimiter showing reward information.
    */
   const visibleRewardInfoTooltip = useMemo(() => {
-    return rewardInfo.length > 0;
-  }, [rewardInfo]);
+    return isFetchedTokens && rewardInfo.length > 0;
+  }, [isFetchedTokens, rewardInfo]);
+
+  const isLoadingRewardInfo = isLoadingMyDelegation || !isFetchedTokens;
 
   /**
    * Automatically switch to the voting weight tab if undelegationInfos is empty
@@ -348,7 +350,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
                     }
                   : undefined
               }
-              isLoading={isLoadingMyDelegation}
+              isLoading={isLoadingRewardInfo}
             />
             <InfoBox
               title={t("Governance:myDel.reward.title")}

--- a/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
+++ b/packages/web/src/layouts/governance/components/my-delegation/MyDelegation.tsx
@@ -8,7 +8,7 @@ import Button, { ButtonHierarchy } from "@components/common/button/Button";
 import IconSwap from "@components/common/icons/IconSwap";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import Tooltip from "@components/common/tooltip/Tooltip";
-import { useTokenData } from "@hooks/token/data/use-token-data";
+import { useTokenPriceHelper } from "@hooks/token/data/use-token-price-helper";
 import {
   DelegationItemInfo,
   MyDelegatesInfo,
@@ -72,7 +72,7 @@ const MyDelegation: React.FC<MyDelegationProps> = ({
   const { t } = useTranslation();
   const { getGnotPath } = useGnotToGnot();
   const [isOpenUndelegateModal, setIsOpenUndelegateModal] = useState(false);
-  const { getTokenUSDPrice, tokens } = useTokenData();
+  const { getTokenUSDPrice, tokens } = useTokenPriceHelper();
   const [showUndel, setShowUndel] = useState(false);
 
   const sortByAmountAndDate = useCallback((a: DelegationItemInfo, b: DelegationItemInfo) => {

--- a/packages/web/src/layouts/pool/pool-add/components/additional-info/quick-pool-info/QuickPoolInfo.tsx
+++ b/packages/web/src/layouts/pool/pool-add/components/additional-info/quick-pool-info/QuickPoolInfo.tsx
@@ -8,8 +8,8 @@ import IconStrokeArrowRight from "@components/common/icons/IconStrokeArrowRight"
 import OverlapTokenLogo from "@components/common/overlap-token-logo/OverlapTokenLogo";
 import { PAGE_PATH_TYPE } from "@constants/page.constant";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
-import { useTokenData } from "@hooks/token/data/use-token-data";
 import { PoolDetailModel } from "@models/pool/pool-detail-model";
+import { useGetTokens } from "@query/token";
 import { PositionModel } from "@models/position/position-model";
 import { TokenModel } from "@models/token/token-model";
 import { checkGnotPath } from "@utils/common";
@@ -40,7 +40,7 @@ const QuickPoolInfo: React.FC<Props> = ({
   const { t } = useTranslation();
 
   const { getGnotPath } = useGnotToGnot();
-  const { tokens } = useTokenData();
+  const { data: { tokens = [] } = {} } = useGetTokens();
 
   const tokenA = useMemo(
     () =>

--- a/packages/web/src/layouts/pool/pool-add/containers/additional-info-container/AdditionalInfoContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-add/containers/additional-info-container/AdditionalInfoContainer.tsx
@@ -9,8 +9,8 @@ import { initialDetailPool } from "@models/pool/pool-detail-model";
 import { isNativeToken } from "@models/token/token-model";
 import { useGetPoolDetailByPath } from "@query/pools";
 import { EarnState } from "@states/index";
-import { useTokenData } from "@hooks/token/data/use-token-data";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
+import { useGetTokens } from "@query/token";
 import { checkGnotPath } from "@utils/common";
 
 import AdditionalInfo from "../../components/additional-info/AdditionalInfo";
@@ -41,7 +41,7 @@ const AdditionalInfoContainer: React.FC = () => {
   const [currentPoolPath] = useAtom(EarnState.currentPoolPath);
   const [{ isLoading: isLoadingRPCPoolInfo }] = useAtom(EarnState.poolInfoQuery);
   const { poolPath, tokenPair } = usePoolAddSearchParams();
-  const { tokens } = useTokenData();
+  const { data: { tokens = [] } = {} } = useGetTokens();
   const { getGnotPath } = useGnotToGnot();
 
   const currentPoolTokenPair = useMemo(() => parseTokenPairFromPoolPath(currentPoolPath), [currentPoolPath]);

--- a/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/staking-content-card/StakingContentCard.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/staking/staking-content/staking-content-card/StakingContentCard.tsx
@@ -13,7 +13,6 @@ import { PulseSkeletonWrapper } from "@components/common/pulse-skeleton/PulseSke
 import Tooltip from "@components/common/tooltip/Tooltip";
 import { StakingPeriodType, STAKING_PERIOD_INFO, RewardType } from "@constants/option.constant";
 import { pulseSkeletonStyle } from "@constants/skeleton.constant";
-import { useTokenData } from "@hooks/token/data/use-token-data";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { PositionModel } from "@models/position/position-model";
 import { useGetAllTokenPrices } from "@query/token";
@@ -106,7 +105,7 @@ const StakingContentCard: React.FC<StakingContentCardProps> = ({
   loading,
 }) => {
   const { t } = useTranslation();
-  const { tokenPrices } = useTokenData();
+  const { data: tokenPrices = {} } = useGetAllTokenPrices();
   const hasPosition = positions.length > 0;
 
   const checkedStep = useMemo(() => {
@@ -285,7 +284,7 @@ interface SummuryAprProps {
 
 export const SummuryApr: React.FC<SummuryAprProps> = ({ period, checkPoints, positions, stakingApr, loading }) => {
   const { t } = useTranslation();
-  const { tokenPrices } = useTokenData();
+  const { data: tokenPrices = {} } = useGetAllTokenPrices();
 
   const hasPosition = positions.length > 0;
 

--- a/packages/web/src/layouts/pool/pool-detail/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/containers/pool-pair-information-container/PoolPairInformationContainer.tsx
@@ -11,8 +11,8 @@ import { useWindowSize } from "@hooks/common/use-window-size";
 import { usePoolLiquiditySegmentsByPath } from "@hooks/pool/data/use-pool-liquidity-segments-by-path";
 import { usePositionData } from "@hooks/pool/data/use-position-data";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
-import { useTokenData } from "@hooks/token/data/use-token-data";
 import { useGetPoolDetailByPath, useGetPoolSqrtPriceX96 } from "@query/pools";
+import { useGetAllTokenPrices } from "@query/token";
 import { PoolConverter } from "@services/converters/pool";
 import { makeSwapFeeTier } from "@utils/swap-utils";
 
@@ -45,7 +45,7 @@ const PoolPairInformationContainer: React.FC<PoolPairInformationContainerProps> 
     },
   });
 
-  const { tokenPrices } = useTokenData();
+  const { data: tokenPrices = {} } = useGetAllTokenPrices();
   const visibleTickRange = React.useMemo(() => LIQUIDITY_GRAPH_VISIBLE_TICK_RANGES[zoomLevel], [zoomLevel]);
 
   const onClickPath = (path: string) => {

--- a/packages/web/src/layouts/pool/pool-incentivize/PoolIncentivize.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/PoolIncentivize.tsx
@@ -9,8 +9,8 @@ import useRouter from "@hooks/common/use-custom-router";
 import { useLoading } from "@hooks/common/use-loading";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
-import { useTokenData } from "@hooks/token/data/use-token-data";
 import { DEVICE_TYPE } from "@styles/media";
+import { useGetTokens } from "@query/token";
 import { checkGnotPath } from "@utils/common";
 import { makeRouteUrl } from "@utils/page.utils";
 
@@ -26,7 +26,7 @@ const PoolIncentivize: React.FC = () => {
   const poolPath = router.getPoolPath() || "::";
   const [tokenAPath, tokenBPath, fee] = poolPath.split(":");
   const { getGnotPath } = useGnotToGnot();
-  const { tokens } = useTokenData();
+  const { data: { tokens = [] } = {} } = useGetTokens();
 
   const { isLoading } = useLoading();
 

--- a/packages/web/src/layouts/pool/pool-incentivize/components/pool-incentivize/incentive-creation-deposit/IncentiveCreationDeposit.tsx
+++ b/packages/web/src/layouts/pool/pool-incentivize/components/pool-incentivize/incentive-creation-deposit/IncentiveCreationDeposit.tsx
@@ -6,8 +6,8 @@ import { DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } from "@common/values";
 import { GNS_TOKEN } from "@common/values/token-constant";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import { GNS_TOKEN_PATH } from "@constants/environment.constant";
-import { useTokenData } from "@hooks/token/data/use-token-data";
 import { useGetIncentiveCreationDeposit } from "@query/pools";
+import { useGetTokens } from "@query/token";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
 
 import {
@@ -19,7 +19,7 @@ import IconInfo from "@components/common/icons/IconInfo";
 
 const IncentiveCreationDeposit: React.FC = () => {
   const { t } = useTranslation();
-  const { tokens } = useTokenData();
+  const { data: { tokens = [] } = {} } = useGetTokens();
   const theme = useTheme();
   const { data: depositGnsAmount = DEFAULT_INCENTIVE_CREATION_DEPOSIT_GNS_AMOUNT } = useGetIncentiveCreationDeposit();
 

--- a/packages/web/src/layouts/pool/pool-stake/components/stake-position/select-stake-result/SelectStakeResult.tsx
+++ b/packages/web/src/layouts/pool/pool-stake/components/stake-position/select-stake-result/SelectStakeResult.tsx
@@ -5,7 +5,7 @@ import Badge, { BADGE_TYPE } from "@components/common/badge/Badge";
 import IconInfo from "@components/common/icons/IconInfo";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import Tooltip from "@components/common/tooltip/Tooltip";
-import { useTokenData } from "@hooks/token/data/use-token-data";
+import { useGetAllTokenPrices } from "@query/token";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { TokenModel } from "@models/token/token-model";
 import { checkGnotPath } from "@utils/common";
@@ -26,7 +26,7 @@ interface PooledTokenEntry {
 
 const SelectStakeResult: React.FC<SelectStakeResultProps> = ({ positions, isHiddenBadge = false }) => {
   const { t } = useTranslation();
-  const { tokenPrices } = useTokenData();
+  const { data: tokenPrices = {} } = useGetAllTokenPrices();
 
   const pooledTokenEntries = useMemo<PooledTokenEntry[]>(() => {
     const entries = new Map<string, PooledTokenEntry>();

--- a/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.spec.tsx
+++ b/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.spec.tsx
@@ -47,10 +47,10 @@ jest.mock("@hooks/token/data/use-gnot-wugnot", () => {
   };
 });
 
-jest.mock("@hooks/token/data/use-token-data", () => {
+jest.mock("@query/token", () => {
   const tokenPrices = {};
   return {
-    useTokenData: () => ({ tokenPrices }),
+    useGetAllTokenPrices: () => ({ data: tokenPrices }),
   };
 });
 

--- a/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.tsx
+++ b/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.tsx
@@ -7,8 +7,8 @@ import { usePositionData } from "@hooks/pool/data/use-position-data";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { usePoolData } from "@hooks/pool/data/use-pool-data";
 import { useGnotToGnot } from "@hooks/token/data/use-gnot-wugnot";
-import { useTokenData } from "@hooks/token/data/use-token-data";
 import { useWallet } from "@hooks/wallet/data/use-wallet";
+import { useGetAllTokenPrices } from "@query/token";
 import { PositionMapper } from "@models/position/mapper/position-mapper";
 import { PoolPositionModel } from "@models/position/pool-position-model";
 import { ThemeState } from "@states/index";
@@ -55,7 +55,7 @@ const WalletPositionCardListContainer: React.FC<WalletPositionCardListContainerP
   const { pools, loading } = usePoolData();
   const themeKey = useAtomValue(ThemeState.themeKey);
   const divRef = useRef<HTMLDivElement | null>(null);
-  const { tokenPrices = {} } = useTokenData();
+  const { data: tokenPrices = {} } = useGetAllTokenPrices();
 
   const [isViewMorePositions, setIsViewMorePositions] = useState(false);
   const [mappedData, setMappedData] = useState<PoolPositionModel[]>([]);

--- a/packages/web/src/layouts/swap/containers/swap-container/SwapContainer.tsx
+++ b/packages/web/src/layouts/swap/containers/swap-container/SwapContainer.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import { GNOT_TOKEN_DEFAULT } from "@common/values/token-constant";
 import useRouter from "@hooks/common/use-custom-router";
 import { useSwapHandler } from "@hooks/swap/data/use-swap-handler";
-import { useTokenData } from "@hooks/token/data/use-token-data";
+import { useGetTokens } from "@query/token";
 import { ThemeState } from "@states/index";
 
 import SwapCard from "../../components/swap-card/SwapCard";
@@ -13,7 +13,7 @@ const SwapContainer: React.FC = () => {
   const themeKey = useAtomValue(ThemeState.themeKey);
   const router = useRouter();
   const [initialized, setInitialized] = useState(false);
-  const { tokens } = useTokenData();
+  const { data: { tokens = [] } = {} } = useGetTokens();
 
   const {
     connectedWallet,


### PR DESCRIPTION
## Summary
- remove remaining bare/tokens-only/token-prices-only `useTokenData` usage from the follow-up target views
- add a lightweight `useTokenPricing` for governance price lookup without balance side effects
- expand the token-data optimization guard spec to cover the migrated consumers

## Validation
- `yarn jest --testPathPattern="earn-token-data-optimization|GovernanceSummary|WalletPositionCardListContainer"`
- `yarn next lint --file ...` (warnings only: existing hook dependency warnings; spec files are ignored by lint config)
- `yarn workspace @gnoswap-labs/web build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved token pricing and metadata retrieval across claims, governance, pools, swaps, staking, and portfolio views.
  * Added more reliable USD value calculations with safe handling while token data is loading or unavailable.
  * Improved loading indicators and reward information display during token data retrieval.

* **Bug Fixes**
  * Prevented incomplete token data from causing incorrect values or premature rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->