### PR TITLE
fix: truncate long token names on home page

### DIFF
--- a/packages/web/src/components/common/select-token-incentivize/SelectTokenIncentivize.spec.tsx
+++ b/packages/web/src/components/common/select-token-incentivize/SelectTokenIncentivize.spec.tsx
@@ -1,6 +1,7 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Provider as JotaiProvider } from "jotai";
 import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
+import { TokenModel } from "@models/token/token-model";
 import SelectToken, { SelectTokenIncentivizeProps } from "./SelectTokenIncentivize";
 
 describe("SelectToken Component", () => {
@@ -29,5 +30,42 @@ describe("SelectToken Component", () => {
         </GnoswapThemeProvider>
       </JotaiProvider>,
     );
+  });
+
+  it("truncates long token names in the token list", async () => {
+    const token: TokenModel = {
+      path: "gno.land/r/football/world",
+      type: "GRC20",
+      chainId: "Gnoland",
+      name: "FOOTBALL WORLD CUB",
+      symbol: "FWC",
+      displaySymbol: "FWC",
+      decimals: 6,
+      logoURI: "",
+      createdAt: "",
+      priceID: "gno.land/r/football/world",
+    };
+
+    const args: SelectTokenIncentivizeProps = {
+      keyword: "",
+      defaultTokens: [],
+      tokens: [token],
+      tokenPrices: {},
+      changeKeyword: jest.fn(),
+      changeToken: jest.fn(),
+      close: jest.fn(),
+      themeKey: "dark",
+    };
+
+    render(
+      <JotaiProvider>
+        <GnoswapThemeProvider>
+          <SelectToken {...args} />
+        </GnoswapThemeProvider>
+      </JotaiProvider>,
+    );
+
+    expect(await screen.findByText("FOOTBALL...")).toBeInTheDocument();
+    expect(screen.queryByText("FOOTBALL WORLD CUB")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/common/select-token-incentivize/SelectTokenIncentivize.tsx
+++ b/packages/web/src/components/common/select-token-incentivize/SelectTokenIncentivize.tsx
@@ -5,6 +5,7 @@ import { TokenModel } from "@models/token/token-model";
 import BigNumber from "bignumber.js";
 import MissingLogo from "../missing-logo/MissingLogo";
 import { useTranslation } from "react-i18next";
+import { formatDisplayTokenName } from "@utils/token-utils";
 export interface SelectTokenIncentivizeProps {
   keyword: string;
   defaultTokens: TokenModel[];
@@ -66,7 +67,7 @@ const SelectTokenIncentivize: React.FC<SelectTokenIncentivizeProps> = ({ tokens,
                   width={24}
                   mobileWidth={24}
                 />
-                <span className="token-name">{token.name}</span>
+                <span className="token-name">{formatDisplayTokenName(token.name)}</span>
                 <span className="token-symbol">{token.displaySymbol}</span>
               </div>
               <span className="token-balance">{getTokenPrice(token)}</span>

--- a/packages/web/src/components/common/token-info-cell/TokenInfoCell.spec.tsx
+++ b/packages/web/src/components/common/token-info-cell/TokenInfoCell.spec.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { Provider as JotaiProvider } from "jotai";
+
+import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
+
+import TokenInfoCell from "./TokenInfoCell";
+
+const TOKEN = {
+  path: "gno.land/r/football/world",
+  name: "FOOTBALL WORLD CUB",
+  symbol: "FWC",
+  displaySymbol: "FWC",
+  logoURI: "",
+};
+
+describe("TokenInfoCell", () => {
+  it("truncates long names when requested", async () => {
+    render(
+      <JotaiProvider>
+        <GnoswapThemeProvider>
+          <TokenInfoCell token={TOKEN} isNative={false} truncateName />
+        </GnoswapThemeProvider>
+      </JotaiProvider>,
+    );
+
+    expect(await screen.findByText("FOOTBALL...")).toBeInTheDocument();
+    expect(screen.queryByText("FOOTBALL WORLD CUB")).not.toBeInTheDocument();
+  });
+
+  it("preserves the full name by default for shared consumers", async () => {
+    render(
+      <JotaiProvider>
+        <GnoswapThemeProvider>
+          <TokenInfoCell token={TOKEN} isNative={false} />
+        </GnoswapThemeProvider>
+      </JotaiProvider>,
+    );
+
+    expect(await screen.findByText("FOOTBALL WORLD CUB")).toBeInTheDocument();
+    expect(screen.queryByText("FOOTBALL...")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/common/token-info-cell/TokenInfoCell.tsx
+++ b/packages/web/src/components/common/token-info-cell/TokenInfoCell.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo, useRef } from "react";
 import useElementWidth from "@hooks/common/use-element-width";
 import { useGnoscanUrl } from "@hooks/common/use-gnoscan-url";
 import { DEVICE_TYPE } from "@styles/media";
-import { formatTokenPath } from "@utils/token-utils";
+import { formatDisplayTokenName, formatTokenPath } from "@utils/token-utils";
 
 import IconOpenLink from "@components/common/icons/IconOpenLink";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
@@ -20,9 +20,10 @@ export interface TokenInfoCellProps {
   };
   isNative: boolean;
   breakpoint?: DEVICE_TYPE;
+  truncateName?: boolean;
 }
 
-function TokenInfoCell({ token, breakpoint, isNative }: TokenInfoCellProps) {
+function TokenInfoCell({ token, breakpoint, isNative, truncateName = false }: TokenInfoCellProps) {
   const { name, path, symbol, displaySymbol, logoURI } = token;
   const theme = useTheme();
   const { getGnoscanUrl, getTokenUrl } = useGnoscanUrl();
@@ -37,6 +38,8 @@ function TokenInfoCell({ token, breakpoint, isNative }: TokenInfoCellProps) {
   const tokenPathDisplay = useMemo(() => {
     return formatTokenPath(path, isNative);
   }, [isNative, path]);
+
+  const displayName = truncateName ? formatDisplayTokenName(name) : name;
 
   const onClickPath = useCallback(
     (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
@@ -56,7 +59,7 @@ function TokenInfoCell({ token, breakpoint, isNative }: TokenInfoCellProps) {
       <div className={`token-name-symbol-path ${breakpoint === DEVICE_TYPE.MOBILE ? "mobile" : ""}`}>
         <div className="token-name-path">
           <strong className="token-name" ref={tokenNameRef} id={elementId}>
-            {name}
+            {displayName}
           </strong>
           <div className="token-link" onClick={onClickPath}>
             <span>{tokenPathDisplay}</span>

--- a/packages/web/src/components/home/card-list-item/CardListTokenItem.spec.tsx
+++ b/packages/web/src/components/home/card-list-item/CardListTokenItem.spec.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { Provider as JotaiProvider } from "jotai";
+
+import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
+import { CardListTokenInfo } from "@models/common/card-list-item-info";
+
+import CardListTokenItem from "./CardListTokenItem";
+
+const TOKEN_ITEM: CardListTokenInfo = {
+  token: {
+    path: "gno.land/r/football/world",
+    type: "GRC20",
+    chainId: "Gnoland",
+    name: "FOOTBALL WORLD CUB",
+    symbol: "FWC",
+    displaySymbol: "FWC",
+    decimals: 6,
+    logoURI: "",
+    createdAt: "",
+    priceID: "gno.land/r/football/world",
+  },
+  upDown: "none",
+  content: "-",
+};
+
+describe("CardListTokenItem", () => {
+  it("truncates long token names in the home card list", async () => {
+    render(
+      <JotaiProvider>
+        <GnoswapThemeProvider>
+          <CardListTokenItem index={1} item={TOKEN_ITEM} onClickItem={jest.fn()} />
+        </GnoswapThemeProvider>
+      </JotaiProvider>,
+    );
+
+    expect(await screen.findByText("FOOTBALL...")).toBeInTheDocument();
+    expect(screen.queryByText("FOOTBALL WORLD CUB")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/home/card-list-item/CardListTokenItem.tsx
+++ b/packages/web/src/components/home/card-list-item/CardListTokenItem.tsx
@@ -4,6 +4,7 @@ import IconTriangleArrowUp from "@components/common/icons/IconTriangleArrowUp";
 import IconTriangleArrowDown from "@components/common/icons/IconTriangleArrowDown";
 import { CardListTokenInfo } from "@models/common/card-list-item-info";
 import { useCallback, useMemo } from "react";
+import { formatDisplayTokenName } from "@utils/token-utils";
 
 interface CardListTokenItemProps {
   index: number;
@@ -35,7 +36,7 @@ const CardListTokenItem: React.FC<CardListTokenItemProps> = ({ index, item, onCl
         width={20}
         mobileWidth={20}
       />
-      <strong className="token-name">{item.token.name}</strong>
+      <strong className="token-name">{formatDisplayTokenName(item.token.name)}</strong>
       <span className="list-content">{item.token.displaySymbol}</span>
       {visibleUp && <IconTriangleArrowUp className="arrow-up" />}
       {visibleDown && <IconTriangleArrowDown className="arrow-down" />}

--- a/packages/web/src/components/home/mobile-token-info/MobileTokenInfo.tsx
+++ b/packages/web/src/components/home/mobile-token-info/MobileTokenInfo.tsx
@@ -48,7 +48,7 @@ const MobileTokenInfo: React.FC<TokenInfoProps> = ({ item }) => {
     <TokenInfoWrapper>
       <HoverSection onClick={() => onClickItem(token.path)}>
         <TableColumn className="name-col left" tdWidth={MOBILE_TOKEN_TD_WIDTH[1]}>
-          <TokenInfoCell token={token} isNative={item.isNative} breakpoint={DEVICE_TYPE.MOBILE} />
+          <TokenInfoCell token={token} isNative={item.isNative} breakpoint={DEVICE_TYPE.MOBILE} truncateName />
         </TableColumn>
         <TableColumn className={cx("price-col", priceStyle.className)} tdWidth={MOBILE_TOKEN_TD_WIDTH[2]}>
           <span>

--- a/packages/web/src/components/home/token-info/TokenInfo.tsx
+++ b/packages/web/src/components/home/token-info/TokenInfo.tsx
@@ -108,7 +108,7 @@ const TokenInfo: React.FC<TokenInfoProps> = ({ item, idx }) => {
           <span className="token-index">{idx}</span>
         </TableColumn>
         <TableColumn className="name-col left left-padding" tdWidth={TOKEN_TD_WIDTH[1]}>
-          <TokenInfoCell token={token} isNative={isNative} />
+          <TokenInfoCell token={token} isNative={isNative} truncateName />
         </TableColumn>
         <TableColumn className={cx("right-padding-16", priceStyle.className)} tdWidth={TOKEN_TD_WIDTH[2]}>
           {renderPrice(price)}

--- a/packages/web/src/layouts/portfolio/components/asset-list/asset-list-table/asset-info/AssetInfo.spec.tsx
+++ b/packages/web/src/layouts/portfolio/components/asset-list/asset-list-table/asset-info/AssetInfo.spec.tsx
@@ -1,6 +1,6 @@
 import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
 import { DEVICE_TYPE } from "@styles/media";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Provider as JotaiProvider } from "jotai";
 import AssetInfo, { AssetInfoProps } from "./AssetInfo";
 
@@ -17,13 +17,13 @@ jest.mock("next/router", () => ({
 }));
 
 describe("AssetInfo Component", () => {
-  it("AssetInfo render", () => {
+  it("AssetInfo render", async () => {
     const mockProps: AssetInfoProps = {
       asset: {
         path: "gno.land/r/onbloc/gns",
         type: "GRC20",
         chainId: "Gnoland",
-        name: "Gnoswap",
+        name: "FOOTBALL WORLD CUB",
         symbol: "GNS",
         displaySymbol: "GNS",
         decimals: 6,
@@ -46,5 +46,8 @@ describe("AssetInfo Component", () => {
         </GnoswapThemeProvider>
       </JotaiProvider>,
     );
+
+    expect(await screen.findByText("FOOTBALL...")).toBeInTheDocument();
+    expect(screen.queryByText("FOOTBALL WORLD CUB")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/layouts/portfolio/components/asset-list/asset-list-table/asset-info/AssetInfo.tsx
+++ b/packages/web/src/layouts/portfolio/components/asset-list/asset-list-table/asset-info/AssetInfo.tsx
@@ -49,7 +49,7 @@ const AssetInfo: React.FC<AssetInfoProps> = ({ asset, deposit, withdraw, moveTok
   }, [withdraw, asset]);
 
   const tokenInfoCell = useMemo(
-    () => <TokenInfoCell token={asset} isNative={isNativeToken(asset)} breakpoint={breakpoint} />,
+    () => <TokenInfoCell token={asset} isNative={isNativeToken(asset)} breakpoint={breakpoint} truncateName />,
     [asset, breakpoint],
   );
 

--- a/packages/web/src/layouts/swap/components/swap-info-chart/swap-token-info/SwapTokenHeader.spec.tsx
+++ b/packages/web/src/layouts/swap/components/swap-info-chart/swap-token-info/SwapTokenHeader.spec.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { Provider as JotaiProvider } from "jotai";
+
+import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
+
+import SwapTokenHeader from "./SwapTokenHeader";
+
+jest.mock("@hooks/common/use-element-width", () => ({
+  __esModule: true,
+  default: () => 0,
+}));
+
+jest.mock("@hooks/common/use-custom-router", () => ({
+  __esModule: true,
+  default: () => ({
+    movePageWithTokenPath: jest.fn(),
+  }),
+}));
+
+jest.mock("@hooks/common/use-gnoscan-url", () => ({
+  __esModule: true,
+  useGnoscanUrl: () => ({
+    getGnoscanUrl: () => "",
+    getTokenUrl: () => "",
+  }),
+}));
+
+describe("SwapTokenHeader", () => {
+  it("truncates long token names in the swap header", async () => {
+    render(
+      <JotaiProvider>
+        <GnoswapThemeProvider>
+          <SwapTokenHeader
+            tokenInfo={{
+              name: "FOOTBALL WORLD CUB",
+              symbol: "FWC",
+              displaySymbol: "FWC",
+              logoURI: "",
+              path: "gno.land/r/football/world",
+              isNative: false,
+            }}
+            priceGradeType="NONE"
+            currentPrice="$1.00"
+            containerWidth={600}
+          />
+        </GnoswapThemeProvider>
+      </JotaiProvider>,
+    );
+
+    expect(await screen.findByText("FOOTBALL...")).toBeInTheDocument();
+    expect(screen.queryByText("FOOTBALL WORLD CUB")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/layouts/swap/components/swap-info-chart/swap-token-info/SwapTokenHeader.tsx
+++ b/packages/web/src/layouts/swap/components/swap-info-chart/swap-token-info/SwapTokenHeader.tsx
@@ -16,7 +16,7 @@ import IconOpenLink from "@components/common/icons/IconOpenLink";
 import MissingLogo from "@components/common/missing-logo/MissingLogo";
 import useCustomRouter from "@hooks/common/use-custom-router";
 import { nullish } from "@utils/nullish-utils";
-import { formatTokenPath } from "@utils/token-utils";
+import { formatDisplayTokenName, formatTokenPath } from "@utils/token-utils";
 import { SwapTokenHeaderWrapper } from "./SwapTokenHeader.styles";
 
 import PriceWarning from "@components/common/price-warning/PriceWarning";
@@ -47,6 +47,7 @@ const SwapTokenHeader = ({
 }: SwapTokenHeaderProps) => {
   const router = useCustomRouter();
   const elementId = React.useMemo(() => `${tokenInfo.name}`, [tokenInfo.name]);
+  const displayTokenName = React.useMemo(() => formatDisplayTokenName(tokenInfo.name), [tokenInfo.name]);
 
   const { priceStyle, shouldShowPriceWarning } = useTokenPriceInfo({ priceGradeType });
 
@@ -115,7 +116,7 @@ const SwapTokenHeader = ({
               ref={tokenNameRef}
               onClick={onClickTokenName}
             >
-              {tokenInfo.name}
+              {displayTokenName}
             </button>
             <button className="link" onClick={onClickPath}>
               <span>{displayTokenPath}</span>

--- a/packages/web/src/layouts/token-detail/components/token-chart/token-chart-info/TokenChartInfo.spec.tsx
+++ b/packages/web/src/layouts/token-detail/components/token-chart/token-chart-info/TokenChartInfo.spec.tsx
@@ -1,24 +1,29 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Provider as JotaiProvider } from "jotai";
 import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
+import { MATH_NEGATIVE_TYPE } from "@constants/option.constant";
 import TokenChartInfo, { TokenChartInfoProps } from "./TokenChartInfo";
 
 describe("TokenChartInfo Component", () => {
-  it("TokenChartInfo render", () => {
+  it("truncates a long token name while preserving the chart info layout", async () => {
     const args: TokenChartInfoProps = {
       token: {
-        name: "",
-        symbol: "",
-        displaySymbol: "",
+        name: "FOOTBALL WORLD CUB",
+        symbol: "FWC",
+        displaySymbol: "FWC",
         image: "",
       },
       priceInfo: {
         amount: {
-          value: 0,
-          denom: "",
+          value: 1,
+          denom: "GNOT",
+          status: MATH_NEGATIVE_TYPE.NONE,
         },
-        changedRate: 0,
+        priceGradeType: "NONE",
+        changedRate: "0%",
       },
+      isEmpty: false,
+      loading: false,
     };
 
     render(
@@ -28,5 +33,8 @@ describe("TokenChartInfo Component", () => {
         </GnoswapThemeProvider>
       </JotaiProvider>,
     );
+
+    expect(await screen.findByText("FOOTBALL...")).toBeInTheDocument();
+    expect(screen.queryByText("FOOTBALL WORLD CUB")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/layouts/token-detail/components/token-chart/token-chart-info/TokenChartInfo.tsx
+++ b/packages/web/src/layouts/token-detail/components/token-chart/token-chart-info/TokenChartInfo.tsx
@@ -11,6 +11,7 @@ import { TOKEN_PRICE_GRADE_TYPE } from "@models/token/token-price-grade";
 import PriceWarning from "@components/common/price-warning/PriceWarning";
 import { cx } from "@emotion/css";
 import { useTokenPriceInfo } from "@hooks/token/data/use-token-price-info";
+import { formatDisplayTokenName } from "@utils/token-utils";
 
 export interface TokenChartInfoProps {
   token: {
@@ -82,7 +83,7 @@ const TokenChartInfo: React.FC<TokenChartInfoProps> = ({ token, priceInfo, loadi
           )}
           {!loading && (
             <div>
-              <span className="token-name">{token.name}</span>
+              <span className="token-name">{formatDisplayTokenName(token.name)}</span>
               <span className="token-symbol">{token.displaySymbol}</span>
             </div>
           )}

--- a/packages/web/src/utils/token-utils.spec.ts
+++ b/packages/web/src/utils/token-utils.spec.ts
@@ -1,6 +1,7 @@
 import { GNOT_TOKEN } from "@common/values/token-constant";
 import { TokenModel } from "@models/token/token-model";
 import {
+  formatDisplayTokenName,
   formatDisplayTokenSymbol,
   formatTokenBalanceDisplay,
   formatTokenModelPath,
@@ -36,6 +37,18 @@ describe("format display token symbol", () => {
     expect(formatDisplayTokenSymbol("ibc/488D610A5FB7878660703092A35BC4E7D0C88E2EA71174337AA317A22C05177F")).toBe(
       "ibc/488D6...",
     );
+  });
+});
+
+describe("format display token name", () => {
+  it("should keep token names with 9 or fewer characters", () => {
+    expect(formatDisplayTokenName("FOOTBALL")).toBe("FOOTBALL");
+    expect(formatDisplayTokenName("123456789")).toBe("123456789");
+  });
+
+  it("should shorten long token names and remove a trailing cut-space", () => {
+    expect(formatDisplayTokenName("FOOTBALL WORLD CUB")).toBe("FOOTBALL...");
+    expect(formatDisplayTokenName("1234567890")).toBe("123456789...");
   });
 });
 

--- a/packages/web/src/utils/token-utils.ts
+++ b/packages/web/src/utils/token-utils.ts
@@ -20,6 +20,12 @@ export function formatDisplayTokenSymbol(symbol: string): string {
   return `${symbol.slice(0, TOKEN_DISPLAY_MAX_LENGTH)}...`;
 }
 
+export function formatDisplayTokenName(name: string): string {
+  if (name.length <= TOKEN_DISPLAY_MAX_LENGTH) return name;
+
+  return `${name.slice(0, TOKEN_DISPLAY_MAX_LENGTH).trimEnd()}...`;
+}
+
 export function makeRawTokenAmount(token: TokenModel, amount: string | number) {
   const number = BigNumber(amount.toString());
   if (number.isNaN()) {


### PR DESCRIPTION
## Summary
- Prevents long token names from breaking the Home token list layout.
- Applies display-only truncation to Home desktop and mobile token views while preserving the original token name for links, search, and sorting.
- Keeps the shared token cell reusable for other screens without forcing the same truncation policy on Portfolio.

## Implementation
- Added a shared nine-character display formatter that appends `...` for longer names and removes trailing whitespace before the ellipsis.
- Added an explicit `truncateName` prop to `TokenInfoCell` and enabled it only in the Home token views.
- Added regression coverage for the formatter and the token cell rendering.
