### PR TITLE
fix: add English fallback for token verification filters

### DIFF
--- a/packages/web/src/components/home/token-list-header/TokenListHeader.tsx
+++ b/packages/web/src/components/home/token-list-header/TokenListHeader.tsx
@@ -65,7 +65,7 @@ const TokenListHeader: React.FC<TokenListHeaderProps> = ({
       checked={showUnverifiedTokens}
       onChange={toggleShowUnverifiedTokens}
       hasLabel={true}
-      labelText={t("Main:tokenList.showUnverifiedTokens")}
+      labelText={t("Main:tokenList.showUnverifiedTokens", { defaultValue: "Show unverified tokens" })}
       labelExtra={unverifiedTokensInfo}
       labelExtraPosition="before"
     />

--- a/packages/web/src/layouts/portfolio/components/asset-list/asset-list-header/AssetListHeader.tsx
+++ b/packages/web/src/layouts/portfolio/components/asset-list/asset-list-header/AssetListHeader.tsx
@@ -73,7 +73,7 @@ const AssetListHeader: React.FC<AssetListHeaderProps> = ({
             checked={showUnverifiedTokens}
             onChange={toggleShowUnverifiedTokens}
             hasLabel={true}
-            labelText={t("Wallet:assets.showUnverifiedTokens")}
+            labelText={t("Wallet:assets.showUnverifiedTokens", { defaultValue: "Show unverified tokens" })}
           />
           {connected && (
             <Switch


### PR DESCRIPTION
## Summary
- add English fallback text for the Main and Portfolio `Show unverified tokens` labels
- prevent the i18n key from being rendered when an English translation resource is missing at runtime
- keep the i18nexus-managed locale files unchanged because they are already synchronized on `develop`

## Jira
- GSW-2946

## Validation
- focused Main and Portfolio tests: 20 passed
- Prettier and diff check passed
- targeted ESLint passed (repository Pages-directory warning only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear “Show unverified tokens” fallback label to unverified-token filters in token lists and portfolio asset lists.
  * Filter labels now remain understandable when translations are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->