### PR TITLE
fix(swap): parse DrySwapRoute error response

### DIFF
--- a/packages/web/src/common/clients/gno-provider/methods/dry-swap.ts
+++ b/packages/web/src/common/clients/gno-provider/methods/dry-swap.ts
@@ -21,12 +21,12 @@ function makeDrySwapResponse(abciResponse: string): DrySwapResponse {
     return { available: false, inputAmount: 0, outputAmount: 0 };
   }
 
-  const [inputAmount, outputAmount, available] = drySwapResponse;
+  const [inputAmount, outputAmount, error] = drySwapResponse;
 
   return {
     inputAmount: BigNumber(inputAmount).toNumber(),
     outputAmount: BigNumber(outputAmount).toNumber(),
-    available: available === "true",
+    available: error === "undefined",
   };
 }
 

--- a/packages/web/src/utils/rpc-utils.spec.ts
+++ b/packages/web/src/utils/rpc-utils.spec.ts
@@ -1,0 +1,52 @@
+import {
+  evaluateExpressionToNumber,
+  evaluateExpressionToObject,
+  evaluateExpressionToStrings,
+  evaluateExpressionToUint256,
+} from "./rpc-utils";
+
+const DEV_RPC_NUMBER_RESPONSE = "(15 uint64)";
+const DEV_RPC_OBJECT_RESPONSE =
+  "(\"{\\\"pool\\\":false,\\\"position\\\":false,\\\"protocol_fee\\\":false,\\\"router\\\":false,\\\"staker\\\":false,\\\"launchpad\\\":false,\\\"governance\\\":false,\\\"gov_staker\\\":false,\\\"xgns\\\":false,\\\"community_pool\\\":false,\\\"emission\\\":false,\\\"withdraw\\\":false}\" string)";
+const DEV_RPC_UINT256_RESPONSE = "(\"7912525539738091750091588668\" string)";
+
+describe("evaluateExpressionToNumber", () => {
+  it("parses the router.GetSwapFee dev RPC response", () => {
+    expect(evaluateExpressionToNumber(DEV_RPC_NUMBER_RESPONSE)).toBe(15);
+  });
+});
+
+describe("evaluateExpressionToObject", () => {
+  it("parses the halt.GetHaltConfigJson dev RPC response", () => {
+    expect(evaluateExpressionToObject<Record<string, boolean>>(DEV_RPC_OBJECT_RESPONSE)).toEqual({
+      pool: false,
+      position: false,
+      protocol_fee: false,
+      router: false,
+      staker: false,
+      launchpad: false,
+      governance: false,
+      gov_staker: false,
+      xgns: false,
+      community_pool: false,
+      emission: false,
+      withdraw: false,
+    });
+  });
+});
+
+describe("evaluateExpressionToUint256", () => {
+  it("parses the pool.GetSlot0SqrtPriceX96 dev RPC response", () => {
+    expect(evaluateExpressionToUint256(DEV_RPC_UINT256_RESPONSE)).toBe(7912525539738091750091588668n);
+  });
+});
+
+describe("evaluateExpressionToStrings", () => {
+  it("parses typed values and untyped nil values", () => {
+    expect(evaluateExpressionToStrings("(123 string)\n(456 string)\n(undefined)")).toEqual(["123", "456", "undefined"]);
+  });
+
+  it("preserves spaces inside typed string values", () => {
+    expect(evaluateExpressionToStrings("(\"hello world\" string)")).toEqual(["hello world"]);
+  });
+});

--- a/packages/web/src/utils/rpc-utils.ts
+++ b/packages/web/src/utils/rpc-utils.ts
@@ -97,6 +97,9 @@ function matchStringValues(str: string): string[] {
 }
 
 function parseABCIValue(str: string): string {
-  const regexp = /\s.*$/;
-  return str.replace(regexp, "").slice(1);
+  const value = str.trim();
+  const valueWithoutParentheses = value.startsWith("(") && value.endsWith(")") ? value.slice(1, -1) : value;
+  const typeSeparatorIndex = valueWithoutParentheses.lastIndexOf(" ");
+
+  return typeSeparatorIndex === -1 ? valueWithoutParentheses : valueWithoutParentheses.slice(0, typeSeparatorIndex);
 }


### PR DESCRIPTION
## Summary

Update the frontend parser for the new `DrySwapRoute` `(string, string, error)` response and validate it against actual Gno RPC output.

## AS-IS

- The third `DrySwapRoute` return value changed from `bool` to `error`.
- A successful Gno error value is serialized as `(undefined)`.
- The old `parseABCIValue` removed only the opening parenthesis with `slice(1)`.
- Because `(undefined)` has no type suffix, it was parsed as `undefined)` and could not match the success condition.

## TO-BE

- Remove both outer parentheses explicitly.
- Remove only the type suffix after the last space, preserving spaces inside quoted strings.
- Treat `error === "undefined"` as a successful dry swap response.
- Add fixture-based tests using real dev RPC responses for number, JSON object, string, and uint256 parsing.

## Tests

- `yarn jest src/utils/rpc-utils.spec.ts src/repositories/swap-router --ci --runInBand`
- Prettier check passed
- ESLint passed for changed source files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected swap availability detection so valid dry-run swaps are recognized accurately.
  - Improved parsing of RPC values, including whitespace, typed values, and responses without type information.
  - Ensured numeric, object, large-integer, and string RPC responses are interpreted correctly.

- **Tests**
  - Added coverage for multiple RPC response formats and expression evaluators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->