### PR TITLE
fix: show closed position toggle only when needed

### DIFF
--- a/packages/web/src/layouts/earn/components/earn-my-positions/EarnMyPositions.tsx
+++ b/packages/web/src/layouts/earn/components/earn-my-positions/EarnMyPositions.tsx
@@ -41,6 +41,7 @@ export interface EarnMyPositionsProps {
   account: AccountModel | null;
   /** UI toggle state: whether closed positions should be shown in this view. */
   isClosed: boolean;
+  hasClosedPositions: boolean;
   handleChangeClosed: () => void;
   tokenPrices: Record<string, TokenPriceModel>;
   highestApr: number;
@@ -82,6 +83,7 @@ const EarnMyPositions: React.FC<EarnMyPositionsProps> = ({
   themeKey,
   account,
   isClosed,
+  hasClosedPositions,
   handleChangeClosed,
   tokenPrices,
   highestApr,
@@ -104,6 +106,7 @@ const EarnMyPositions: React.FC<EarnMyPositionsProps> = ({
       moveEarnStake={moveEarnStake}
       isSwitchNetwork={isSwitchNetwork}
       isClosed={isClosed}
+      hasClosedPositions={hasClosedPositions}
       handleChangeClosed={handleChangeClosed}
       positions={positions}
       onOpenVideoGuide={onOpenVideoGuide}

--- a/packages/web/src/layouts/earn/components/earn-my-positions/earn-my-positions-header/EarnMyPositionsHeader.spec.tsx
+++ b/packages/web/src/layouts/earn/components/earn-my-positions/earn-my-positions-header/EarnMyPositionsHeader.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Provider as JotaiProvider } from "jotai";
 import GnoswapThemeProvider from "@providers/gnoswap-theme-provider/GnoswapThemeProvider";
 import EarnMyPositionsHeader, { EarnMyPositionsHeaderProps } from "./EarnMyPositionsHeader";
@@ -7,6 +7,9 @@ describe("EarnMyPositionsHeader Component", () => {
   it("EarnMyPositionsHeader render", () => {
     const args: EarnMyPositionsHeaderProps = {
       connected: false,
+      visiblePositions: true,
+      positionLength: 0,
+      hasClosedPositions: true,
       isSwitchNetwork: false,
       availableStake: false,
       moveEarnAdd: () => {
@@ -29,5 +32,59 @@ describe("EarnMyPositionsHeader Component", () => {
         </GnoswapThemeProvider>
       </JotaiProvider>,
     );
+  });
+
+  it("hides both closed-position switches when no closed position exists", () => {
+    const args: EarnMyPositionsHeaderProps = {
+      connected: true,
+      visiblePositions: true,
+      positionLength: 2,
+      hasClosedPositions: false,
+      isSwitchNetwork: false,
+      availableStake: false,
+      moveEarnAdd: jest.fn(),
+      moveEarnStake: jest.fn(),
+      isClosed: false,
+      handleChangeClosed: jest.fn(),
+      positions: [],
+      onOpenVideoGuide: jest.fn(),
+    };
+
+    render(
+      <JotaiProvider>
+        <GnoswapThemeProvider>
+          <EarnMyPositionsHeader {...args} />
+        </GnoswapThemeProvider>
+      </JotaiProvider>,
+    );
+
+    expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+  });
+
+  it("renders both desktop and mobile closed-position switches when a closed position exists", () => {
+    const args: EarnMyPositionsHeaderProps = {
+      connected: true,
+      visiblePositions: true,
+      positionLength: 2,
+      hasClosedPositions: true,
+      isSwitchNetwork: false,
+      availableStake: false,
+      moveEarnAdd: jest.fn(),
+      moveEarnStake: jest.fn(),
+      isClosed: false,
+      handleChangeClosed: jest.fn(),
+      positions: [],
+      onOpenVideoGuide: jest.fn(),
+    };
+
+    render(
+      <JotaiProvider>
+        <GnoswapThemeProvider>
+          <EarnMyPositionsHeader {...args} />
+        </GnoswapThemeProvider>
+      </JotaiProvider>,
+    );
+
+    expect(screen.getAllByRole("checkbox")).toHaveLength(2);
   });
 });

--- a/packages/web/src/layouts/earn/components/earn-my-positions/earn-my-positions-header/EarnMyPositionsHeader.tsx
+++ b/packages/web/src/layouts/earn/components/earn-my-positions/earn-my-positions-header/EarnMyPositionsHeader.tsx
@@ -24,6 +24,7 @@ export interface EarnMyPositionsHeaderProps {
   moveEarnStake: () => void;
   /** UI toggle state: whether closed positions should be shown in this view. */
   isClosed: boolean;
+  hasClosedPositions: boolean;
   handleChangeClosed: () => void;
   positions: PoolPositionModel[];
   onOpenVideoGuide: (type: "POSITION") => void;
@@ -40,6 +41,7 @@ const EarnMyPositionsHeader: React.FC<EarnMyPositionsHeaderProps> = ({
   moveEarnAdd,
   moveEarnStake,
   isClosed,
+  hasClosedPositions,
   handleChangeClosed,
   onOpenVideoGuide,
 }) => {
@@ -101,7 +103,7 @@ const EarnMyPositionsHeader: React.FC<EarnMyPositionsHeaderProps> = ({
     <PositionsWrapper>
       <div className="header-content">
         <HeaderTextWrapper>{renderMyPositionTitle()}</HeaderTextWrapper>
-        {visiblePositions && (
+        {visiblePositions && hasClosedPositions && (
           <Switch
             checked={isClosed}
             onChange={handleChangeClosed}
@@ -117,7 +119,7 @@ const EarnMyPositionsHeader: React.FC<EarnMyPositionsHeaderProps> = ({
         )}
       </div>
       <div className="button-wrapper">
-        {visiblePositions && (
+        {visiblePositions && hasClosedPositions && (
           <Switch
             checked={isClosed}
             onChange={handleChangeClosed}

--- a/packages/web/src/layouts/earn/containers/earn-my-position-container/EarnMyPositionContainer.tsx
+++ b/packages/web/src/layouts/earn/containers/earn-my-position-container/EarnMyPositionContainer.tsx
@@ -53,13 +53,38 @@ const EarnMyPositionContainer: React.FC<EarnMyPositionContainerProps> = ({
     return DESKTOP * 5; // 4 * 5 = 20
   }, [width]);
 
-  const { isError, isFetchedPosition, loading: isLoadingPosition, positions, totalPositionCount } = usePositionData({
+  const openPositionData = usePositionData({
+    address,
+    page: 1,
+    limit: 1,
+    withClosed: false,
+    scopeId: "EarnMyPositionContainer-open",
+  });
+  const allPositionData = usePositionData({
+    address,
+    page: 1,
+    limit: 1,
+    withClosed: true,
+    scopeId: "EarnMyPositionContainer-all",
+  });
+  const {
+    isError,
+    isFetchedPosition,
+    loading: isLoadingPosition,
+    positions,
+    totalPositionCount,
+  } = usePositionData({
     address,
     page,
     limit,
     withClosed: isClosed,
     scopeId: "EarnMyPositionContainer",
   });
+
+  const hasClosedPositions =
+    allPositionData.isFetchedPosition &&
+    openPositionData.isFetchedPosition &&
+    allPositionData.totalPositionCount > openPositionData.totalPositionCount;
 
   const divRef = useRef<HTMLDivElement | null>(null);
 
@@ -327,6 +352,7 @@ const EarnMyPositionContainer: React.FC<EarnMyPositionContainerProps> = ({
       themeKey={themeKey}
       account={account}
       isClosed={isClosed}
+      hasClosedPositions={hasClosedPositions}
       handleChangeClosed={handleChangeClosed}
       tokenPrices={tokenPrices}
       highestApr={highestApr}

--- a/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.spec.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.spec.tsx
@@ -40,16 +40,36 @@ describe("WalletMyPositionsHeader", () => {
     jest.clearAllMocks();
   });
 
-  it("uses the open position count when closed positions are hidden", () => {
+  it("uses the open position count and hides the switch when no closed positions exist", () => {
+    mockUsePositionData.mockImplementation(({ withClosed }: { withClosed?: boolean }) => ({
+      isFetchedPosition: true,
+      isPositionDataAvailable: true,
+      totalPositionCount: withClosed ? 2 : 2,
+    }));
+
+    render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={false} />);
+
+    expect(screen.getByRole("heading")).toHaveTextContent("Wallet:myPosi (2)");
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(mockUsePositionData).toHaveBeenNthCalledWith(1, {
+      withClosed: false,
+      page: 1,
+      limit: 1,
+      scopeId: "WalletMyPositionsHeader-open",
+    });
+    expect(mockUsePositionData).toHaveBeenNthCalledWith(2, {
+      withClosed: true,
+      page: 1,
+      limit: 1,
+      scopeId: "WalletMyPositionsHeader-all",
+    });
+  });
+
+  it("shows the switch when a closed position exists outside the current page", () => {
     render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={false} />);
 
     expect(screen.getByRole("heading")).toHaveTextContent("Wallet:myPosi (2)");
     expect(screen.getByRole("checkbox")).toBeInTheDocument();
-    expect(mockUsePositionData).toHaveBeenCalledTimes(1);
-    expect(mockUsePositionData).toHaveBeenCalledWith({
-      withClosed: false,
-      scopeId: "WalletMyPositionsHeader",
-    });
   });
 
   it("uses the inclusive position count when closed positions are shown", () => {
@@ -57,35 +77,31 @@ describe("WalletMyPositionsHeader", () => {
 
     expect(screen.getByRole("heading")).toHaveTextContent("Wallet:myPosi (3)");
     expect(screen.getByRole("checkbox")).toBeInTheDocument();
-    expect(mockUsePositionData).toHaveBeenCalledTimes(1);
-    expect(mockUsePositionData).toHaveBeenCalledWith({
-      withClosed: true,
-      scopeId: "WalletMyPositionsHeader",
-    });
   });
 
-  it("keeps the closed switch visible without relying on a current-page closed position", () => {
+  it("keeps the header available while the position queries are transitioning", () => {
+    mockUsePositionData.mockImplementation(({ withClosed }: { withClosed?: boolean }) => ({
+      isFetchedPosition: false,
+      isPositionDataAvailable: true,
+      totalPositionCount: withClosed ? 3 : 2,
+    }));
+
+    render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={true} />);
+
+    expect(screen.getByRole("heading")).toHaveTextContent("Wallet:myPosi (3)");
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
+  it("hides the header while position data is unavailable", () => {
     mockUsePositionData.mockReturnValue({
       isFetchedPosition: true,
-      isPositionDataAvailable: true,
+      isPositionDataAvailable: false,
       totalPositionCount: 0,
     });
 
     render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={false} />);
 
-    expect(screen.getByRole("checkbox")).toBeInTheDocument();
-  });
-
-  it("keeps the rendered header while the filtered position query is transitioning", () => {
-    mockUsePositionData.mockReturnValue({
-      isFetchedPosition: false,
-      isPositionDataAvailable: true,
-      totalPositionCount: 43,
-    });
-
-    render(<WalletMyPositionsHeader toggleClosed={jest.fn()} isClosed={true} />);
-
-    expect(screen.getByRole("heading")).toHaveTextContent("Wallet:myPosi (43)");
-    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.tsx
+++ b/packages/web/src/layouts/portfolio/components/wallet-my-positions-header/WalletMyPositionsHeader.tsx
@@ -17,22 +17,38 @@ const WalletMyPositionsHeader: React.FC<WalletMyPositionsHeaderProps> = ({ toggl
   const { t } = useTranslation();
   const { isSwitchNetwork } = useWallet();
 
-  const { isPositionDataAvailable, totalPositionCount } = usePositionData({
-    withClosed: isClosed,
-    scopeId: "WalletMyPositionsHeader",
+  const openPositionData = usePositionData({
+    withClosed: false,
+    page: 1,
+    limit: 1,
+    scopeId: "WalletMyPositionsHeader-open",
   });
+  const allPositionData = usePositionData({
+    withClosed: true,
+    page: 1,
+    limit: 1,
+    scopeId: "WalletMyPositionsHeader-all",
+  });
+  const activePositionData = isClosed ? allPositionData : openPositionData;
+  const { isPositionDataAvailable, totalPositionCount } = activePositionData;
+  const hasClosedPositions =
+    allPositionData.isFetchedPosition &&
+    openPositionData.isFetchedPosition &&
+    allPositionData.totalPositionCount > openPositionData.totalPositionCount;
 
   if (!isPositionDataAvailable || isSwitchNetwork) return null;
 
   return (
     <div css={wrapper}>
       {totalPositionCount > 0 && <h2>{`${t("Wallet:myPosi")} (${totalPositionCount.toLocaleString()})`}</h2>}
-      <Switch
-        checked={isClosed}
-        onChange={toggleClosed}
-        hasLabel={true}
-        labelText={t("Earn:positions.showClosedSwitch")}
-      />
+      {hasClosedPositions && (
+        <Switch
+          checked={isClosed}
+          onChange={toggleClosed}
+          hasLabel={true}
+          labelText={t("Earn:positions.showClosedSwitch")}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Show the `Show closed positions` toggle on Earn and Portfolio only when the wallet has at least one closed position.
- Determine closed-position existence from the difference between `withClosed=true` and `withClosed=false` total counts, so pagination does not hide closed positions outside the first page.
- Preserve the existing Open-only and Open+Closed list/count behavior when the toggle changes.

## Validation
- Targeted Jest: 4 suites / 13 tests passed
- Prettier check passed
- Targeted ESLint exited 0, with 4 existing React Hook dependency warnings and the repository's Next pages-directory warning
- Browser validation was not run because the affected wallet/API flow requires connected wallet state and a configured runtime environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Closed-position switches now appear only when closed positions are available.
  * Position availability is detected across all pages, so the switch appears even when closed positions are not on the current page.
  * Position headers remain stable while data is loading or changing.

* **Bug Fixes**
  * Prevented closed-position controls from displaying when no closed positions exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->