### PR TITLE
fix: remove Gno Bridge link from header dropdown menu

### DIFF
--- a/packages/web/src/constants/header.constant.ts
+++ b/packages/web/src/constants/header.constant.ts
@@ -83,9 +83,4 @@ export const SIDE_EXTRA_MENU_NAV = [
     path: "privacy",
     iconType: "OPEN_LINK",
   },
-  {
-    title: "HeaderFooter:gnoBridge",
-    path: EXT_URL.BRIDGE,
-    iconType: "OPEN_LINK",
-  },
 ] as const;


### PR DESCRIPTION
## Summary
- Remove the Gno Bridge entry from the header dropdown menu.

## Testing
- Not run (constant-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the outdated GnoBridge link from the additional navigation menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->