### PR TITLE
fix: preserve transaction links for pending broadcasts

### DIFF
--- a/packages/web/src/hooks/common/use-gnoscan-url.spec.tsx
+++ b/packages/web/src/hooks/common/use-gnoscan-url.spec.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Provider as JotaiProvider } from "jotai";
+
+import { useGnoscanUrl } from "./use-gnoscan-url";
+
+const txHash = "ebKeJB6fEOh9BO2MJk1+aNdPmR5BEjVBavhbb42ZL/4=";
+
+describe("useGnoscanUrl", () => {
+  it("encodes URL-sensitive transaction hash characters once", () => {
+    const Probe = () => {
+      const { getTxUrl } = useGnoscanUrl();
+
+      return <output data-testid="tx-url">{getTxUrl(txHash)}</output>;
+    };
+
+    render(
+      <JotaiProvider>
+        <Probe />
+      </JotaiProvider>,
+    );
+
+    const txUrl = screen.getByTestId("tx-url").textContent || "";
+    expect(txUrl).toContain(`txhash=${encodeURIComponent(txHash)}`);
+    expect(txUrl).not.toContain(`txhash=${txHash}`);
+  });
+});

--- a/packages/web/src/hooks/common/use-gnoscan-url.tsx
+++ b/packages/web/src/hooks/common/use-gnoscan-url.tsx
@@ -41,7 +41,7 @@ export const useGnoscanUrl = () => {
 
   const getTxUrl = useCallback(
     (txHash: string) => {
-      return getGnoscanUrl(GnoscanDataType.Transactions, `details?txhash=${txHash}`);
+      return getGnoscanUrl(GnoscanDataType.Transactions, `details?txhash=${encodeURIComponent(txHash)}`);
     },
     [getGnoscanUrl],
   );

--- a/packages/web/src/hooks/common/use-transaction-event-store.spec.tsx
+++ b/packages/web/src/hooks/common/use-transaction-event-store.spec.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+import { DexEvent } from "@repositories/common";
+
+import { useTransactionEventStore } from "./use-transaction-event-store";
+
+jest.mock("@hooks/common/use-snackbar", () => ({
+  useSnackbar: jest.fn(),
+}));
+
+jest.mock("@hooks/common/use-gnoswap-context", () => ({
+  useGnoswapContext: jest.fn(),
+}));
+
+jest.mock("@hooks/common/use-custom-router", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("@hooks/common/use-message", () => ({
+  useMessage: jest.fn(),
+}));
+
+jest.mock("@hooks/swap/data/use-wrap", () => ({
+  useWrap: jest.fn(),
+}));
+
+jest.mock("@hooks/wallet/data/use-wallet", () => ({
+  useWallet: jest.fn(),
+}));
+
+jest.mock("@query/common", () => ({
+  useGetNotifications: jest.fn(),
+}));
+
+import useCustomRouter from "@hooks/common/use-custom-router";
+import { useGnoswapContext } from "@hooks/common/use-gnoswap-context";
+import { useMessage } from "@hooks/common/use-message";
+import { useSnackbar } from "@hooks/common/use-snackbar";
+import { useWrap } from "@hooks/swap/data/use-wrap";
+import { useWallet } from "@hooks/wallet/data/use-wallet";
+import { useGetNotifications } from "@query/common";
+
+describe("useTransactionEventStore", () => {
+  const txHash = "ebKeJB6fEOh9BO2MJk1+aNdPmR5BEjVBavhbb42ZL/4=";
+  const enqueue = jest.fn();
+  const eventStore = { addEvent: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useSnackbar as jest.Mock).mockReturnValue({
+      hasBadgeSnackbar: false,
+      enqueue,
+      dequeue: jest.fn(),
+      change: jest.fn(),
+    });
+    (useGnoswapContext as jest.Mock).mockReturnValue({
+      eventStore,
+      tokenRepository: {},
+      poolRepository: {},
+      positionRepository: {},
+    });
+    (useCustomRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useMessage as jest.Mock).mockReturnValue({
+      getMessage: jest.fn(),
+      getReceiveWugnotMessage: jest.fn(),
+      getStakePositionMessage: jest.fn(),
+    });
+    (useWrap as jest.Mock).mockReturnValue({
+      fetchWugnotBalance: jest.fn(),
+      unwrapAll: jest.fn(),
+    });
+    (useWallet as jest.Mock).mockReturnValue({ account: null });
+    (useGetNotifications as jest.Mock).mockReturnValue({ refetch: jest.fn() });
+  });
+
+  it("keeps the known transaction hash on the pending snackbar", () => {
+    const Probe = () => {
+      const { enqueueEvent } = useTransactionEventStore();
+
+      React.useEffect(() => {
+        enqueueEvent({ txHash, action: DexEvent.SWAP });
+      }, [enqueueEvent]);
+
+      return null;
+    };
+
+    render(<Probe />);
+
+    expect(enqueue).toHaveBeenCalledWith(
+      { txHash },
+      expect.objectContaining({
+        type: "pending",
+      }),
+    );
+  });
+});

--- a/packages/web/src/hooks/common/use-transaction-event-store.ts
+++ b/packages/web/src/hooks/common/use-transaction-event-store.ts
@@ -87,9 +87,7 @@ export const useTransactionEventStore = () => {
     visibleEmitResult?: boolean;
     checkWugnotTransfer?: boolean;
     checkStakePosition?: boolean;
-    formatData?: (
-      result: string[] | null,
-    ) => {
+    formatData?: (result: string[] | null) => {
       tokenASymbol?: string;
       tokenBSymbol?: string;
       tokenAAmount?: string;
@@ -105,7 +103,7 @@ export const useTransactionEventStore = () => {
     }
 
     const pendingSnackbarConfig = makeSnackbarConfig("pending");
-    enqueue(undefined, pendingSnackbarConfig);
+    enqueue({ txHash }, pendingSnackbarConfig);
 
     const updatingSnackbarConfig = makeSnackbarConfig("updating", UPDATING_SNACKBAR_TIMEOUT);
     const receiveWugnotSnackbarConfig = makeSnackbarConfig("receive-wugnot", BADGE_SNACKBAR_TIMEOUT);


### PR DESCRIPTION
## Summary

- Preserve the known transaction hash when creating a pending transaction snackbar.
- Encode transaction hashes in GnoScan URLs so Base64 characters such as `+`, `/`, and `=` are preserved.
- Add regression coverage for pending snackbar content and transaction URL encoding.

## Validation

- Focused Jest tests passed.
- Full web test suite passed: 152 suites and 703 tests.
- Prettier check passed.
- Targeted ESLint completed with no errors.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction links now correctly encode special characters in transaction hashes, ensuring they open the intended details page.
  * Pending transaction notifications now include the associated transaction hash for more accurate status information.

* **Tests**
  * Added coverage for transaction URL encoding.
  * Added coverage verifying transaction hashes appear correctly in pending notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->