### PR TITLE
fix: reduce pool add liquidity RPC polling

### DIFF
--- a/packages/web/src/hooks/pool/data/use-select-pool.spec.ts
+++ b/packages/web/src/hooks/pool/data/use-select-pool.spec.ts
@@ -11,13 +11,18 @@ describe("useSelectPool liquidity segment price", () => {
     expect(source).toContain("segmentCurrentPrice,\n      ],");
   });
 
-  it("keeps pool RPC queries off idle refetch polling", () => {
+  it("keeps liquidity RPC off idle refetch polling while refreshing sqrt price on add pages", () => {
     const source = readFileSync(path.join(__dirname, "use-select-pool.tsx"), { encoding: "utf8" });
     const addPagePollingMatches = source.match(/refetchInterval: shouldRefetch \? 5_000 : false/g) ?? [];
 
-    expect(addPagePollingMatches).toHaveLength(1);
+    expect(addPagePollingMatches).toHaveLength(2);
     expect(source).toContain("useGetPoolLiquidity(calculatedPoolPath, {\n    enabled: !!calculatedPoolPath && !isCreate,\n  });");
-    expect(source).toContain("useGetPoolSqrtPriceX96(calculatedPoolPath, {\n    enabled: !!calculatedPoolPath && !isCreate,\n  });");
+    expect(source).toContain(
+      "useGetPoolSqrtPriceX96(calculatedPoolPath, {\n" +
+        "    enabled: !!calculatedPoolPath && !isCreate,\n" +
+        "    refetchInterval: shouldRefetch ? 5_000 : false,\n" +
+        "  });",
+    );
   });
 
   it("exposes manual pool data refetch for transaction success paths", () => {

--- a/packages/web/src/hooks/pool/data/use-select-pool.spec.ts
+++ b/packages/web/src/hooks/pool/data/use-select-pool.spec.ts
@@ -10,4 +10,22 @@ describe("useSelectPool liquidity segment price", () => {
     expect(source).toContain("currentPrice: segmentCurrentPrice");
     expect(source).toContain("segmentCurrentPrice,\n      ],");
   });
+
+  it("keeps pool RPC queries off idle refetch polling", () => {
+    const source = readFileSync(path.join(__dirname, "use-select-pool.tsx"), { encoding: "utf8" });
+    const addPagePollingMatches = source.match(/refetchInterval: shouldRefetch \? 5_000 : false/g) ?? [];
+
+    expect(addPagePollingMatches).toHaveLength(1);
+    expect(source).toContain("useGetPoolLiquidity(calculatedPoolPath, {\n    enabled: !!calculatedPoolPath && !isCreate,\n  });");
+    expect(source).toContain("useGetPoolSqrtPriceX96(calculatedPoolPath, {\n    enabled: !!calculatedPoolPath && !isCreate,\n  });");
+  });
+
+  it("exposes manual pool data refetch for transaction success paths", () => {
+    const source = readFileSync(path.join(__dirname, "use-select-pool.tsx"), { encoding: "utf8" });
+
+    expect(source).toContain("refetchPoolData: () => Promise<void>;");
+    expect(source).toContain("const refetchPoolData = useCallback(async () => {");
+    expect(source).toContain("Promise.allSettled([refetchPoolFromDb(), refetchLiquidity(), refetchSqrtPriceX96()])");
+    expect(source).toContain("refetchPoolData,");
+  });
 });

--- a/packages/web/src/hooks/pool/data/use-select-pool.tsx
+++ b/packages/web/src/hooks/pool/data/use-select-pool.tsx
@@ -84,6 +84,7 @@ export interface SelectPool {
   isOrderedPrice: boolean;
   setIsChangeMinMax: (value: boolean) => void;
   isLoading: boolean;
+  refetchPoolData: () => Promise<void>;
 }
 
 export const useSelectPool = ({
@@ -160,14 +161,21 @@ export const useSelectPool = ({
 
   const shouldRefetch = ["/earn/pool/add", "/earn/add"].includes(router.pathname);
 
-  const { data: poolFromDb, isLoading: isLoadingPoolFromDb } = useGetPoolFromDb(convertPath, {
+  const {
+    data: poolFromDb,
+    isLoading: isLoadingPoolFromDb,
+    refetch: refetchPoolFromDb,
+  } = useGetPoolFromDb(convertPath, {
     enabled: !!convertPath && !isCreate,
     refetchInterval: shouldRefetch ? 5_000 : false,
   });
 
-  const { data: liquidity, isLoading: isLoadingLiquidity } = useGetPoolLiquidity(calculatedPoolPath, {
+  const {
+    data: liquidity,
+    isLoading: isLoadingLiquidity,
+    refetch: refetchLiquidity,
+  } = useGetPoolLiquidity(calculatedPoolPath, {
     enabled: !!calculatedPoolPath && !isCreate,
-    refetchInterval: shouldRefetch ? 5_000 : false,
   });
 
   const { data: tickSpacing, isLoading: isLoadingTickSpacing } = useGetPoolTickSpacing(calculatedPoolPath, {
@@ -175,9 +183,12 @@ export const useSelectPool = ({
     fallbackFeeTier: feeTier,
   });
 
-  const { data: sqrtPriceX96, isLoading: isLoadingSqrtPriceX96 } = useGetPoolSqrtPriceX96(calculatedPoolPath, {
+  const {
+    data: sqrtPriceX96,
+    isLoading: isLoadingSqrtPriceX96,
+    refetch: refetchSqrtPriceX96,
+  } = useGetPoolSqrtPriceX96(calculatedPoolPath, {
     enabled: !!calculatedPoolPath && !isCreate,
-    refetchInterval: shouldRefetch ? 5_000 : false,
   });
 
   const isLoadingPoolInfo = isLoadingPoolFromDb || isLoadingLiquidity || isLoadingTickSpacing || isLoadingSqrtPriceX96;
@@ -248,6 +259,10 @@ export const useSelectPool = ({
     },
     [feeTier, isCreate, startPrice, tokenA, tokenB, isLoading, isLoadingPoolInfo, isLoadingLiquiditySegments],
   );
+
+  const refetchPoolData = useCallback(async () => {
+    await Promise.allSettled([refetchPoolFromDb(), refetchLiquidity(), refetchSqrtPriceX96()]);
+  }, [refetchPoolFromDb, refetchLiquidity, refetchSqrtPriceX96]);
 
   const minPrice = useMemo(() => {
     if (fullRange) {
@@ -579,5 +594,6 @@ export const useSelectPool = ({
     poolFromDb,
     liquidity,
     sqrtPriceX96,
+    refetchPoolData,
   };
 };

--- a/packages/web/src/hooks/pool/data/use-select-pool.tsx
+++ b/packages/web/src/hooks/pool/data/use-select-pool.tsx
@@ -189,6 +189,7 @@ export const useSelectPool = ({
     refetch: refetchSqrtPriceX96,
   } = useGetPoolSqrtPriceX96(calculatedPoolPath, {
     enabled: !!calculatedPoolPath && !isCreate,
+    refetchInterval: shouldRefetch ? 5_000 : false,
   });
 
   const isLoadingPoolInfo = isLoadingPoolFromDb || isLoadingLiquidity || isLoadingTickSpacing || isLoadingSqrtPriceX96;

--- a/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.spec.ts
+++ b/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.spec.ts
@@ -9,6 +9,7 @@ describe("usePoolAddLiquidityConfirmModal pool refresh", () => {
 
     expect(source).toContain("const { poolPath: selectedPoolPath, refetchPoolData } = selectPool;");
     expect(source).toContain("await refetchPoolData();");
+    expect(source).toContain("[QUERY_KEY.rpcPools],");
     expect(source).toContain("await delay(1000);\n              await handleRefreshData();");
     expect(source).toContain("onSuccess: handleRefreshData");
     expect(source).toContain("rpcProvider,\n    handleRefreshData,");

--- a/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.spec.ts
+++ b/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.spec.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+describe("usePoolAddLiquidityConfirmModal pool refresh", () => {
+  it("refreshes selected pool RPC data after add liquidity emits", () => {
+    const source = readFileSync(path.join(__dirname, "use-pool-add-liquidity-confirm-modal.tsx"), {
+      encoding: "utf8",
+    });
+
+    expect(source).toContain("const { poolPath: selectedPoolPath, refetchPoolData } = selectPool;");
+    expect(source).toContain("await refetchPoolData();");
+    expect(source).toContain("await delay(1000);\n              await handleRefreshData();");
+    expect(source).toContain("onSuccess: handleRefreshData");
+  });
+});

--- a/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.spec.ts
+++ b/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.spec.ts
@@ -11,5 +11,6 @@ describe("usePoolAddLiquidityConfirmModal pool refresh", () => {
     expect(source).toContain("await refetchPoolData();");
     expect(source).toContain("await delay(1000);\n              await handleRefreshData();");
     expect(source).toContain("onSuccess: handleRefreshData");
+    expect(source).toContain("rpcProvider,\n    handleRefreshData,");
   });
 });

--- a/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
@@ -124,6 +124,7 @@ export const usePoolAddLiquidityConfirmModal = ({
     invalidateQueryKey("AddLiquidity", [
       [QUERY_KEY.positions, currentChainId, address],
       [QUERY_KEY.pools],
+      [QUERY_KEY.rpcPools],
       [QUERY_KEY.poolDetail, poolPath],
       [QUERY_KEY.poolLiquidityTicks],
     ]);

--- a/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
@@ -114,9 +114,12 @@ export const usePoolAddLiquidityConfirmModal = ({
   const [openedModal, setOpenedModal] = useAtom(CommonState.openedModal);
   const [, setModalContent] = useAtom(CommonState.modalContent);
   const { invalidateQueryKey } = useInvalidateQueries();
+  const { poolPath: selectedPoolPath, refetchPoolData } = selectPool;
 
   const handleRefreshData = useCallback(async () => {
-    const poolPath = selectPool.poolPath || "";
+    const poolPath = selectedPoolPath || "";
+
+    await refetchPoolData();
 
     invalidateQueryKey("AddLiquidity", [
       [QUERY_KEY.positions, currentChainId, address],
@@ -124,7 +127,7 @@ export const usePoolAddLiquidityConfirmModal = ({
       [QUERY_KEY.poolDetail, poolPath],
       [QUERY_KEY.poolLiquidityTicks],
     ]);
-  }, [invalidateQueryKey, selectPool.poolPath, currentChainId, address]);
+  }, [invalidateQueryKey, selectedPoolPath, refetchPoolData, currentChainId, address]);
 
   const tokenAAmount = useMemo(() => {
     const depositRatio = selectPool.depositRatio;
@@ -409,7 +412,7 @@ export const usePoolAddLiquidityConfirmModal = ({
             },
             onEmit: async () => {
               await delay(1000);
-              handleRefreshData();
+              await handleRefreshData();
             },
             onSuccess: handleRefreshData,
           });

--- a/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
+++ b/packages/web/src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx
@@ -476,6 +476,7 @@ export const usePoolAddLiquidityConfirmModal = ({
     slippage,
     createPool,
     rpcProvider,
+    handleRefreshData,
   ]);
 
   const openAddPositionModal = useCallback(() => {

--- a/packages/web/src/react-query/pools/use-get-rpc-pools-by.spec.ts
+++ b/packages/web/src/react-query/pools/use-get-rpc-pools-by.spec.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+describe("useGetRPCPoolsBy polling", () => {
+  it("fetches fee-tier liquidity without idle refetch polling", () => {
+    const source = readFileSync(path.join(__dirname, "use-get-rpc-pools-by.ts"), { encoding: "utf8" });
+
+    expect(source).toContain("poolRepository.getPoolLiquidity(poolPath)");
+    expect(source).toContain("staleTime: 1000 * 30");
+    expect(source).not.toContain("refetchInterval");
+  });
+});

--- a/packages/web/src/react-query/pools/use-get-rpc-pools-by.ts
+++ b/packages/web/src/react-query/pools/use-get-rpc-pools-by.ts
@@ -43,6 +43,5 @@ export const useGetRPCPoolsBy = (poolPaths: string[]) => {
     },
     enabled: poolPaths.length > 0,
     staleTime: 1000 * 30,
-    refetchInterval: 1000 * 60,
   });
 };


### PR DESCRIPTION
## Summary
- remove idle `GetLiquidity` polling from the selected pool query on add-liquidity pages
- remove idle 60s `GetLiquidity` polling from fee-tier candidate pool queries
- keep add-page `GetSlot0SqrtPriceX96` polling so pool DB price/currentTick and sqrt price stay fresh together for amount calculations
- refresh selected pool data and fee-tier RPC pool data after add/create liquidity emit and success events
- add regression coverage for the reduced polling policy and success refresh wiring

## Verification
- yarn workspace @gnoswap-labs/web jest --runTestsByPath src/react-query/pools/use-get-rpc-pools-by.spec.ts src/hooks/pool/data/use-select-pool.spec.ts src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.spec.ts --runInBand
- yarn workspace @gnoswap-labs/web next lint --file src/react-query/pools/use-get-rpc-pools-by.ts --file src/react-query/pools/use-get-rpc-pools-by.spec.ts --file src/hooks/pool/data/use-select-pool.tsx --file src/hooks/pool/data/use-select-pool.spec.ts --file src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.tsx --file src/hooks/pool/ui/use-pool-add-liquidity-confirm-modal.spec.ts (passes with existing hook dependency warnings; spec files are ignored by the repo lint config)
- yarn workspace @gnoswap-labs/web build

## Notes
- LSP diagnostics were unavailable because the local LSP daemon could not be reached.
- Full tsc --noEmit is blocked by unrelated pre-existing spec type errors outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pool details refresh more reliably after a successful “add liquidity” action, with improved pool-path handling.
  - Adjusted pool data polling so idle refetch doesn’t trigger unnecessary liquidity polling.
- **New Features**
  - Pool selection now exposes a `refetchPoolData()` method to manually refresh pool details from all available sources concurrently.
- **Tests**
  - Added/expanded tests covering idle polling behavior and the post-transaction refresh flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
