### PR TITLE
fix: render flat Exchange Rate charts

### DIFF
--- a/packages/web/src/components/common/line-graph/LineGraph.spec.tsx
+++ b/packages/web/src/components/common/line-graph/LineGraph.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { Provider as JotaiProvider } from "jotai";
 import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
 import LineGraph, { LineGraphProps } from "./LineGraph";
@@ -17,5 +17,28 @@ describe("LineGraph Component", () => {
         </GnoswapThemeProvider>
       </JotaiProvider>,
     );
+  });
+
+  it("renders a horizontal line for a single data point when requested", async () => {
+    const args: LineGraphProps = {
+      color: "#FFFFFF",
+      datas: [{ value: "0.1", time: "2026-08-12T00:00:00.000Z" }],
+      width: 400,
+      height: 200,
+      renderSinglePointAsLine: true,
+    };
+
+    const { container } = render(
+      <JotaiProvider>
+        <GnoswapThemeProvider>
+          <LineGraph {...args} />
+        </GnoswapThemeProvider>
+      </JotaiProvider>,
+    );
+
+    await waitFor(() => {
+      const path = container.querySelector("path[stroke='#FFFFFF']");
+      expect(path?.getAttribute("d")).toMatch(/^M [^,]+,[^ ]+ L [^,]+,[^ ]+$/);
+    });
   });
 });

--- a/packages/web/src/components/common/line-graph/LineGraph.tsx
+++ b/packages/web/src/components/common/line-graph/LineGraph.tsx
@@ -98,6 +98,7 @@ export interface LineGraphProps {
   onMouseMove?: (LineGraphData?: LineGraphData, dateDisplay?: { date: string; time: string; value?: string }) => void;
   onMouseOut?: (active: boolean) => void;
   baseLineMap?: [boolean, boolean, boolean, boolean];
+  baseLineLabels?: string[];
   baseLineLabelsPosition?: "left" | "right";
   baseLineLabelsTransform?: (value: string) => string;
   graphBorder?: [boolean, boolean, boolean, boolean];
@@ -109,6 +110,7 @@ export interface LineGraphProps {
   yAxisMin?: string;
   yAxisMax?: string;
   fillAreaBelowLine?: boolean;
+  renderSinglePointAsLine?: boolean;
 }
 
 export interface LineGraphRef {
@@ -167,6 +169,7 @@ const LineGraph: React.FC<LineGraphProps> = ({
   onMouseMove: onLineGraphMouseMove,
   onMouseOut: onLineGraphMouseOut,
   showBaseLineLabels = false,
+  baseLineLabels,
   showPriceRangeLine = true,
   baseLineMap = [true, true, true, true],
   baseLineLabelsPosition = "left",
@@ -180,6 +183,7 @@ const LineGraph: React.FC<LineGraphProps> = ({
   yAxisMin,
   yAxisMax,
   fillAreaBelowLine = false,
+  renderSinglePointAsLine = false,
 }: LineGraphProps) => {
   const COMPONENT_ID = (Math.random() * 100000).toString();
   const [activated, setActivated] = useState(false);
@@ -190,7 +194,10 @@ const LineGraph: React.FC<LineGraphProps> = ({
   const [baseLineYAxis, setBaseLineYAxis] = useState<string[]>([]);
   const [baseLineNumberWidth, setBaseLineNumberWidth] = useState<number>(0);
   const { height: customHeight = 0, locationTooltip } = customData;
-  const baseLineCount = useMemo(() => 4, []);
+  const baseLineCount = useMemo(
+    () => (baseLineLabels && baseLineLabels.length > 0 ? baseLineLabels.length : 4),
+    [baseLineLabels],
+  );
   const theme = useTheme();
 
   const isFocus = useCallback(() => {
@@ -199,7 +206,7 @@ const LineGraph: React.FC<LineGraphProps> = ({
 
   useEffect(() => {
     updatePoints(datas, width, height);
-  }, [datas, width, height, baseLineNumberWidth, yAxisMin, yAxisMax]);
+  }, [baseLineLabels, datas, width, height, baseLineNumberWidth, yAxisMin, yAxisMax]);
 
   useEffect(() => {
     onLineGraphMouseMove?.(datas[currentPointIndex]);
@@ -316,68 +323,70 @@ const LineGraph: React.FC<LineGraphProps> = ({
       return maxValueBigNumber.minus(minValueBigNumber);
     })();
 
-    const baseLineData = new Array(baseLineCount).fill("").map((value, index) => {
-      // Gap from lowest value or highest value  to baseline
-      const additionalGap = (() => {
-        if (everyPointEqual) return minMaxGap.dividedBy(2);
+    const baseLineData =
+      baseLineLabels ??
+      new Array(baseLineCount).fill("").map((value, index) => {
+        // Gap from lowest value or highest value  to baseline
+        const additionalGap = (() => {
+          if (everyPointEqual) return minMaxGap.dividedBy(2);
 
-        return minMaxGap.multipliedBy(gapRatio / 2);
-      })();
+          return minMaxGap.multipliedBy(gapRatio / 2);
+        })();
 
-      // Gap between bottom and top base line
-      const baseLineGap = (() => {
-        if (everyPointEqual) return minMaxGap;
+        // Gap between bottom and top base line
+        const baseLineGap = (() => {
+          if (everyPointEqual) return minMaxGap;
 
-        if (minValueBigNumber.isLessThanOrEqualTo(0)) return maxValueBigNumber;
+          if (minValueBigNumber.isLessThanOrEqualTo(0)) return maxValueBigNumber;
 
-        return minMaxGap.multipliedBy(1 + gapRatio);
-      })();
+          return minMaxGap.multipliedBy(1 + gapRatio);
+        })();
 
-      // Lowest baseline value
-      const tempBottomBaseLineValue = minValueBigNumber.minus(additionalGap);
-      const bottomBaseLineValue = tempBottomBaseLineValue.isLessThanOrEqualTo(0)
-        ? BigNumber(0)
-        : tempBottomBaseLineValue;
+        // Lowest baseline value
+        const tempBottomBaseLineValue = minValueBigNumber.minus(additionalGap);
+        const bottomBaseLineValue = tempBottomBaseLineValue.isLessThanOrEqualTo(0)
+          ? BigNumber(0)
+          : tempBottomBaseLineValue;
 
-      const currentBaseLineValue = bottomBaseLineValue.plus(baseLineGap.multipliedBy(index / (baseLineCount - 1)));
+        const currentBaseLineValue = bottomBaseLineValue.plus(baseLineGap.multipliedBy(index / (baseLineCount - 1)));
 
-      if (currentBaseLineValue.isLessThan(-1)) {
-        return (
-          "-" +
-          convertToKMB(currentBaseLineValue.absoluteValue().toFixed(), {
+        if (currentBaseLineValue.isLessThan(-1)) {
+          return (
+            "-" +
+            convertToKMB(currentBaseLineValue.absoluteValue().toFixed(), {
+              maximumFractionDigits: 2,
+              minimumFractionDigits: 2,
+            })
+          );
+        }
+
+        if (currentBaseLineValue.isGreaterThan(-1) && currentBaseLineValue.isLessThan(0)) {
+          return "-" + subscriptFormat(currentBaseLineValue.abs().toFixed());
+        }
+
+        if (currentBaseLineValue.isLessThan(1)) {
+          return subscriptFormat(currentBaseLineValue.toString(), {
+            significantDigits: 3,
+            subscriptOffset: 3,
+          });
+        }
+
+        if (currentBaseLineValue.isGreaterThanOrEqualTo(1) && currentBaseLineValue.isLessThan(100)) {
+          return convertToKMB(currentBaseLineValue.toString(), {
             maximumFractionDigits: 2,
             minimumFractionDigits: 2,
-          })
-        );
-      }
+          });
+        }
 
-      if (currentBaseLineValue.isGreaterThan(-1) && currentBaseLineValue.isLessThan(0)) {
-        return "-" + subscriptFormat(currentBaseLineValue.abs().toFixed());
-      }
+        const result = Math.round(currentBaseLineValue.toNumber()).toString();
 
-      if (currentBaseLineValue.isLessThan(1)) {
-        return subscriptFormat(currentBaseLineValue.toString(), {
-          significantDigits: 3,
-          subscriptOffset: 3,
-        });
-      }
+        if (currentBaseLineValue.isLessThan(1)) return subscriptFormat(currentBaseLineValue.toFixed());
 
-      if (currentBaseLineValue.isGreaterThanOrEqualTo(1) && currentBaseLineValue.isLessThan(100)) {
-        return convertToKMB(currentBaseLineValue.toString(), {
+        return convertToKMB(result, {
           maximumFractionDigits: 2,
           minimumFractionDigits: 2,
         });
-      }
-
-      const result = Math.round(currentBaseLineValue.toNumber()).toString();
-
-      if (currentBaseLineValue.isLessThan(1)) return subscriptFormat(currentBaseLineValue.toFixed());
-
-      return convertToKMB(result, {
-        maximumFractionDigits: 2,
-        minimumFractionDigits: 2,
       });
-    });
 
     setBaseLineYAxis([...baseLineData]);
 
@@ -525,6 +534,12 @@ const LineGraph: React.FC<LineGraphProps> = ({
 
   const getGraphLine = useCallback(
     (smooth?: boolean, fill?: boolean) => {
+      if (renderSinglePointAsLine && points.length === 1) {
+        const startX = showBaseLineLabels && baseLineLabelsPosition === "left" ? baseLineNumberWidth : 0;
+        const endX = width - (showBaseLineLabels && baseLineLabelsPosition === "right" ? baseLineNumberWidth : 0);
+        return `M ${startX},${points[0].y} L ${endX},${points[0].y}`;
+      }
+
       function mappedPoint(point: Point, index: number, points: Point[]) {
         if (index === 0) {
           return `${fill ? "L" : "M"} ${point.x},${point.y}`;
@@ -534,7 +549,7 @@ const LineGraph: React.FC<LineGraphProps> = ({
       }
       return points.map((point, index) => mappedPoint(point, index, points)).join(" ");
     },
-    [points],
+    [baseLineLabelsPosition, baseLineNumberWidth, points, renderSinglePointAsLine, showBaseLineLabels, width],
   );
 
   const firstPoint = useMemo(() => {
@@ -715,7 +730,7 @@ const LineGraph: React.FC<LineGraphProps> = ({
             {showBaseLine && (
               <>
                 {baseLineYAxis.map((value, index) => {
-                  const showBaseLine = baseLineMap[index];
+                  const showBaseLine = baseLineMap[index] ?? true;
                   const currentHeight = height - (height * index) / (baseLineCount - 1);
                   const baseWidth =
                     width - (showBaseLineLabels && baseLineLabelsPosition === "left" ? 0 : baseLineNumberWidth);
@@ -753,7 +768,7 @@ const LineGraph: React.FC<LineGraphProps> = ({
                 })}
               </>
             )}
-            {hasOnlyOnePoint && (
+            {hasOnlyOnePoint && !renderSinglePointAsLine && (
               <circle cx={points?.[0]?.x || 0} cy={points?.[0]?.y || 0} r={1} stroke={color} fill={color} />
             )}
             {!isSameData && <path fill={`url(#gradient${COMPONENT_ID})`} stroke={color} strokeWidth={0} d={areaPath} />}

--- a/packages/web/src/layouts/pool/pool-add/components/additional-info/exchange-rate-graph/exchange-rate-graph-content/ExchangeRateGraphContent.tsx
+++ b/packages/web/src/layouts/pool/pool-add/components/additional-info/exchange-rate-graph/exchange-rate-graph-content/ExchangeRateGraphContent.tsx
@@ -8,6 +8,7 @@ import useComponentSize from "@hooks/common/use-component-size";
 import { useWindowSize } from "@hooks/common/use-window-size";
 import { DEVICE_TYPE } from "@styles/media";
 import { getLocalizeTime, parseDate } from "@utils/chart";
+import { getYAxisInfo } from "@utils/chart-y-axis";
 
 import { ExchangeRateGraphContentWrapper, ExchangeRateGraphXAxisWrapper } from "./ExchangeRateGraphContent.styles";
 import { IPoolPriceRatioItem } from "@models/pool/pool-model";
@@ -44,6 +45,16 @@ export function ExchangeRateGraphContent({ pricesData, onMouseMove, onMouseOut }
   }, [pricesChartData, i18n.language]);
 
   const hasSingleData = useMemo(() => pricesChartData?.length === 1, [pricesChartData]);
+
+  const chartYAxis = useMemo(() => {
+    const latestPrice = pricesChartData[pricesChartData.length - 1]?.value;
+    const tokenPrice = latestPrice !== undefined ? Number(latestPrice) : undefined;
+
+    return getYAxisInfo(
+      pricesChartData.map(item => item.value),
+      tokenPrice !== undefined && Number.isFinite(tokenPrice) ? tokenPrice : undefined,
+    );
+  }, [pricesChartData]);
 
   const countXAxis = useMemo(() => {
     if (hasSingleData) return 1;
@@ -97,6 +108,10 @@ export function ExchangeRateGraphContent({ pricesData, onMouseMove, onMouseOut }
             }}
             showBaseLine
             showBaseLineLabels
+            baseLineLabels={chartYAxis.labels}
+            yAxisMin={chartYAxis.minValue}
+            yAxisMax={chartYAxis.maxValue}
+            renderSinglePointAsLine
             isShowTooltip={true}
             renderBottom={renderXAxis}
             onMouseOut={onMouseOut}

--- a/packages/web/src/layouts/token-detail/containers/token-chart-container/TokenChartContainer.tsx
+++ b/packages/web/src/layouts/token-detail/containers/token-chart-container/TokenChartContainer.tsx
@@ -1,4 +1,3 @@
-import BigNumber from "bignumber.js";
 import dayjs from "dayjs";
 import { useAtom } from "jotai";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -17,6 +16,7 @@ import { IPriceResponse, IPrices1d } from "@repositories/token";
 import { TokenState } from "@states/index";
 import { DEVICE_TYPE } from "@styles/media";
 import { getLabelChartV2, getLocalizeTime, getNumberOfAxis } from "@utils/chart";
+import { getYAxisInfo } from "@utils/chart-y-axis";
 import { checkPositivePrice, generateDateSequence } from "@utils/common";
 import { formatPrice } from "@utils/new-number-utils";
 
@@ -89,149 +89,6 @@ function createXAxisDatas(
     default:
       return labelX;
   }
-}
-
-// Allowed y-axis scale units — `{1..9} * 10^n` (e.g., 0.01, 0.02, 1, 10, 20, 300, 700000).
-const SINGLE_DIGIT_SCALE_BASES = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-
-/**
- * Find the smallest allowed scale unit that satisfies `candidate >= threshold` (or
- * `candidate > threshold` when `inclusive` is false).
- */
-function findAllowedScaleUnit(threshold: BigNumber, inclusive = true): BigNumber {
-  const thresholdNumber = threshold.toNumber();
-  if (!isFinite(thresholdNumber) || thresholdNumber <= 0) {
-    return new BigNumber(1);
-  }
-
-  const startExponent = Math.floor(Math.log10(thresholdNumber)) - 1;
-  for (let e = startExponent; e <= startExponent + 4; e++) {
-    const magnitude = new BigNumber(10).pow(e);
-    for (const base of SINGLE_DIGIT_SCALE_BASES) {
-      const candidate = magnitude.multipliedBy(base);
-      const satisfied = inclusive ? candidate.isGreaterThanOrEqualTo(threshold) : candidate.isGreaterThan(threshold);
-      if (satisfied) return candidate;
-    }
-  }
-
-  return new BigNumber(1);
-}
-
-function roundToMultiple(value: BigNumber, unit: BigNumber, mode: "ceil" | "floor"): BigNumber {
-  if (unit.isZero()) return value;
-  const roundingMode = mode === "ceil" ? BigNumber.ROUND_CEIL : BigNumber.ROUND_FLOOR;
-  return value.dividedBy(unit).integerValue(roundingMode).multipliedBy(unit);
-}
-
-function trimTrailingZeros(value: string): string {
-  return value
-    .replace(/(\.\d*?[1-9])0+$/g, "$1")
-    .replace(/\.0+$/g, "")
-    .replace(/\.$/g, "");
-}
-
-function truncateToSignificantDigits(value: BigNumber, significantDigits: number): string {
-  if (!value.isFinite() || value.isZero()) return "0";
-
-  const negative = value.isNegative();
-  const absValue = value.abs();
-  const exponent = absValue.e ?? 0;
-  const decimalPlaces = Math.max(significantDigits - exponent - 1, 0);
-  const factor = new BigNumber(10).pow(decimalPlaces);
-  const truncated = absValue.multipliedBy(factor).integerValue(BigNumber.ROUND_FLOOR).dividedBy(factor);
-  const normalized = trimTrailingZeros(truncated.toFixed(decimalPlaces));
-
-  return negative ? `-${normalized}` : normalized;
-}
-
-function getYAxisInfo(datas: string[], tokenPrice?: number): { labels: string[]; minValue: string; maxValue: string } {
-  const Y_AXIS_LABEL_COUNT = 6;
-  const Y_AXIS_STEP_COUNT = Y_AXIS_LABEL_COUNT - 1;
-  // Fall back to fixed-decimal formatting until the price query resolves to avoid
-  // a visible flicker where high-priced tokens briefly render with significant
-  // digits before switching.
-  const useSignificantFormat = tokenPrice !== undefined && tokenPrice < 1;
-
-  // Derive the number of decimals from the step unit so narrow ranges on tokens
-  // priced >= $1 still get distinct labels (e.g., step 0.001 -> 3 decimals).
-  const formatYAxisValue = (value: BigNumber, scaleUnit?: BigNumber) => {
-    if (useSignificantFormat) {
-      return truncateToSignificantDigits(value, 3);
-    }
-    const unitDecimals = scaleUnit ? Math.max(0, -(scaleUnit.e ?? 0)) : 0;
-    const decimals = Math.max(2, unitDecimals);
-    return value.toFixed(decimals);
-  };
-
-  const numericDatas = datas.map(item => new BigNumber(item)).filter(item => !item.isNaN());
-
-  if (numericDatas.length === 0) {
-    return {
-      labels: new Array(Y_AXIS_LABEL_COUNT).fill(formatYAxisValue(new BigNumber(0))),
-      minValue: "0",
-      maxValue: "0",
-    };
-  }
-
-  const lowest = BigNumber.min(...numericDatas);
-  const highest = BigNumber.max(...numericDatas);
-
-  if (highest.isZero() && lowest.isZero()) {
-    return {
-      labels: new Array(Y_AXIS_LABEL_COUNT).fill(formatYAxisValue(new BigNumber(0))),
-      minValue: "0",
-      maxValue: "0",
-    };
-  }
-
-  const targetMax = highest.multipliedBy(1.2);
-  const targetMin = lowest.multipliedBy(0.8);
-  const targetRange = targetMax.minus(targetMin);
-
-  // Pick the smallest allowed scale unit so the window [minPoint..maxPoint] covers
-  let scaleUnit = findAllowedScaleUnit(targetRange.dividedBy(Y_AXIS_STEP_COUNT));
-
-  let maxPoint = roundToMultiple(targetMax, scaleUnit, "ceil");
-  let minPoint = roundToMultiple(targetMin, scaleUnit, "floor");
-  let actualSteps = maxPoint.minus(minPoint).dividedBy(scaleUnit).integerValue(BigNumber.ROUND_HALF_UP).toNumber();
-
-  for (let attempt = 0; attempt < 16 && actualSteps > Y_AXIS_STEP_COUNT; attempt++) {
-    scaleUnit = findAllowedScaleUnit(scaleUnit, false);
-    maxPoint = roundToMultiple(targetMax, scaleUnit, "ceil");
-    minPoint = roundToMultiple(targetMin, scaleUnit, "floor");
-    actualSteps = maxPoint.minus(minPoint).dividedBy(scaleUnit).integerValue(BigNumber.ROUND_HALF_UP).toNumber();
-  }
-
-  // If the snapped window fits in fewer than 5 steps, expand so we always render
-  while (
-    maxPoint.minus(minPoint).dividedBy(scaleUnit).integerValue(BigNumber.ROUND_HALF_UP).toNumber() < Y_AXIS_STEP_COUNT
-  ) {
-    const topSlack = maxPoint.minus(targetMax).abs();
-    const bottomSlack = targetMin.minus(minPoint).abs();
-
-    if (topSlack.isLessThanOrEqualTo(bottomSlack)) {
-      maxPoint = maxPoint.plus(scaleUnit);
-    } else {
-      const candidateMin = minPoint.minus(scaleUnit);
-      if (lowest.isGreaterThanOrEqualTo(0) && candidateMin.isLessThan(0)) {
-        maxPoint = maxPoint.plus(scaleUnit);
-      } else {
-        minPoint = candidateMin;
-      }
-    }
-  }
-
-  const labels: string[] = [];
-  for (let i = 0; i <= Y_AXIS_STEP_COUNT; i++) {
-    const value = minPoint.plus(scaleUnit.multipliedBy(i));
-    labels.push(formatYAxisValue(value, scaleUnit));
-  }
-
-  return {
-    labels,
-    minValue: minPoint.toFixed(),
-    maxValue: maxPoint.toFixed(),
-  };
 }
 
 const priceChangeDetailInit = {

--- a/packages/web/src/utils/chart-y-axis.spec.ts
+++ b/packages/web/src/utils/chart-y-axis.spec.ts
@@ -1,0 +1,19 @@
+import { getYAxisInfo } from "./chart-y-axis";
+
+describe("getYAxisInfo", () => {
+  it("keeps sub-unit chart labels to three significant digits", () => {
+    expect(getYAxisInfo(["0.1"], 0.1)).toEqual({
+      labels: ["0.08", "0.088", "0.096", "0.104", "0.112", "0.12"],
+      minValue: "0.08",
+      maxValue: "0.12",
+    });
+  });
+
+  it("returns a stable zero range for zero-only data", () => {
+    expect(getYAxisInfo(["0"], 0)).toEqual({
+      labels: ["0", "0", "0", "0", "0", "0"],
+      minValue: "0",
+      maxValue: "0",
+    });
+  });
+});

--- a/packages/web/src/utils/chart-y-axis.ts
+++ b/packages/web/src/utils/chart-y-axis.ts
@@ -1,0 +1,147 @@
+import BigNumber from "bignumber.js";
+
+const SINGLE_DIGIT_SCALE_BASES = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+const Y_AXIS_LABEL_COUNT = 6;
+const Y_AXIS_STEP_COUNT = Y_AXIS_LABEL_COUNT - 1;
+
+export interface ChartYAxisInfo {
+  labels: string[];
+  minValue: string;
+  maxValue: string;
+}
+
+function findAllowedScaleUnit(threshold: BigNumber, inclusive = true): BigNumber {
+  const thresholdNumber = threshold.toNumber();
+  if (!isFinite(thresholdNumber) || thresholdNumber <= 0) {
+    return new BigNumber(1);
+  }
+
+  const startExponent = Math.floor(Math.log10(thresholdNumber)) - 1;
+  for (let exponent = startExponent; exponent <= startExponent + 4; exponent++) {
+    const magnitude = new BigNumber(10).pow(exponent);
+    for (const base of SINGLE_DIGIT_SCALE_BASES) {
+      const candidate = magnitude.multipliedBy(base);
+      const satisfiesThreshold = inclusive
+        ? candidate.isGreaterThanOrEqualTo(threshold)
+        : candidate.isGreaterThan(threshold);
+      if (satisfiesThreshold) return candidate;
+    }
+  }
+
+  return new BigNumber(1);
+}
+
+function roundToMultiple(value: BigNumber, unit: BigNumber, mode: "ceil" | "floor"): BigNumber {
+  if (unit.isZero()) return value;
+  const roundingMode = mode === "ceil" ? BigNumber.ROUND_CEIL : BigNumber.ROUND_FLOOR;
+  return value.dividedBy(unit).integerValue(roundingMode).multipliedBy(unit);
+}
+
+function trimTrailingZeros(value: string): string {
+  return value
+    .replace(/(\.\d*?[1-9])0+$/g, "$1")
+    .replace(/\.0+$/g, "")
+    .replace(/\.$/g, "");
+}
+
+export function truncateToSignificantDigits(value: BigNumber, significantDigits: number): string {
+  if (!value.isFinite() || value.isZero()) return "0";
+
+  const negative = value.isNegative();
+  const absoluteValue = value.abs();
+  const exponent = absoluteValue.e ?? 0;
+  const decimalPlaces = Math.max(significantDigits - exponent - 1, 0);
+  const factor = new BigNumber(10).pow(decimalPlaces);
+  const truncated = absoluteValue.multipliedBy(factor).integerValue(BigNumber.ROUND_FLOOR).dividedBy(factor);
+  const normalized = trimTrailingZeros(truncated.toFixed(decimalPlaces));
+
+  return negative ? `-${normalized}` : normalized;
+}
+
+export function formatSubUnitChartValue(value: BigNumber | string | number): string {
+  return truncateToSignificantDigits(new BigNumber(value), 3);
+}
+
+export function getYAxisInfo(datas: string[], tokenPrice?: number): ChartYAxisInfo {
+  // Keep the same three-significant-digit format used by the token detail chart
+  // for prices below one, while preserving fixed decimals for larger prices.
+  const useSignificantFormat = tokenPrice !== undefined && tokenPrice < 1;
+
+  const formatYAxisValue = (value: BigNumber, scaleUnit?: BigNumber) => {
+    if (useSignificantFormat) {
+      return formatSubUnitChartValue(value);
+    }
+
+    const unitDecimals = scaleUnit ? Math.max(0, -(scaleUnit.e ?? 0)) : 0;
+    const decimals = Math.max(2, unitDecimals);
+    return value.toFixed(decimals);
+  };
+
+  const numericDatas = datas.map(item => new BigNumber(item)).filter(item => !item.isNaN());
+
+  if (numericDatas.length === 0) {
+    return {
+      labels: new Array(Y_AXIS_LABEL_COUNT).fill(formatYAxisValue(new BigNumber(0))),
+      minValue: "0",
+      maxValue: "0",
+    };
+  }
+
+  const lowest = BigNumber.min(...numericDatas);
+  const highest = BigNumber.max(...numericDatas);
+
+  if (highest.isZero() && lowest.isZero()) {
+    return {
+      labels: new Array(Y_AXIS_LABEL_COUNT).fill(formatYAxisValue(new BigNumber(0))),
+      minValue: "0",
+      maxValue: "0",
+    };
+  }
+
+  const targetMax = highest.multipliedBy(1.2);
+  const targetMin = lowest.multipliedBy(0.8);
+  const targetRange = targetMax.minus(targetMin);
+
+  let scaleUnit = findAllowedScaleUnit(targetRange.dividedBy(Y_AXIS_STEP_COUNT));
+
+  let maxPoint = roundToMultiple(targetMax, scaleUnit, "ceil");
+  let minPoint = roundToMultiple(targetMin, scaleUnit, "floor");
+  let actualSteps = maxPoint.minus(minPoint).dividedBy(scaleUnit).integerValue(BigNumber.ROUND_HALF_UP).toNumber();
+
+  for (let attempt = 0; attempt < 16 && actualSteps > Y_AXIS_STEP_COUNT; attempt++) {
+    scaleUnit = findAllowedScaleUnit(scaleUnit, false);
+    maxPoint = roundToMultiple(targetMax, scaleUnit, "ceil");
+    minPoint = roundToMultiple(targetMin, scaleUnit, "floor");
+    actualSteps = maxPoint.minus(minPoint).dividedBy(scaleUnit).integerValue(BigNumber.ROUND_HALF_UP).toNumber();
+  }
+
+  while (
+    maxPoint.minus(minPoint).dividedBy(scaleUnit).integerValue(BigNumber.ROUND_HALF_UP).toNumber() < Y_AXIS_STEP_COUNT
+  ) {
+    const topSlack = maxPoint.minus(targetMax).abs();
+    const bottomSlack = targetMin.minus(minPoint).abs();
+
+    if (topSlack.isLessThanOrEqualTo(bottomSlack)) {
+      maxPoint = maxPoint.plus(scaleUnit);
+    } else {
+      const candidateMin = minPoint.minus(scaleUnit);
+      if (lowest.isGreaterThanOrEqualTo(0) && candidateMin.isLessThan(0)) {
+        maxPoint = maxPoint.plus(scaleUnit);
+      } else {
+        minPoint = candidateMin;
+      }
+    }
+  }
+
+  const labels: string[] = [];
+  for (let index = 0; index <= Y_AXIS_STEP_COUNT; index++) {
+    const value = minPoint.plus(scaleUnit.multipliedBy(index));
+    labels.push(formatYAxisValue(value, scaleUnit));
+  }
+
+  return {
+    labels,
+    minValue: minPoint.toFixed(),
+    maxValue: maxPoint.toFixed(),
+  };
+}


### PR DESCRIPTION
## Summary

- Render a flat Exchange Rate chart as a horizontal line when the API returns a single price point.
- Apply significant-digit Y-axis formatting consistently to Exchange Rate and token charts.
- Keep the API response unchanged and normalize a single point only during rendering.

## Validation

- Targeted Jest: 2 suites and 4 tests passed.
- Prettier check passed.
- Targeted ESLint passed with 0 errors and 5 existing hook-dependency warnings.
- `git diff --check` passed.
