### PR TITLE
fix: correct pool token deposit ratios

### DIFF
--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-detailed-position-card/MyDetailedPositionCard.tsx
@@ -46,13 +46,11 @@ import { formatTokenExchangeRate } from "@utils/stake-position-utils";
 import { isEndTickBy, tickToPrice, tickToPriceStr } from "@utils/swap-utils";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
 import { isClaimableReward, mapToDisplayRewardType } from "@utils/reward-utils";
-import { makeDisplayPrice, sortTokensByPoolOrder } from "@utils/pool-utils";
+import { calculateTokenDepositRatio, makeDisplayPrice, sortTokensByPoolOrder } from "@utils/pool-utils";
 
 import { BalanceTooltipContent, PositionBalanceInfo } from "./BalanceTooltipContent";
 import ManageButton from "./manage-button/ManageButton";
 import PositionHistory from "./PositionHistory";
-import { DEFAULT_TOKEN_PRICE_RATIO } from "@common/values";
-
 import {
   CopyTooltip,
   LoadingChart,
@@ -211,10 +209,8 @@ const MyDetailedPositionCard: React.FC<MyDetailedPositionCardProps> = ({
       return 0.5;
     }
 
-    const priceRatio = position?.pool?.price || DEFAULT_TOKEN_PRICE_RATIO;
-
-    return tokenABalance / (tokenABalance + tokenBBalance / priceRatio);
-  }, [tokenABalance, tokenBBalance, position?.pool?.price]);
+    return calculateTokenDepositRatio(tokenABalance, tokenBBalance, position?.pool?.price, tokenA, tokenB);
+  }, [tokenABalance, tokenBBalance, position?.pool?.price, tokenA, tokenB]);
 
   const depositRatioStrOfTokenA = useMemo(() => {
     const depositStr = `${Math.round(depositRatio * 100)}%`;

--- a/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-liquidity-content/MyLiquidityContent.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/my-liquidity/my-liquidity-content/MyLiquidityContent.tsx
@@ -22,8 +22,7 @@ import { isGNOTPath } from "@utils/common";
 import { formatOtherPrice, formatPoolPairAmount } from "@utils/new-number-utils";
 import { makeDisplayTokenAmount } from "@utils/token-utils";
 import { mapToDisplayRewardType } from "@utils/reward-utils";
-import { DEFAULT_TOKEN_PRICE_RATIO } from "@common/values";
-import { sortDisplayRewards } from "@utils/pool-utils";
+import { calculateTokenDepositRatio, sortDisplayRewards } from "@utils/pool-utils";
 
 import {
   AmountDisplayWrapper,
@@ -481,10 +480,18 @@ const MyLiquidityContent: React.FC<MyLiquidityContentProps> = ({
       return 0.5;
     }
 
-    const priceRatio = positionData?.price || DEFAULT_TOKEN_PRICE_RATIO;
+    if (!positionData) {
+      return 0.5;
+    }
 
-    return tokenABalance / (tokenABalance + tokenBBalance / priceRatio);
-  }, [tokenABalance, tokenBBalance, positionData?.price]);
+    return calculateTokenDepositRatio(
+      tokenABalance,
+      tokenBBalance,
+      positionData.price,
+      positionData.tokenA,
+      positionData.tokenB,
+    );
+  }, [tokenABalance, tokenBBalance, positionData]);
 
   const depositRatioStrOfTokenA = useMemo(() => {
     const depositStr = `${Math.round(depositRatio * 100)}%`;

--- a/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-content/PoolPairInfoContent.tsx
+++ b/packages/web/src/layouts/pool/pool-detail/components/pool-pair-information/pool-pair-info-content/PoolPairInfoContent.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { cx } from "@emotion/css";
 
-import { STATIC_TEXT, DEFAULT_TOKEN_PRICE_RATIO } from "@common/values";
+import { STATIC_TEXT } from "@common/values";
 import IconStar from "@components/common/icons/IconStar";
 import IconAdd from "@components/common/icons/IconAdd";
 import IconRemove from "@components/common/icons/IconRemove";
@@ -22,7 +22,7 @@ import { PoolLiquiditySegmentModel } from "@models/pool/pool-liquidity-model";
 import { TokenModel } from "@models/token/token-model";
 import { ThemeState } from "@states/index";
 import { formatOtherPrice, formatPoolPairAmount, formatRate } from "@utils/new-number-utils";
-import { makeDisplayPrice } from "@utils/pool-utils";
+import { calculateTokenDepositRatio, makeDisplayPrice } from "@utils/pool-utils";
 import { formatTokenExchangeRate } from "@utils/stake-position-utils";
 
 import {
@@ -97,10 +97,8 @@ const PoolPairInfoContent: React.FC<PoolPairInfoContentProps> = ({
       return 0.5;
     }
 
-    const priceRatio = pool.price || DEFAULT_TOKEN_PRICE_RATIO;
-
-    return tokenABalanceNum / (tokenABalanceNum + tokenBBalanceNum / priceRatio);
-  }, [tokenABalance, tokenBBalance, pool.price]);
+    return calculateTokenDepositRatio(tokenABalanceNum, tokenBBalanceNum, pool.price, pool.tokenA, pool.tokenB);
+  }, [tokenABalance, tokenBBalance, pool.price, pool.tokenA, pool.tokenB]);
 
   const depositRatioStrOfTokenA = useMemo(() => {
     if (Number.isNaN(depositRatio)) return "(0%)";

--- a/packages/web/src/utils/pool-utils.spec.ts
+++ b/packages/web/src/utils/pool-utils.spec.ts
@@ -1,5 +1,6 @@
 import { TokenModel } from "@models/token/token-model";
 import {
+  calculateTokenDepositRatio,
   invertSqrtPriceX96,
   isOrderedTokenPaths,
   isValidCurrentPrice,
@@ -84,6 +85,36 @@ describe("isOrderedTokenPaths", () => {
     // "gno.land/r/gnoland/wugnot" < "gno.land/r/gnoswap/gns" lexicographically
     expect(isOrderedTokenPaths(wgnotPath, gnsPath)).toBe(true);
     expect(isOrderedTokenPaths(gnsPath, wgnotPath)).toBe(false);
+  });
+});
+
+describe("token deposit ratio", () => {
+  it("should calculate an equal value split for tokens with different decimals", () => {
+    const sol = makeToken("SOL", 9);
+    const usdc = makeToken("USDC", 6);
+
+    expect(calculateTokenDepositRatio(100, 1036.45, 0.0103645, sol, usdc)).toBeCloseTo(0.5, 10);
+  });
+
+  it("should calculate an equal value split for BTC and USDC", () => {
+    const btc = makeToken("BTC", 8);
+    const usdc = makeToken("USDC", 6);
+
+    expect(calculateTokenDepositRatio(1, 49260, 492.6, btc, usdc)).toBeCloseTo(0.5, 10);
+  });
+
+  it("should preserve the ratio for tokens with equal decimals", () => {
+    const tokenA = makeToken("A", 6);
+    const tokenB = makeToken("B", 6);
+
+    expect(calculateTokenDepositRatio(100, 200, 2, tokenA, tokenB)).toBeCloseTo(0.5, 10);
+  });
+
+  it("should return an equal split when both balances are zero", () => {
+    const tokenA = makeToken("A", 9);
+    const tokenB = makeToken("B", 6);
+
+    expect(calculateTokenDepositRatio(0, 0, 1, tokenA, tokenB)).toBe(0.5);
   });
 });
 

--- a/packages/web/src/utils/pool-utils.ts
+++ b/packages/web/src/utils/pool-utils.ts
@@ -70,6 +70,21 @@ export function makeDisplayPrice(price: number | string, baseToken: TokenModel, 
     .toNumber();
 }
 
+export function calculateTokenDepositRatio(
+  tokenABalance: number,
+  tokenBBalance: number,
+  price: number | string | null | undefined,
+  tokenA: TokenModel,
+  tokenB: TokenModel,
+): number {
+  if (tokenABalance + tokenBBalance === 0) {
+    return 0.5;
+  }
+
+  const priceRatio = price ? makeDisplayPrice(price, tokenA, tokenB) : 1;
+  return tokenABalance / (tokenABalance + tokenBBalance / priceRatio);
+}
+
 export function makeRawPrice(price: number | string, baseToken: TokenModel, quoteToken: TokenModel): number {
   return BigNumber(price)
     .shiftedBy(quoteToken.decimals - baseToken.decimals)


### PR DESCRIPTION
## Summary
- Corrects the token value-share percentages shown in pool detail and position views.

## Context
- Pool and position balances are converted to display units, while the pool price remains in the raw price domain.
- Mixing those units caused pairs with different token decimals to display distorted shares such as 0%/100% or 1%/99%.

## Changes
- Normalize the pool price with `makeDisplayPrice` before calculating spot-price-based value shares.
- Reuse the shared calculation across the pool summary, aggregated My Liquidity, and individual position detail views.
- Add regression coverage for 9/6-decimal pairs, 8/6-decimal pairs, equal-decimal pairs, and zero balances.

## Verification
- `yarn workspace @gnoswap-labs/web jest --ci --runTestsByPath src/utils/pool-utils.spec.ts --runInBand` — 29 tests passed.
- Targeted ESLint — 0 errors; existing warnings only.
- Prettier check — passed.
- `git diff --check` — passed.

## Notes
- No API, contract, or deployment changes are included.
- The displayed percentage represents each token's value share at the current pool spot price, not the raw quantity share.
