### PR TITLE
fix: correct footer Explore link route

### DIFF
--- a/packages/web/src/components/common/footer/Footer.spec.tsx
+++ b/packages/web/src/components/common/footer/Footer.spec.tsx
@@ -1,16 +1,32 @@
 import Footer from "./Footer";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Provider as JotaiProvider } from "jotai";
 import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
 
+jest.mock("next-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
 describe("Footer Component", () => {
-  it("should render", () => {
+  const renderFooter = () =>
     render(
       <JotaiProvider>
         <GnoswapThemeProvider>
           <Footer />
         </GnoswapThemeProvider>
       </JotaiProvider>,
+    );
+
+  it("should render", () => {
+    renderFooter();
+  });
+
+  it("links the Explore menu item to the explore page", () => {
+    renderFooter();
+
+    expect(screen.getByRole("link", { name: "HeaderFooter:governanceSection.item.dashboard" })).toHaveAttribute(
+      "href",
+      "/explore",
     );
   });
 });

--- a/packages/web/src/constants/footer.constant.tsx
+++ b/packages/web/src/constants/footer.constant.tsx
@@ -88,7 +88,7 @@ export const FOOTER_RIGHT_NAV = [
       },
       {
         title: "HeaderFooter:governanceSection.item.dashboard",
-        path: "/dashboard",
+        path: "/explore",
         newTab: false,
       },
     ],


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Governance Dashboard footer link to direct visitors to the Explore page.
  * Added coverage to verify the footer link destination and ensure the footer renders correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->