### PR TITLE
fix: correct paginated position card layout

### DIFF
--- a/packages/web/src/components/common/my-position-card-list/MyPositionCardList.spec.tsx
+++ b/packages/web/src/components/common/my-position-card-list/MyPositionCardList.spec.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import MyPositionCardList from "./MyPositionCardList";
+import { PoolPositionModel } from "@models/position/pool-position-model";
+
+jest.mock("./MyPositionCardList.styles", () => ({
+  CardListWrapper: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  BlankPositionCard: () => <div data-testid="blank-position-card" />,
+}));
+
+jest.mock("./my-position-card/MyPositionCard", () => ({
+  __esModule: true,
+  default: ({ position }: { position: PoolPositionModel }) => (
+    <div data-testid="position-card">{position.lpTokenId}</div>
+  ),
+}));
+
+jest.mock("../scroll-wrapper", () => {
+  const HorizontalScrollWrapper = React.forwardRef<
+    HTMLDivElement,
+    { children: React.ReactNode; loading: boolean; onScroll?: () => void }
+  >(({ children }, ref) => (
+    <div data-testid="horizontal-scroll-wrapper" ref={ref}>
+      {children}
+    </div>
+  ));
+  HorizontalScrollWrapper.displayName = "HorizontalScrollWrapper";
+
+  return { HorizontalScrollWrapper };
+});
+
+jest.mock("../pagination/Pagination", () => ({
+  __esModule: true,
+  default: () => <div data-testid="pagination" />,
+}));
+
+describe("MyPositionCardList", () => {
+  it("fills only the current row on the last paginated page", () => {
+    const positions = Array.from({ length: 3 }, (_, index) => ({
+      lpTokenId: index + 1,
+    })) as unknown as PoolPositionModel[];
+
+    render(
+      <MyPositionCardList
+        isFetched
+        isLoading={false}
+        loadMore={false}
+        positions={positions}
+        currentIndex={1}
+        maxDisplayCount={4}
+        movePoolDetail={jest.fn()}
+        mobile={false}
+        showPositionIndicator={false}
+        showLoadMore={false}
+        width={1440}
+        themeKey="light"
+        tokenPrices={{}}
+        currentPage={3}
+        totalPage={3}
+        movePage={jest.fn()}
+        limit={20}
+      />,
+    );
+
+    expect(screen.getAllByTestId("position-card")).toHaveLength(3);
+    expect(screen.getAllByTestId("blank-position-card")).toHaveLength(1);
+    expect(screen.getByTestId("pagination")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/common/my-position-card-list/MyPositionCardList.tsx
+++ b/packages/web/src/components/common/my-position-card-list/MyPositionCardList.tsx
@@ -57,7 +57,6 @@ const MyPositionCardList: React.FC<MyPositionCardListProps> = ({
   currentPage,
   totalPage,
   movePage,
-  limit,
 }) => {
   const breakpoint = width >= 920 ? DEVICE_TYPE.WEB : DEVICE_TYPE.MOBILE;
 
@@ -67,13 +66,12 @@ const MyPositionCardList: React.FC<MyPositionCardListProps> = ({
   const shouldShowLoadMoreButton = !mobile && !isLoading && showLoadMore && !!onClickLoadMore;
   const shouldShowPositionIndicator = showPositionIndicator && isFetched && hasPositions && !isLoading;
   const shouldShowPagination = Boolean(totalPage && totalPage > 1 && (mobile || !loadMore));
-  const targetCount = shouldShowPagination && limit ? limit : maxDisplayCount;
   const shouldShowBlankCards = isFetched && !isLoading && hasPositions && positions.length < maxDisplayCount;
 
   const blankCardCount = useMemo(() => {
     if (!shouldShowBlankCards) return 0;
-    return targetCount - positions.length;
-  }, [shouldShowBlankCards, targetCount, positions.length]);
+    return Math.max(0, maxDisplayCount - positions.length);
+  }, [shouldShowBlankCards, maxDisplayCount, positions.length]);
 
   return (
     <CardListWrapper $loading={isLoading}>
@@ -95,7 +93,8 @@ const MyPositionCardList: React.FC<MyPositionCardListProps> = ({
           Array(blankCardCount)
             .fill(1)
             .map((_, index) => <BlankPositionCard key={index} />)}
-        {shouldShowSkeleton && !hasPositions &&
+        {shouldShowSkeleton &&
+          !hasPositions &&
           Array.from({ length: maxDisplayCount }).map((_, idx) => (
             <span key={idx} className="card-skeleton" css={pulseSkeletonStyle({ w: "100%", tone: "600" })} />
           ))}


### PR DESCRIPTION
## Summary

- Fixed the last pagination page rendering the full API `limit` as blank cards.
- Blank cards are now calculated from the responsive row capacity (`maxDisplayCount`) and the number of actual positions.
- With `limit=20`, 3 actual positions, and a desktop four-column layout, only 1 blank card is rendered.
- Added regression coverage for the shared `MyPositionCardList` component.


## Validation

- Targeted Jest: 2 suites / 3 tests passed
- ESLint: passed (with the repository's existing `pages` directory warning only)
- Prettier check: passed
- `git diff --check`: passed
- Full TypeScript check: blocked by 50 pre-existing type errors in unrelated spec files.
- The local `/earn` page loaded successfully, but the authenticated final pagination page could not be reproduced in the browser because the wallet was disconnected and the dev API was unavailable due to local DNS/network restrictions.
