### PR TITLE
fix(portfolio): match Earn position toggle behavior

### DIFF
--- a/packages/web/src/hooks/pool/data/use-position-data.spec.tsx
+++ b/packages/web/src/hooks/pool/data/use-position-data.spec.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+
+import { useLoading } from "@hooks/common/use-loading";
+import { useWallet } from "@hooks/wallet/data/use-wallet";
+import { useMakePoolPositions, useGetPositionsByAddress } from "@query/positions";
+import { usePoolData } from "./use-pool-data";
+import { usePositionData } from "./use-position-data";
+
+jest.mock("@hooks/common/use-loading", () => ({
+  useLoading: jest.fn(),
+}));
+
+jest.mock("@hooks/wallet/data/use-wallet", () => ({
+  useWallet: jest.fn(),
+}));
+
+jest.mock("@query/positions", () => ({
+  useGetPositionsByAddress: jest.fn(),
+  useMakePoolPositions: jest.fn(),
+}));
+
+jest.mock("./use-pool-data", () => ({
+  usePoolData: jest.fn(),
+}));
+
+const mockUseLoading = useLoading as jest.Mock;
+const mockUseWallet = useWallet as jest.Mock;
+const mockUseGetPositionsByAddress = useGetPositionsByAddress as jest.Mock;
+const mockUseMakePoolPositions = useMakePoolPositions as jest.Mock;
+const mockUsePoolData = usePoolData as jest.Mock;
+
+const previousPositions = [{ id: 1 }];
+
+const PositionDataProbe = () => {
+  const { isFetchedPosition, isPositionDataAvailable, positions, totalPositionCount } = usePositionData({
+    withClosed: true,
+  });
+
+  return (
+    <div>
+      <span data-testid="is-fetched">{String(isFetchedPosition)}</span>
+      <span data-testid="is-data-available">{String(isPositionDataAvailable)}</span>
+      <span data-testid="position-count">{String(totalPositionCount)}</span>
+      <span data-testid="mapped-position-count">{String(positions.length)}</span>
+    </div>
+  );
+};
+
+describe("usePositionData", () => {
+  beforeEach(() => {
+    mockUseLoading.mockReturnValue({ isLoading: false });
+    mockUseWallet.mockReturnValue({ account: { address: "g1address" }, connected: true });
+    mockUsePoolData.mockReturnValue({ pools: [], loading: false, isFetchedPools: true });
+    mockUseGetPositionsByAddress.mockReturnValue({
+      data: { positions: previousPositions, totalCount: 43 },
+      isFetched: false,
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+    mockUseMakePoolPositions.mockImplementation(
+      (positions: unknown[] | undefined, _pools: unknown[], isFetchedPosition: boolean, isFetchedPools: boolean) => {
+        const isFetched = isFetchedPosition && isFetchedPools;
+        return {
+          data: isFetched ? positions ?? [] : [],
+          isFetched,
+          isLoading: !isFetched,
+        };
+      },
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("keeps previous positions available while a filtered query is transitioning", () => {
+    render(<PositionDataProbe />);
+
+    expect(screen.getByTestId("is-fetched")).toHaveTextContent("false");
+    expect(screen.getByTestId("is-data-available")).toHaveTextContent("true");
+    expect(screen.getByTestId("position-count")).toHaveTextContent("43");
+    expect(screen.getByTestId("mapped-position-count")).toHaveTextContent("1");
+    expect(mockUseMakePoolPositions).toHaveBeenCalledWith(previousPositions, [], true, true, "");
+  });
+});

--- a/packages/web/src/hooks/pool/data/use-position-data.ts
+++ b/packages/web/src/hooks/pool/data/use-position-data.ts
@@ -42,6 +42,10 @@ export const usePositionData = (options?: UsePositionDataOption) => {
   });
 
   const { totalCount: totalPositionCount = 0, positions: rawPositions = [] } = data ?? {};
+  // React Query keeps the previous result while a filter-specific query is transitioning.
+  // Keep that result available for rendering without changing the meaning of isFetchedPosition.
+  const hasPositionData = data !== undefined;
+  const isPositionDataAvailable = isFetchedPosition || hasPositionData;
 
   const { isLoading: isCommonLoading } = useLoading();
 
@@ -49,7 +53,7 @@ export const usePositionData = (options?: UsePositionDataOption) => {
     data: positions = [],
     isFetched: isFetchedPoolPositions,
     isLoading: isLoadingPoolPositions,
-  } = useMakePoolPositions(rawPositions, pools, isFetchedPosition, isFetchedPools, options?.scopeId || "");
+  } = useMakePoolPositions(rawPositions, pools, isPositionDataAvailable, isFetchedPools, options?.scopeId || "");
 
   const availableStake = useMemo(() => {
     if (!isFetchedPoolPositions) {
@@ -95,6 +99,7 @@ export const usePositionData = (options?: UsePositionDataOption) => {
     checkStakedPool,
     getPositions,
     isFetchedPosition: isFetchedPosition && isFetchedPoolPositions,
+    isPositionDataAvailable: isPositionDataAvailable && isFetchedPoolPositions,
     loading,
     isLoadingPool,
   };

--- a/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.spec.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 import { usePositionData } from "@hooks/pool/data/use-position-data";
 
@@ -29,32 +29,46 @@ const mockUsePositionData = usePositionData as jest.Mock;
 
 describe("WalletMyPositionsHeader", () => {
   beforeEach(() => {
-    mockUsePositionData.mockReturnValue({
+    mockUsePositionData.mockImplementation(({ withClosed }: { withClosed?: boolean }) => ({
       positions: [],
       isFetchedPosition: true,
-      totalPositionCount: 1,
-    });
+      totalPositionCount: withClosed ? 3 : 2,
+    }));
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it("always fetches all positions to determine if closed positions exist", () => {
+  it("uses the open position count when closed positions are hidden", () => {
     render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={false} />);
 
-    expect(mockUsePositionData).toHaveBeenCalledWith({
-      withClosed: true,
+    expect(screen.getByRole("heading")).toHaveTextContent("Wallet:myPosi (2)");
+    expect(mockUsePositionData).toHaveBeenNthCalledWith(1, {
+      withClosed: false,
       scopeId: "WalletMyPositionsHeader",
+    });
+    expect(mockUsePositionData).toHaveBeenNthCalledWith(2, {
+      withClosed: true,
+      scopeId: "WalletMyPositionsHeader:closed-check",
     });
   });
 
-  it("still fetches all positions even when toggle shows closed positions", () => {
+  it("uses the inclusive position count when closed positions are shown", () => {
     render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={true} />);
 
-    expect(mockUsePositionData).toHaveBeenCalledWith({
-      withClosed: true,
-      scopeId: "WalletMyPositionsHeader",
-    });
+    expect(screen.getByRole("heading")).toHaveTextContent("Wallet:myPosi (3)");
+  });
+
+  it("shows the closed switch when a closed position exists outside the first page", () => {
+    mockUsePositionData.mockImplementation(({ withClosed }: { withClosed?: boolean }) => ({
+      positions: [],
+      isFetchedPosition: true,
+      totalPositionCount: withClosed ? 21 : 20,
+    }));
+
+    render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={false} />);
+
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.spec.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.spec.tsx
@@ -30,7 +30,6 @@ const mockUsePositionData = usePositionData as jest.Mock;
 describe("WalletMyPositionsHeader", () => {
   beforeEach(() => {
     mockUsePositionData.mockImplementation(({ withClosed }: { withClosed?: boolean }) => ({
-      positions: [],
       isFetchedPosition: true,
       totalPositionCount: withClosed ? 3 : 2,
     }));
@@ -44,13 +43,11 @@ describe("WalletMyPositionsHeader", () => {
     render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={false} />);
 
     expect(screen.getByRole("heading")).toHaveTextContent("Wallet:myPosi (2)");
-    expect(mockUsePositionData).toHaveBeenNthCalledWith(1, {
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+    expect(mockUsePositionData).toHaveBeenCalledTimes(1);
+    expect(mockUsePositionData).toHaveBeenCalledWith({
       withClosed: false,
       scopeId: "WalletMyPositionsHeader",
-    });
-    expect(mockUsePositionData).toHaveBeenNthCalledWith(2, {
-      withClosed: true,
-      scopeId: "WalletMyPositionsHeader:closed-check",
     });
   });
 
@@ -58,14 +55,19 @@ describe("WalletMyPositionsHeader", () => {
     render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={true} />);
 
     expect(screen.getByRole("heading")).toHaveTextContent("Wallet:myPosi (3)");
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+    expect(mockUsePositionData).toHaveBeenCalledTimes(1);
+    expect(mockUsePositionData).toHaveBeenCalledWith({
+      withClosed: true,
+      scopeId: "WalletMyPositionsHeader",
+    });
   });
 
-  it("shows the closed switch when a closed position exists outside the first page", () => {
-    mockUsePositionData.mockImplementation(({ withClosed }: { withClosed?: boolean }) => ({
-      positions: [],
+  it("keeps the closed switch visible without relying on a current-page closed position", () => {
+    mockUsePositionData.mockReturnValue({
       isFetchedPosition: true,
-      totalPositionCount: withClosed ? 21 : 20,
-    }));
+      totalPositionCount: 0,
+    });
 
     render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={false} />);
 

--- a/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.spec.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.spec.tsx
@@ -31,6 +31,7 @@ describe("WalletMyPositionsHeader", () => {
   beforeEach(() => {
     mockUsePositionData.mockImplementation(({ withClosed }: { withClosed?: boolean }) => ({
       isFetchedPosition: true,
+      isPositionDataAvailable: true,
       totalPositionCount: withClosed ? 3 : 2,
     }));
   });
@@ -66,11 +67,25 @@ describe("WalletMyPositionsHeader", () => {
   it("keeps the closed switch visible without relying on a current-page closed position", () => {
     mockUsePositionData.mockReturnValue({
       isFetchedPosition: true,
+      isPositionDataAvailable: true,
       totalPositionCount: 0,
     });
 
     render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={false} />);
 
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+  });
+
+  it("keeps the rendered header while the filtered position query is transitioning", () => {
+    mockUsePositionData.mockReturnValue({
+      isFetchedPosition: false,
+      isPositionDataAvailable: true,
+      totalPositionCount: 43,
+    });
+
+    render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={true} />);
+
+    expect(screen.getByRole("heading")).toHaveTextContent("Wallet:myPosi (43)");
     expect(screen.getByRole("checkbox")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.tsx
@@ -17,12 +17,12 @@ const WalletMyPositionsHeader: React.FC<WalletMyPositionsHeaderProps> = ({ toggl
   const { t } = useTranslation();
   const { isSwitchNetwork } = useWallet();
 
-  const { isFetchedPosition, totalPositionCount } = usePositionData({
+  const { isPositionDataAvailable, totalPositionCount } = usePositionData({
     withClosed: isClosed,
     scopeId: "WalletMyPositionsHeader",
   });
 
-  if (!isFetchedPosition || isSwitchNetwork) return null;
+  if (!isPositionDataAvailable || isSwitchNetwork) return null;
 
   return (
     <div css={wrapper}>

--- a/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.tsx
@@ -17,31 +17,22 @@ const WalletMyPositionsHeader: React.FC<WalletMyPositionsHeaderProps> = ({ toggl
   const { t } = useTranslation();
   const { isSwitchNetwork } = useWallet();
 
-  const { isFetchedPosition: isFetchedOpenPositions, totalPositionCount: openPositionCount } = usePositionData({
-    withClosed: false,
+  const { isFetchedPosition, totalPositionCount } = usePositionData({
+    withClosed: isClosed,
     scopeId: "WalletMyPositionsHeader",
   });
-  const { isFetchedPosition: isFetchedAllPositions, totalPositionCount: allPositionCount } = usePositionData({
-    withClosed: true,
-    scopeId: "WalletMyPositionsHeader:closed-check",
-  });
 
-  const totalPositionCount = isClosed ? allPositionCount : openPositionCount;
-  const hasClosedPositions = allPositionCount > openPositionCount;
-
-  if (!isFetchedOpenPositions || !isFetchedAllPositions || isSwitchNetwork) return null;
+  if (!isFetchedPosition || isSwitchNetwork) return null;
 
   return (
     <div css={wrapper}>
       {totalPositionCount > 0 && <h2>{`${t("Wallet:myPosi")} (${totalPositionCount.toLocaleString()})`}</h2>}
-      {hasClosedPositions && (
-        <Switch
-          checked={isClosed}
-          onChange={toggleClosed}
-          hasLabel={true}
-          labelText={t("Earn:positions.showClosedSwitch")}
-        />
-      )}
+      <Switch
+        checked={isClosed}
+        onChange={toggleClosed}
+        hasLabel={true}
+        labelText={t("Earn:positions.showClosedSwitch")}
+      />
     </div>
   );
 };

--- a/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.tsx
@@ -17,20 +17,19 @@ const WalletMyPositionsHeader: React.FC<WalletMyPositionsHeaderProps> = ({ toggl
   const { t } = useTranslation();
   const { isSwitchNetwork } = useWallet();
 
-  const {
-    positions,
-    isFetchedPosition: isFetchedPosition,
-    totalPositionCount,
-  } = usePositionData({
-    withClosed: true,
+  const { isFetchedPosition: isFetchedOpenPositions, totalPositionCount: openPositionCount } = usePositionData({
+    withClosed: false,
     scopeId: "WalletMyPositionsHeader",
   });
+  const { isFetchedPosition: isFetchedAllPositions, totalPositionCount: allPositionCount } = usePositionData({
+    withClosed: true,
+    scopeId: "WalletMyPositionsHeader:closed-check",
+  });
 
-  const hasClosedPositions = React.useMemo(() => {
-    return positions.some(position => position.closed);
-  }, [positions]);
+  const totalPositionCount = isClosed ? allPositionCount : openPositionCount;
+  const hasClosedPositions = allPositionCount > openPositionCount;
 
-  if (!isFetchedPosition || isSwitchNetwork) return null;
+  if (!isFetchedOpenPositions || !isFetchedAllPositions || isSwitchNetwork) return null;
 
   return (
     <div css={wrapper}>

--- a/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.spec.tsx
+++ b/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.spec.tsx
@@ -9,9 +9,13 @@ jest.mock("jotai", () => ({
   useAtomValue: () => "light",
 }));
 
+const mockMyPositionCardList = jest.fn();
 jest.mock("@components/common/my-position-card-list/MyPositionCardList", () => ({
   __esModule: true,
-  default: () => <div data-testid="my-position-card-list" />,
+  default: (props: { isLoading: boolean }) => {
+    mockMyPositionCardList(props);
+    return <div data-testid="my-position-card-list" />;
+  },
 }));
 
 jest.mock("@hooks/common/use-custom-router", () => ({
@@ -103,5 +107,16 @@ describe("WalletPositionCardListContainer", () => {
         page: 1,
       }),
     );
+  });
+
+  it("does not show a loading state while switching a fetched position list", () => {
+    const { rerender } = render(<WalletPositionCardListContainer isClosed={false} />);
+
+    expect(mockMyPositionCardList.mock.calls.some(([props]) => props.isLoading)).toBe(false);
+
+    mockMyPositionCardList.mockClear();
+    rerender(<WalletPositionCardListContainer isClosed={true} />);
+
+    expect(mockMyPositionCardList.mock.calls.some(([props]) => props.isLoading)).toBe(false);
   });
 });

--- a/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.spec.tsx
+++ b/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.spec.tsx
@@ -77,6 +77,7 @@ describe("WalletPositionCardListContainer", () => {
   beforeEach(() => {
     mockUsePositionData.mockReturnValue({
       isFetchedPosition: true,
+      isPositionDataAvailable: true,
       loading: false,
       positions: [],
       totalPositionCount: 0,
@@ -118,5 +119,26 @@ describe("WalletPositionCardListContainer", () => {
     rerender(<WalletPositionCardListContainer isClosed={true} />);
 
     expect(mockMyPositionCardList.mock.calls.some(([props]) => props.isLoading)).toBe(false);
+  });
+
+  it("keeps the card list renderable while the filtered position query is transitioning", () => {
+    let isFetchedPosition = true;
+    mockUsePositionData.mockImplementation(() => ({
+      isFetchedPosition,
+      isPositionDataAvailable: true,
+      loading: false,
+      positions: [],
+      totalPositionCount: 0,
+    }));
+
+    const { rerender } = render(<WalletPositionCardListContainer isClosed={false} />);
+    isFetchedPosition = false;
+    mockMyPositionCardList.mockClear();
+
+    rerender(<WalletPositionCardListContainer isClosed={true} />);
+
+    const [lastProps] = mockMyPositionCardList.mock.calls.at(-1) as [{ isFetched: boolean; isLoading: boolean }];
+    expect(lastProps.isFetched).toBe(true);
+    expect(lastProps.isLoading).toBe(false);
   });
 });

--- a/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.tsx
+++ b/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.tsx
@@ -40,7 +40,7 @@ const WalletPositionCardListContainer: React.FC<WalletPositionCardListContainerP
   }, [width]);
 
   const {
-    isFetchedPosition,
+    isPositionDataAvailable,
     loading: loadingPositions,
     positions: positionsData = [],
     totalPositionCount,
@@ -271,7 +271,7 @@ const WalletPositionCardListContainer: React.FC<WalletPositionCardListContainerP
     <MyPositionCardList
       positions={mappedData}
       loadMore={!isViewMorePositions}
-      isFetched={isFetchedPosition}
+      isFetched={isPositionDataAvailable}
       isLoading={loading || isLoadingPosition}
       movePoolDetail={movePoolDetail}
       currentIndex={currentIndex}

--- a/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.tsx
+++ b/packages/web/src/layouts/portfolio/containers/wallet-position-card-list-container/WalletPositionCardListContainer.tsx
@@ -58,8 +58,6 @@ const WalletPositionCardListContainer: React.FC<WalletPositionCardListContainerP
   const { data: tokenPrices = {} } = useGetAllTokenPrices();
 
   const [isViewMorePositions, setIsViewMorePositions] = useState(false);
-  const [mappedData, setMappedData] = useState<PoolPositionModel[]>([]);
-  const [isDataMappingLoading, setIsDataMappingLoading] = useState(true);
 
   const handleClickLoadMore = useCallback(() => {
     setIsViewMorePositions(!isViewMorePositions);
@@ -134,7 +132,7 @@ const WalletPositionCardListContainer: React.FC<WalletPositionCardListContainerP
 
   const showedPosition = useMemo(() => {
     return [...openPosition, ...(isClosed ? closedPosition : [])];
-  }, [closedPosition, isClosed, openPosition, limit]);
+  }, [closedPosition, isClosed, openPosition]);
 
   const handleScroll = useCallback(() => {
     if (divRef.current) {
@@ -219,32 +217,23 @@ const WalletPositionCardListContainer: React.FC<WalletPositionCardListContainerP
     }
   }, [showedPosition.length]);
 
-  const getMappedData = (): PoolPositionModel[] => {
-    if (isViewMorePositions) {
-      return showedPosition;
-    }
+  const mappedData = useMemo(() => {
+    let targetPositions: PoolPositionModel[];
 
-    for (const breakpoint of POSITION_CARD_LIST_BREAKPOINTS) {
-      if (width > breakpoint.width) {
-        return showedPosition.slice(0, breakpoint.displayCount);
+    if (isViewMorePositions) {
+      targetPositions = showedPosition;
+    } else {
+      targetPositions = showedPosition;
+      for (const breakpoint of POSITION_CARD_LIST_BREAKPOINTS) {
+        if (width > breakpoint.width) {
+          targetPositions = showedPosition.slice(0, breakpoint.displayCount);
+          break;
+        }
       }
     }
 
-    return showedPosition;
-  };
-
-  const updateDataMapping = useCallback(() => {
-    setIsDataMappingLoading(true);
-    const newMappedData = getMappedData();
-    const convertedMappedData = PositionConverter.convertPositions(newMappedData);
-
-    setMappedData(convertedMappedData);
-    setIsDataMappingLoading(false);
-  }, [isViewMorePositions, width, showedPosition, limit]);
-
-  useEffect(() => {
-    updateDataMapping();
-  }, [updateDataMapping]);
+    return PositionConverter.convertPositions(targetPositions);
+  }, [isViewMorePositions, width, showedPosition]);
 
   /**
    * Navigate to specific page
@@ -283,7 +272,7 @@ const WalletPositionCardListContainer: React.FC<WalletPositionCardListContainerP
       positions={mappedData}
       loadMore={!isViewMorePositions}
       isFetched={isFetchedPosition}
-      isLoading={loading || isLoadingPosition || isDataMappingLoading}
+      isLoading={loading || isLoadingPosition}
       movePoolDetail={movePoolDetail}
       currentIndex={currentIndex}
       maxDisplayCount={maxDisplayCount}


### PR DESCRIPTION
## Summary
- Make Portfolio position counts follow the Closed toggle, matching Earn.
- Use a single position query with `withClosed: isClosed`.
- Keep the Closed switch available independently of the current page contents.
- Preserve the previous Header and position cards while the filtered query transitions between Open and Closed results.
- Expose position-data availability separately from `isFetchedPosition`, so React Query's `keepPreviousData` result remains renderable without treating the new query as fetched.
- Match Earn's rendering flow by deriving mapped position cards synchronously with `useMemo`, avoiding a transient loading state when toggling Closed.

## Validation
- Targeted Jest: 3 suites, 9 tests passed.
- Prettier check passed.
- Targeted ESLint passed with 0 errors; the repository emitted its existing missing-pages-directory warning.
- `git diff --check` passed.
- Browser smoke: the `/portfolio` shell rendered, but the temporary worktree had no usable API base; local requests for `/pools`, `/chain`, and `/tokens/prices` returned 404. Wallet-dependent position toggling was not exercised because no wallet was connected.
- GitHub Actions for the latest head are still in progress; Vercel Preview Comments completed successfully and CodeRabbit is pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved switching between open and closed position filters without showing unnecessary loading states.
  * Preserved previously displayed positions while filtered results are loading.
  * Ensured position counts and filter controls reflect the selected view accurately.
  * Kept position cards visible and usable during data transitions.
* **Tests**
  * Added coverage for filter counts, loading behavior, data availability, and position list rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->