### PR TITLE
fix: remove Gno Bridge link from header dropdown menu

### DIFF
--- a/packages/web/src/constants/header.constant.ts
+++ b/packages/web/src/constants/header.constant.ts
@@ -83,9 +83,4 @@ export const SIDE_EXTRA_MENU_NAV = [
     path: "privacy",
     iconType: "OPEN_LINK",
   },
-  {
-    title: "HeaderFooter:gnoBridge",
-    path: EXT_URL.BRIDGE,
-    iconType: "OPEN_LINK",
-  },
 ] as const;


### PR DESCRIPTION
## Summary
- Remove the "Gno Bridge" entry from the header's extra menu dropdown that was added in #944, so the bridge link is no longer exposed to users.

## Context
- #944 added a `SIDE_EXTRA_MENU_NAV` entry linking to the bridge. This PR removes that entry so the link is no longer surfaced in the UI.

## Changes
- Remove the Gno Bridge item from `SIDE_EXTRA_MENU_NAV` in `header.constant.ts`.

## Notes
- `EXT_URL.BRIDGE` and the `gnoBridge` translation keys are left in place (unused) in case the link is re-exposed later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the outdated “HeaderFooter:gnoBridge” option from the extra navigation menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->